### PR TITLE
feat(libfuncs/e2e): auto-extract e2e sierra code from Cairo repo

### DIFF
--- a/Aegis/Tests/e2e_libfuncs/array_aegis/array_append.sierra
+++ b/Aegis/Tests/e2e_libfuncs/array_aegis/array_append.sierra
@@ -1,0 +1,15 @@
+type Array<felt252> = Array<felt252> [storable: true, drop: true, dup: false, zero_sized: false];
+type Unit = Struct<ut@Tuple> [storable: true, drop: true, dup: true, zero_sized: true];
+type felt252 = felt252 [storable: true, drop: true, dup: true, zero_sized: false];
+
+libfunc array_append<felt252> = array_append<felt252>;
+libfunc struct_construct<Unit> = struct_construct<Unit>;
+libfunc store_temp<Array<felt252>> = store_temp<Array<felt252>>;
+
+array_append<felt252>([0], [1]) -> ([3]); // 0
+array_append<felt252>([3], [2]) -> ([4]); // 1
+struct_construct<Unit>() -> ([5]); // 2
+store_temp<Array<felt252>>([4]) -> ([4]); // 3
+return([4], [5]); // 4
+
+test::foo@0([0]: Array<felt252>, [1]: felt252, [2]: felt252) -> (Array<felt252>, Unit);

--- a/Aegis/Tests/e2e_libfuncs/array_aegis/array_get.sierra
+++ b/Aegis/Tests/e2e_libfuncs/array_aegis/array_get.sierra
@@ -1,0 +1,33 @@
+type RangeCheck = RangeCheck [storable: true, drop: false, dup: false, zero_sized: false];
+type Unit = Struct<ut@Tuple> [storable: true, drop: true, dup: true, zero_sized: true];
+type Box<Snapshot<Array<felt252>>> = Box<Snapshot<Array<felt252>>> [storable: true, drop: true, dup: true, zero_sized: false];
+type core::option::Option::<core::box::Box::<@core::array::Array::<core::felt252>>> = Enum<ut@core::option::Option::<core::box::Box::<@core::array::Array::<core::felt252>>>, Box<Snapshot<Array<felt252>>>, Unit> [storable: true, drop: true, dup: true, zero_sized: false];
+type Array<felt252> = Array<felt252> [storable: true, drop: true, dup: false, zero_sized: false];
+type Snapshot<Array<felt252>> = Snapshot<Array<felt252>> [storable: true, drop: true, dup: true, zero_sized: false];
+type u32 = u32 [storable: true, drop: true, dup: true, zero_sized: false];
+type felt252 = felt252 [storable: true, drop: true, dup: true, zero_sized: false];
+type Array<Array<felt252>> = Array<Array<felt252>> [storable: true, drop: true, dup: false, zero_sized: false];
+type Snapshot<Array<Array<felt252>>> = Snapshot<Array<Array<felt252>>> [storable: true, drop: true, dup: true, zero_sized: false];
+
+libfunc array_get<Array<felt252>> = array_get<Array<felt252>>;
+libfunc branch_align = branch_align;
+libfunc enum_init<core::option::Option::<core::box::Box::<@core::array::Array::<core::felt252>>>, 0> = enum_init<core::option::Option::<core::box::Box::<@core::array::Array::<core::felt252>>>, 0>;
+libfunc store_temp<RangeCheck> = store_temp<RangeCheck>;
+libfunc store_temp<core::option::Option::<core::box::Box::<@core::array::Array::<core::felt252>>>> = store_temp<core::option::Option::<core::box::Box::<@core::array::Array::<core::felt252>>>>;
+libfunc struct_construct<Unit> = struct_construct<Unit>;
+libfunc enum_init<core::option::Option::<core::box::Box::<@core::array::Array::<core::felt252>>>, 1> = enum_init<core::option::Option::<core::box::Box::<@core::array::Array::<core::felt252>>>, 1>;
+
+array_get<Array<felt252>>([0], [1], [2]) { fallthrough([3], [4]) 6([5]) }; // 0
+branch_align() -> (); // 1
+enum_init<core::option::Option::<core::box::Box::<@core::array::Array::<core::felt252>>>, 0>([4]) -> ([6]); // 2
+store_temp<RangeCheck>([3]) -> ([3]); // 3
+store_temp<core::option::Option::<core::box::Box::<@core::array::Array::<core::felt252>>>>([6]) -> ([6]); // 4
+return([3], [6]); // 5
+branch_align() -> (); // 6
+struct_construct<Unit>() -> ([7]); // 7
+enum_init<core::option::Option::<core::box::Box::<@core::array::Array::<core::felt252>>>, 1>([7]) -> ([8]); // 8
+store_temp<RangeCheck>([5]) -> ([5]); // 9
+store_temp<core::option::Option::<core::box::Box::<@core::array::Array::<core::felt252>>>>([8]) -> ([8]); // 10
+return([5], [8]); // 11
+
+test::foo@0([0]: RangeCheck, [1]: Snapshot<Array<Array<felt252>>>, [2]: u32) -> (RangeCheck, core::option::Option::<core::box::Box::<@core::array::Array::<core::felt252>>>);

--- a/Aegis/Tests/e2e_libfuncs/array_aegis/array_len.sierra
+++ b/Aegis/Tests/e2e_libfuncs/array_aegis/array_len.sierra
@@ -1,0 +1,18 @@
+type Array<core::integer::u256> = Array<core::integer::u256> [storable: true, drop: true, dup: false, zero_sized: false];
+type u32 = u32 [storable: true, drop: true, dup: true, zero_sized: false];
+type u128 = u128 [storable: true, drop: true, dup: true, zero_sized: false];
+type core::integer::u256 = Struct<ut@core::integer::u256, u128, u128> [storable: true, drop: true, dup: true, zero_sized: false];
+type Snapshot<Array<core::integer::u256>> = Snapshot<Array<core::integer::u256>> [storable: true, drop: true, dup: true, zero_sized: false];
+
+libfunc snapshot_take<Array<core::integer::u256>> = snapshot_take<Array<core::integer::u256>>;
+libfunc array_len<core::integer::u256> = array_len<core::integer::u256>;
+libfunc store_temp<Array<core::integer::u256>> = store_temp<Array<core::integer::u256>>;
+libfunc store_temp<u32> = store_temp<u32>;
+
+snapshot_take<Array<core::integer::u256>>([0]) -> ([1], [2]); // 0
+array_len<core::integer::u256>([2]) -> ([3]); // 1
+store_temp<Array<core::integer::u256>>([1]) -> ([1]); // 2
+store_temp<u32>([3]) -> ([3]); // 3
+return([1], [3]); // 4
+
+test::foo@0([0]: Array<core::integer::u256>) -> (Array<core::integer::u256>, u32);

--- a/Aegis/Tests/e2e_libfuncs/array_aegis/array_new.sierra
+++ b/Aegis/Tests/e2e_libfuncs/array_aegis/array_new.sierra
@@ -1,0 +1,11 @@
+type Array<felt252> = Array<felt252> [storable: true, drop: true, dup: false, zero_sized: false];
+type felt252 = felt252 [storable: true, drop: true, dup: true, zero_sized: false];
+
+libfunc array_new<felt252> = array_new<felt252>;
+libfunc store_temp<Array<felt252>> = store_temp<Array<felt252>>;
+
+array_new<felt252>() -> ([0]); // 0
+store_temp<Array<felt252>>([0]) -> ([0]); // 1
+return([0]); // 2
+
+test::foo@0() -> (Array<felt252>);

--- a/Aegis/Tests/e2e_libfuncs/array_aegis/array_pop_front.sierra
+++ b/Aegis/Tests/e2e_libfuncs/array_aegis/array_pop_front.sierra
@@ -1,0 +1,28 @@
+type Array<felt252> = Array<felt252> [storable: true, drop: true, dup: false, zero_sized: false];
+type Unit = Struct<ut@Tuple> [storable: true, drop: true, dup: true, zero_sized: true];
+type felt252 = felt252 [storable: true, drop: true, dup: true, zero_sized: false];
+type Box<felt252> = Box<felt252> [storable: true, drop: true, dup: true, zero_sized: false];
+type core::option::Option::<core::box::Box::<core::felt252>> = Enum<ut@core::option::Option::<core::box::Box::<core::felt252>>, Box<felt252>, Unit> [storable: true, drop: true, dup: true, zero_sized: false];
+
+libfunc array_pop_front<felt252> = array_pop_front<felt252>;
+libfunc branch_align = branch_align;
+libfunc enum_init<core::option::Option::<core::box::Box::<core::felt252>>, 0> = enum_init<core::option::Option::<core::box::Box::<core::felt252>>, 0>;
+libfunc store_temp<Array<felt252>> = store_temp<Array<felt252>>;
+libfunc store_temp<core::option::Option::<core::box::Box::<core::felt252>>> = store_temp<core::option::Option::<core::box::Box::<core::felt252>>>;
+libfunc struct_construct<Unit> = struct_construct<Unit>;
+libfunc enum_init<core::option::Option::<core::box::Box::<core::felt252>>, 1> = enum_init<core::option::Option::<core::box::Box::<core::felt252>>, 1>;
+
+array_pop_front<felt252>([0]) { fallthrough([1], [2]) 6([3]) }; // 0
+branch_align() -> (); // 1
+enum_init<core::option::Option::<core::box::Box::<core::felt252>>, 0>([2]) -> ([4]); // 2
+store_temp<Array<felt252>>([1]) -> ([1]); // 3
+store_temp<core::option::Option::<core::box::Box::<core::felt252>>>([4]) -> ([4]); // 4
+return([1], [4]); // 5
+branch_align() -> (); // 6
+struct_construct<Unit>() -> ([5]); // 7
+enum_init<core::option::Option::<core::box::Box::<core::felt252>>, 1>([5]) -> ([6]); // 8
+store_temp<Array<felt252>>([3]) -> ([3]); // 9
+store_temp<core::option::Option::<core::box::Box::<core::felt252>>>([6]) -> ([6]); // 10
+return([3], [6]); // 11
+
+test::foo@0([0]: Array<felt252>) -> (Array<felt252>, core::option::Option::<core::box::Box::<core::felt252>>);

--- a/Aegis/Tests/e2e_libfuncs/array_aegis/array_pop_front_consume.sierra
+++ b/Aegis/Tests/e2e_libfuncs/array_aegis/array_pop_front_consume.sierra
@@ -1,0 +1,28 @@
+type Array<felt252> = Array<felt252> [storable: true, drop: true, dup: false, zero_sized: false];
+type Unit = Struct<ut@Tuple> [storable: true, drop: true, dup: true, zero_sized: true];
+type felt252 = felt252 [storable: true, drop: true, dup: true, zero_sized: false];
+type Box<felt252> = Box<felt252> [storable: true, drop: true, dup: true, zero_sized: false];
+type Tuple<Array<felt252>, Box<felt252>> = Struct<ut@Tuple, Array<felt252>, Box<felt252>> [storable: true, drop: true, dup: false, zero_sized: false];
+type core::option::Option::<(core::array::Array::<core::felt252>, core::box::Box::<core::felt252>)> = Enum<ut@core::option::Option::<(core::array::Array::<core::felt252>, core::box::Box::<core::felt252>)>, Tuple<Array<felt252>, Box<felt252>>, Unit> [storable: true, drop: true, dup: false, zero_sized: false];
+
+libfunc array_pop_front_consume<felt252> = array_pop_front_consume<felt252>;
+libfunc branch_align = branch_align;
+libfunc struct_construct<Tuple<Array<felt252>, Box<felt252>>> = struct_construct<Tuple<Array<felt252>, Box<felt252>>>;
+libfunc enum_init<core::option::Option::<(core::array::Array::<core::felt252>, core::box::Box::<core::felt252>)>, 0> = enum_init<core::option::Option::<(core::array::Array::<core::felt252>, core::box::Box::<core::felt252>)>, 0>;
+libfunc store_temp<core::option::Option::<(core::array::Array::<core::felt252>, core::box::Box::<core::felt252>)>> = store_temp<core::option::Option::<(core::array::Array::<core::felt252>, core::box::Box::<core::felt252>)>>;
+libfunc struct_construct<Unit> = struct_construct<Unit>;
+libfunc enum_init<core::option::Option::<(core::array::Array::<core::felt252>, core::box::Box::<core::felt252>)>, 1> = enum_init<core::option::Option::<(core::array::Array::<core::felt252>, core::box::Box::<core::felt252>)>, 1>;
+
+array_pop_front_consume<felt252>([0]) { fallthrough([1], [2]) 6() }; // 0
+branch_align() -> (); // 1
+struct_construct<Tuple<Array<felt252>, Box<felt252>>>([1], [2]) -> ([3]); // 2
+enum_init<core::option::Option::<(core::array::Array::<core::felt252>, core::box::Box::<core::felt252>)>, 0>([3]) -> ([4]); // 3
+store_temp<core::option::Option::<(core::array::Array::<core::felt252>, core::box::Box::<core::felt252>)>>([4]) -> ([4]); // 4
+return([4]); // 5
+branch_align() -> (); // 6
+struct_construct<Unit>() -> ([5]); // 7
+enum_init<core::option::Option::<(core::array::Array::<core::felt252>, core::box::Box::<core::felt252>)>, 1>([5]) -> ([6]); // 8
+store_temp<core::option::Option::<(core::array::Array::<core::felt252>, core::box::Box::<core::felt252>)>>([6]) -> ([6]); // 9
+return([6]); // 10
+
+test::foo@0([0]: Array<felt252>) -> (core::option::Option::<(core::array::Array::<core::felt252>, core::box::Box::<core::felt252>)>);

--- a/Aegis/Tests/e2e_libfuncs/array_aegis/array_slice.sierra
+++ b/Aegis/Tests/e2e_libfuncs/array_aegis/array_slice.sierra
@@ -1,0 +1,31 @@
+type RangeCheck = RangeCheck [storable: true, drop: false, dup: false, zero_sized: false];
+type Unit = Struct<ut@Tuple> [storable: true, drop: true, dup: true, zero_sized: true];
+type Array<Array<felt252>> = Array<Array<felt252>> [storable: true, drop: true, dup: false, zero_sized: false];
+type Snapshot<Array<Array<felt252>>> = Snapshot<Array<Array<felt252>>> [storable: true, drop: true, dup: true, zero_sized: false];
+type core::option::Option::<@core::array::Array::<core::array::Array::<core::felt252>>> = Enum<ut@core::option::Option::<@core::array::Array::<core::array::Array::<core::felt252>>>, Snapshot<Array<Array<felt252>>>, Unit> [storable: true, drop: true, dup: true, zero_sized: false];
+type u32 = u32 [storable: true, drop: true, dup: true, zero_sized: false];
+type Array<felt252> = Array<felt252> [storable: true, drop: true, dup: false, zero_sized: false];
+type felt252 = felt252 [storable: true, drop: true, dup: true, zero_sized: false];
+
+libfunc array_slice<Array<felt252>> = array_slice<Array<felt252>>;
+libfunc branch_align = branch_align;
+libfunc enum_init<core::option::Option::<@core::array::Array::<core::array::Array::<core::felt252>>>, 0> = enum_init<core::option::Option::<@core::array::Array::<core::array::Array::<core::felt252>>>, 0>;
+libfunc store_temp<RangeCheck> = store_temp<RangeCheck>;
+libfunc store_temp<core::option::Option::<@core::array::Array::<core::array::Array::<core::felt252>>>> = store_temp<core::option::Option::<@core::array::Array::<core::array::Array::<core::felt252>>>>;
+libfunc struct_construct<Unit> = struct_construct<Unit>;
+libfunc enum_init<core::option::Option::<@core::array::Array::<core::array::Array::<core::felt252>>>, 1> = enum_init<core::option::Option::<@core::array::Array::<core::array::Array::<core::felt252>>>, 1>;
+
+array_slice<Array<felt252>>([0], [1], [2], [3]) { fallthrough([4], [5]) 6([6]) }; // 0
+branch_align() -> (); // 1
+enum_init<core::option::Option::<@core::array::Array::<core::array::Array::<core::felt252>>>, 0>([5]) -> ([7]); // 2
+store_temp<RangeCheck>([4]) -> ([4]); // 3
+store_temp<core::option::Option::<@core::array::Array::<core::array::Array::<core::felt252>>>>([7]) -> ([7]); // 4
+return([4], [7]); // 5
+branch_align() -> (); // 6
+struct_construct<Unit>() -> ([8]); // 7
+enum_init<core::option::Option::<@core::array::Array::<core::array::Array::<core::felt252>>>, 1>([8]) -> ([9]); // 8
+store_temp<RangeCheck>([6]) -> ([6]); // 9
+store_temp<core::option::Option::<@core::array::Array::<core::array::Array::<core::felt252>>>>([9]) -> ([9]); // 10
+return([6], [9]); // 11
+
+test::foo@0([0]: RangeCheck, [1]: Snapshot<Array<Array<felt252>>>, [2]: u32, [3]: u32) -> (RangeCheck, core::option::Option::<@core::array::Array::<core::array::Array::<core::felt252>>>);

--- a/Aegis/Tests/e2e_libfuncs/array_aegis/array_snapshot_pop_back.sierra
+++ b/Aegis/Tests/e2e_libfuncs/array_aegis/array_snapshot_pop_back.sierra
@@ -1,0 +1,29 @@
+type Array<felt252> = Array<felt252> [storable: true, drop: true, dup: false, zero_sized: false];
+type Snapshot<Array<felt252>> = Snapshot<Array<felt252>> [storable: true, drop: true, dup: true, zero_sized: false];
+type Unit = Struct<ut@Tuple> [storable: true, drop: true, dup: true, zero_sized: true];
+type felt252 = felt252 [storable: true, drop: true, dup: true, zero_sized: false];
+type Box<felt252> = Box<felt252> [storable: true, drop: true, dup: true, zero_sized: false];
+type core::option::Option::<core::box::Box::<@core::felt252>> = Enum<ut@core::option::Option::<core::box::Box::<@core::felt252>>, Box<felt252>, Unit> [storable: true, drop: true, dup: true, zero_sized: false];
+
+libfunc array_snapshot_pop_back<felt252> = array_snapshot_pop_back<felt252>;
+libfunc branch_align = branch_align;
+libfunc enum_init<core::option::Option::<core::box::Box::<@core::felt252>>, 0> = enum_init<core::option::Option::<core::box::Box::<@core::felt252>>, 0>;
+libfunc store_temp<Snapshot<Array<felt252>>> = store_temp<Snapshot<Array<felt252>>>;
+libfunc store_temp<core::option::Option::<core::box::Box::<@core::felt252>>> = store_temp<core::option::Option::<core::box::Box::<@core::felt252>>>;
+libfunc struct_construct<Unit> = struct_construct<Unit>;
+libfunc enum_init<core::option::Option::<core::box::Box::<@core::felt252>>, 1> = enum_init<core::option::Option::<core::box::Box::<@core::felt252>>, 1>;
+
+array_snapshot_pop_back<felt252>([0]) { fallthrough([1], [2]) 6([3]) }; // 0
+branch_align() -> (); // 1
+enum_init<core::option::Option::<core::box::Box::<@core::felt252>>, 0>([2]) -> ([4]); // 2
+store_temp<Snapshot<Array<felt252>>>([1]) -> ([1]); // 3
+store_temp<core::option::Option::<core::box::Box::<@core::felt252>>>([4]) -> ([4]); // 4
+return([1], [4]); // 5
+branch_align() -> (); // 6
+struct_construct<Unit>() -> ([5]); // 7
+enum_init<core::option::Option::<core::box::Box::<@core::felt252>>, 1>([5]) -> ([6]); // 8
+store_temp<Snapshot<Array<felt252>>>([3]) -> ([3]); // 9
+store_temp<core::option::Option::<core::box::Box::<@core::felt252>>>([6]) -> ([6]); // 10
+return([3], [6]); // 11
+
+test::foo@0([0]: Snapshot<Array<felt252>>) -> (Snapshot<Array<felt252>>, core::option::Option::<core::box::Box::<@core::felt252>>);

--- a/Aegis/Tests/e2e_libfuncs/array_aegis/array_snapshot_pop_front.sierra
+++ b/Aegis/Tests/e2e_libfuncs/array_aegis/array_snapshot_pop_front.sierra
@@ -1,0 +1,29 @@
+type Array<felt252> = Array<felt252> [storable: true, drop: true, dup: false, zero_sized: false];
+type Snapshot<Array<felt252>> = Snapshot<Array<felt252>> [storable: true, drop: true, dup: true, zero_sized: false];
+type Unit = Struct<ut@Tuple> [storable: true, drop: true, dup: true, zero_sized: true];
+type felt252 = felt252 [storable: true, drop: true, dup: true, zero_sized: false];
+type Box<felt252> = Box<felt252> [storable: true, drop: true, dup: true, zero_sized: false];
+type core::option::Option::<core::box::Box::<@core::felt252>> = Enum<ut@core::option::Option::<core::box::Box::<@core::felt252>>, Box<felt252>, Unit> [storable: true, drop: true, dup: true, zero_sized: false];
+
+libfunc array_snapshot_pop_front<felt252> = array_snapshot_pop_front<felt252>;
+libfunc branch_align = branch_align;
+libfunc enum_init<core::option::Option::<core::box::Box::<@core::felt252>>, 0> = enum_init<core::option::Option::<core::box::Box::<@core::felt252>>, 0>;
+libfunc store_temp<Snapshot<Array<felt252>>> = store_temp<Snapshot<Array<felt252>>>;
+libfunc store_temp<core::option::Option::<core::box::Box::<@core::felt252>>> = store_temp<core::option::Option::<core::box::Box::<@core::felt252>>>;
+libfunc struct_construct<Unit> = struct_construct<Unit>;
+libfunc enum_init<core::option::Option::<core::box::Box::<@core::felt252>>, 1> = enum_init<core::option::Option::<core::box::Box::<@core::felt252>>, 1>;
+
+array_snapshot_pop_front<felt252>([0]) { fallthrough([1], [2]) 6([3]) }; // 0
+branch_align() -> (); // 1
+enum_init<core::option::Option::<core::box::Box::<@core::felt252>>, 0>([2]) -> ([4]); // 2
+store_temp<Snapshot<Array<felt252>>>([1]) -> ([1]); // 3
+store_temp<core::option::Option::<core::box::Box::<@core::felt252>>>([4]) -> ([4]); // 4
+return([1], [4]); // 5
+branch_align() -> (); // 6
+struct_construct<Unit>() -> ([5]); // 7
+enum_init<core::option::Option::<core::box::Box::<@core::felt252>>, 1>([5]) -> ([6]); // 8
+store_temp<Snapshot<Array<felt252>>>([3]) -> ([3]); // 9
+store_temp<core::option::Option::<core::box::Box::<@core::felt252>>>([6]) -> ([6]); // 10
+return([3], [6]); // 11
+
+test::foo@0([0]: Snapshot<Array<felt252>>) -> (Snapshot<Array<felt252>>, core::option::Option::<core::box::Box::<@core::felt252>>);

--- a/Aegis/Tests/e2e_libfuncs/array_aegis/span_from_tuple.sierra
+++ b/Aegis/Tests/e2e_libfuncs/array_aegis/span_from_tuple.sierra
@@ -1,0 +1,14 @@
+type Box<Tuple<felt252, felt252, felt252>> = Box<Tuple<felt252, felt252, felt252>> [storable: true, drop: true, dup: true, zero_sized: false];
+type Array<felt252> = Array<felt252> [storable: true, drop: true, dup: false, zero_sized: false];
+type Snapshot<Array<felt252>> = Snapshot<Array<felt252>> [storable: true, drop: true, dup: true, zero_sized: false];
+type felt252 = felt252 [storable: true, drop: true, dup: true, zero_sized: false];
+type Tuple<felt252, felt252, felt252> = Struct<ut@Tuple, felt252, felt252, felt252> [storable: true, drop: true, dup: true, zero_sized: false];
+
+libfunc span_from_tuple<Tuple<felt252, felt252, felt252>> = span_from_tuple<Tuple<felt252, felt252, felt252>>;
+libfunc store_temp<Snapshot<Array<felt252>>> = store_temp<Snapshot<Array<felt252>>>;
+
+span_from_tuple<Tuple<felt252, felt252, felt252>>([0]) -> ([1]); // 0
+store_temp<Snapshot<Array<felt252>>>([1]) -> ([1]); // 1
+return([1]); // 2
+
+test::foo@0([0]: Box<Tuple<felt252, felt252, felt252>>) -> (Snapshot<Array<felt252>>);

--- a/Aegis/Tests/e2e_libfuncs/bitwise_aegis/bitwise.sierra
+++ b/Aegis/Tests/e2e_libfuncs/bitwise_aegis/bitwise.sierra
@@ -1,0 +1,16 @@
+type Bitwise = Bitwise [storable: true, drop: false, dup: false, zero_sized: false];
+type u128 = u128 [storable: true, drop: true, dup: true, zero_sized: false];
+type Tuple<u128, u128, u128> = Struct<ut@Tuple, u128, u128, u128> [storable: true, drop: true, dup: true, zero_sized: false];
+
+libfunc bitwise = bitwise;
+libfunc struct_construct<Tuple<u128, u128, u128>> = struct_construct<Tuple<u128, u128, u128>>;
+libfunc store_temp<Bitwise> = store_temp<Bitwise>;
+libfunc store_temp<Tuple<u128, u128, u128>> = store_temp<Tuple<u128, u128, u128>>;
+
+bitwise([0], [1], [2]) -> ([3], [4], [5], [6]); // 0
+struct_construct<Tuple<u128, u128, u128>>([4], [5], [6]) -> ([7]); // 1
+store_temp<Bitwise>([3]) -> ([3]); // 2
+store_temp<Tuple<u128, u128, u128>>([7]) -> ([7]); // 3
+return([3], [7]); // 4
+
+test::foo@0([0]: Bitwise, [1]: u128, [2]: u128) -> (Bitwise, Tuple<u128, u128, u128>);

--- a/Aegis/Tests/e2e_libfuncs/bitwise_aegis/u16_bitwise.sierra
+++ b/Aegis/Tests/e2e_libfuncs/bitwise_aegis/u16_bitwise.sierra
@@ -1,0 +1,16 @@
+type Bitwise = Bitwise [storable: true, drop: false, dup: false, zero_sized: false];
+type u16 = u16 [storable: true, drop: true, dup: true, zero_sized: false];
+type Tuple<u16, u16, u16> = Struct<ut@Tuple, u16, u16, u16> [storable: true, drop: true, dup: true, zero_sized: false];
+
+libfunc u16_bitwise = u16_bitwise;
+libfunc struct_construct<Tuple<u16, u16, u16>> = struct_construct<Tuple<u16, u16, u16>>;
+libfunc store_temp<Bitwise> = store_temp<Bitwise>;
+libfunc store_temp<Tuple<u16, u16, u16>> = store_temp<Tuple<u16, u16, u16>>;
+
+u16_bitwise([0], [1], [2]) -> ([3], [4], [5], [6]); // 0
+struct_construct<Tuple<u16, u16, u16>>([4], [5], [6]) -> ([7]); // 1
+store_temp<Bitwise>([3]) -> ([3]); // 2
+store_temp<Tuple<u16, u16, u16>>([7]) -> ([7]); // 3
+return([3], [7]); // 4
+
+test::foo@0([0]: Bitwise, [1]: u16, [2]: u16) -> (Bitwise, Tuple<u16, u16, u16>);

--- a/Aegis/Tests/e2e_libfuncs/bitwise_aegis/u32_bitwise.sierra
+++ b/Aegis/Tests/e2e_libfuncs/bitwise_aegis/u32_bitwise.sierra
@@ -1,0 +1,16 @@
+type Bitwise = Bitwise [storable: true, drop: false, dup: false, zero_sized: false];
+type u32 = u32 [storable: true, drop: true, dup: true, zero_sized: false];
+type Tuple<u32, u32, u32> = Struct<ut@Tuple, u32, u32, u32> [storable: true, drop: true, dup: true, zero_sized: false];
+
+libfunc u32_bitwise = u32_bitwise;
+libfunc struct_construct<Tuple<u32, u32, u32>> = struct_construct<Tuple<u32, u32, u32>>;
+libfunc store_temp<Bitwise> = store_temp<Bitwise>;
+libfunc store_temp<Tuple<u32, u32, u32>> = store_temp<Tuple<u32, u32, u32>>;
+
+u32_bitwise([0], [1], [2]) -> ([3], [4], [5], [6]); // 0
+struct_construct<Tuple<u32, u32, u32>>([4], [5], [6]) -> ([7]); // 1
+store_temp<Bitwise>([3]) -> ([3]); // 2
+store_temp<Tuple<u32, u32, u32>>([7]) -> ([7]); // 3
+return([3], [7]); // 4
+
+test::foo@0([0]: Bitwise, [1]: u32, [2]: u32) -> (Bitwise, Tuple<u32, u32, u32>);

--- a/Aegis/Tests/e2e_libfuncs/bitwise_aegis/u64_bitwise.sierra
+++ b/Aegis/Tests/e2e_libfuncs/bitwise_aegis/u64_bitwise.sierra
@@ -1,0 +1,16 @@
+type Bitwise = Bitwise [storable: true, drop: false, dup: false, zero_sized: false];
+type u64 = u64 [storable: true, drop: true, dup: true, zero_sized: false];
+type Tuple<u64, u64, u64> = Struct<ut@Tuple, u64, u64, u64> [storable: true, drop: true, dup: true, zero_sized: false];
+
+libfunc u64_bitwise = u64_bitwise;
+libfunc struct_construct<Tuple<u64, u64, u64>> = struct_construct<Tuple<u64, u64, u64>>;
+libfunc store_temp<Bitwise> = store_temp<Bitwise>;
+libfunc store_temp<Tuple<u64, u64, u64>> = store_temp<Tuple<u64, u64, u64>>;
+
+u64_bitwise([0], [1], [2]) -> ([3], [4], [5], [6]); // 0
+struct_construct<Tuple<u64, u64, u64>>([4], [5], [6]) -> ([7]); // 1
+store_temp<Bitwise>([3]) -> ([3]); // 2
+store_temp<Tuple<u64, u64, u64>>([7]) -> ([7]); // 3
+return([3], [7]); // 4
+
+test::foo@0([0]: Bitwise, [1]: u64, [2]: u64) -> (Bitwise, Tuple<u64, u64, u64>);

--- a/Aegis/Tests/e2e_libfuncs/bitwise_aegis/u8_bitwise.sierra
+++ b/Aegis/Tests/e2e_libfuncs/bitwise_aegis/u8_bitwise.sierra
@@ -1,0 +1,16 @@
+type Bitwise = Bitwise [storable: true, drop: false, dup: false, zero_sized: false];
+type u8 = u8 [storable: true, drop: true, dup: true, zero_sized: false];
+type Tuple<u8, u8, u8> = Struct<ut@Tuple, u8, u8, u8> [storable: true, drop: true, dup: true, zero_sized: false];
+
+libfunc u8_bitwise = u8_bitwise;
+libfunc struct_construct<Tuple<u8, u8, u8>> = struct_construct<Tuple<u8, u8, u8>>;
+libfunc store_temp<Bitwise> = store_temp<Bitwise>;
+libfunc store_temp<Tuple<u8, u8, u8>> = store_temp<Tuple<u8, u8, u8>>;
+
+u8_bitwise([0], [1], [2]) -> ([3], [4], [5], [6]); // 0
+struct_construct<Tuple<u8, u8, u8>>([4], [5], [6]) -> ([7]); // 1
+store_temp<Bitwise>([3]) -> ([3]); // 2
+store_temp<Tuple<u8, u8, u8>>([7]) -> ([7]); // 3
+return([3], [7]); // 4
+
+test::foo@0([0]: Bitwise, [1]: u8, [2]: u8) -> (Bitwise, Tuple<u8, u8, u8>);

--- a/Aegis/Tests/e2e_libfuncs/bool_aegis/bool_and.sierra
+++ b/Aegis/Tests/e2e_libfuncs/bool_aegis/bool_and.sierra
@@ -1,0 +1,11 @@
+type Unit = Struct<ut@Tuple> [storable: true, drop: true, dup: true, zero_sized: true];
+type core::bool = Enum<ut@core::bool, Unit, Unit> [storable: true, drop: true, dup: true, zero_sized: false];
+
+libfunc bool_and_impl = bool_and_impl;
+libfunc store_temp<core::bool> = store_temp<core::bool>;
+
+bool_and_impl([0], [1]) -> ([2]); // 0
+store_temp<core::bool>([2]) -> ([2]); // 1
+return([2]); // 2
+
+test::foo@0([0]: core::bool, [1]: core::bool) -> (core::bool);

--- a/Aegis/Tests/e2e_libfuncs/bool_aegis/bool_not.sierra
+++ b/Aegis/Tests/e2e_libfuncs/bool_aegis/bool_not.sierra
@@ -1,0 +1,11 @@
+type Unit = Struct<ut@Tuple> [storable: true, drop: true, dup: true, zero_sized: true];
+type core::bool = Enum<ut@core::bool, Unit, Unit> [storable: true, drop: true, dup: true, zero_sized: false];
+
+libfunc bool_not_impl = bool_not_impl;
+libfunc store_temp<core::bool> = store_temp<core::bool>;
+
+bool_not_impl([0]) -> ([1]); // 0
+store_temp<core::bool>([1]) -> ([1]); // 1
+return([1]); // 2
+
+test::foo@0([0]: core::bool) -> (core::bool);

--- a/Aegis/Tests/e2e_libfuncs/bool_aegis/bool_or.sierra
+++ b/Aegis/Tests/e2e_libfuncs/bool_aegis/bool_or.sierra
@@ -1,0 +1,11 @@
+type Unit = Struct<ut@Tuple> [storable: true, drop: true, dup: true, zero_sized: true];
+type core::bool = Enum<ut@core::bool, Unit, Unit> [storable: true, drop: true, dup: true, zero_sized: false];
+
+libfunc bool_or_impl = bool_or_impl;
+libfunc store_temp<core::bool> = store_temp<core::bool>;
+
+bool_or_impl([0], [1]) -> ([2]); // 0
+store_temp<core::bool>([2]) -> ([2]); // 1
+return([2]); // 2
+
+test::foo@0([0]: core::bool, [1]: core::bool) -> (core::bool);

--- a/Aegis/Tests/e2e_libfuncs/bool_aegis/bool_xor.sierra
+++ b/Aegis/Tests/e2e_libfuncs/bool_aegis/bool_xor.sierra
@@ -1,0 +1,11 @@
+type Unit = Struct<ut@Tuple> [storable: true, drop: true, dup: true, zero_sized: true];
+type core::bool = Enum<ut@core::bool, Unit, Unit> [storable: true, drop: true, dup: true, zero_sized: false];
+
+libfunc bool_xor_impl = bool_xor_impl;
+libfunc store_temp<core::bool> = store_temp<core::bool>;
+
+bool_xor_impl([0], [1]) -> ([2]); // 0
+store_temp<core::bool>([2]) -> ([2]); // 1
+return([2]); // 2
+
+test::foo@0([0]: core::bool, [1]: core::bool) -> (core::bool);

--- a/Aegis/Tests/e2e_libfuncs/box_aegis/box_forward_snapshot.sierra
+++ b/Aegis/Tests/e2e_libfuncs/box_aegis/box_forward_snapshot.sierra
@@ -1,0 +1,15 @@
+type Box<Array<felt252>> = Box<Array<felt252>> [storable: true, drop: true, dup: false, zero_sized: false];
+type Snapshot<Box<Array<felt252>>> = Snapshot<Box<Array<felt252>>> [storable: true, drop: true, dup: true, zero_sized: false];
+type Box<Snapshot<Array<felt252>>> = Box<Snapshot<Array<felt252>>> [storable: true, drop: true, dup: true, zero_sized: false];
+type Array<felt252> = Array<felt252> [storable: true, drop: true, dup: false, zero_sized: false];
+type Snapshot<Array<felt252>> = Snapshot<Array<felt252>> [storable: true, drop: true, dup: true, zero_sized: false];
+type felt252 = felt252 [storable: true, drop: true, dup: true, zero_sized: false];
+
+libfunc box_forward_snapshot<Array<felt252>> = box_forward_snapshot<Array<felt252>>;
+libfunc store_temp<Box<Snapshot<Array<felt252>>>> = store_temp<Box<Snapshot<Array<felt252>>>>;
+
+box_forward_snapshot<Array<felt252>>([0]) -> ([1]); // 0
+store_temp<Box<Snapshot<Array<felt252>>>>([1]) -> ([1]); // 1
+return([1]); // 2
+
+test::foo@0([0]: Snapshot<Box<Array<felt252>>>) -> (Box<Snapshot<Array<felt252>>>);

--- a/Aegis/Tests/e2e_libfuncs/box_aegis/into_box.sierra
+++ b/Aegis/Tests/e2e_libfuncs/box_aegis/into_box.sierra
@@ -1,0 +1,11 @@
+type test::Empty = Struct<ut@test::Empty> [storable: true, drop: true, dup: true, zero_sized: true];
+type Box<test::Empty> = Box<test::Empty> [storable: true, drop: true, dup: true, zero_sized: false];
+
+libfunc struct_construct<test::Empty> = struct_construct<test::Empty>;
+libfunc into_box<test::Empty> = into_box<test::Empty>;
+
+struct_construct<test::Empty>() -> ([0]); // 0
+into_box<test::Empty>([0]) -> ([1]); // 1
+return([1]); // 2
+
+test::foo@0() -> (Box<test::Empty>);

--- a/Aegis/Tests/e2e_libfuncs/box_aegis/unbox.sierra
+++ b/Aegis/Tests/e2e_libfuncs/box_aegis/unbox.sierra
@@ -1,0 +1,9 @@
+type Box<test::Empty> = Box<test::Empty> [storable: true, drop: true, dup: true, zero_sized: false];
+type test::Empty = Struct<ut@test::Empty> [storable: true, drop: true, dup: true, zero_sized: true];
+
+libfunc unbox<test::Empty> = unbox<test::Empty>;
+
+unbox<test::Empty>([0]) -> ([1]); // 0
+return([1]); // 1
+
+test::foo@0([0]: Box<test::Empty>) -> (test::Empty);

--- a/Aegis/Tests/e2e_libfuncs/builtin_costs_aegis/get_builtin_costs.sierra
+++ b/Aegis/Tests/e2e_libfuncs/builtin_costs_aegis/get_builtin_costs.sierra
@@ -1,0 +1,13 @@
+type BuiltinCosts = BuiltinCosts [storable: true, drop: true, dup: true, zero_sized: false];
+
+libfunc get_builtin_costs = get_builtin_costs;
+libfunc drop<BuiltinCosts> = drop<BuiltinCosts>;
+libfunc store_temp<BuiltinCosts> = store_temp<BuiltinCosts>;
+
+get_builtin_costs() -> ([0]); // 0
+get_builtin_costs() -> ([1]); // 1
+drop<BuiltinCosts>([1]) -> (); // 2
+store_temp<BuiltinCosts>([0]) -> ([0]); // 3
+return([0]); // 4
+
+test::foo@0() -> (BuiltinCosts);

--- a/Aegis/Tests/e2e_libfuncs/bytes31_aegis/bytes31_const.sierra
+++ b/Aegis/Tests/e2e_libfuncs/bytes31_aegis/bytes31_const.sierra
@@ -1,0 +1,10 @@
+type bytes31 = bytes31 [storable: true, drop: true, dup: true, zero_sized: false];
+
+libfunc bytes31_const<256> = bytes31_const<256>;
+libfunc store_temp<bytes31> = store_temp<bytes31>;
+
+bytes31_const<256>() -> ([0]); // 0
+store_temp<bytes31>([0]) -> ([0]); // 1
+return([0]); // 2
+
+test::foo@0() -> (bytes31);

--- a/Aegis/Tests/e2e_libfuncs/bytes31_aegis/bytes31_to_felt252.sierra
+++ b/Aegis/Tests/e2e_libfuncs/bytes31_aegis/bytes31_to_felt252.sierra
@@ -1,0 +1,11 @@
+type bytes31 = bytes31 [storable: true, drop: true, dup: true, zero_sized: false];
+type felt252 = felt252 [storable: true, drop: true, dup: true, zero_sized: false];
+
+libfunc bytes31_to_felt252 = bytes31_to_felt252;
+libfunc store_temp<felt252> = store_temp<felt252>;
+
+bytes31_to_felt252([0]) -> ([1]); // 0
+store_temp<felt252>([1]) -> ([1]); // 1
+return([1]); // 2
+
+test::foo@0([0]: bytes31) -> (felt252);

--- a/Aegis/Tests/e2e_libfuncs/bytes31_aegis/bytes31_try_from_felt252.sierra
+++ b/Aegis/Tests/e2e_libfuncs/bytes31_aegis/bytes31_try_from_felt252.sierra
@@ -1,0 +1,28 @@
+type RangeCheck = RangeCheck [storable: true, drop: false, dup: false, zero_sized: false];
+type Unit = Struct<ut@Tuple> [storable: true, drop: true, dup: true, zero_sized: true];
+type bytes31 = bytes31 [storable: true, drop: true, dup: true, zero_sized: false];
+type core::option::Option::<core::bytes_31::bytes31> = Enum<ut@core::option::Option::<core::bytes_31::bytes31>, bytes31, Unit> [storable: true, drop: true, dup: true, zero_sized: false];
+type felt252 = felt252 [storable: true, drop: true, dup: true, zero_sized: false];
+
+libfunc bytes31_try_from_felt252 = bytes31_try_from_felt252;
+libfunc branch_align = branch_align;
+libfunc enum_init<core::option::Option::<core::bytes_31::bytes31>, 0> = enum_init<core::option::Option::<core::bytes_31::bytes31>, 0>;
+libfunc store_temp<RangeCheck> = store_temp<RangeCheck>;
+libfunc store_temp<core::option::Option::<core::bytes_31::bytes31>> = store_temp<core::option::Option::<core::bytes_31::bytes31>>;
+libfunc struct_construct<Unit> = struct_construct<Unit>;
+libfunc enum_init<core::option::Option::<core::bytes_31::bytes31>, 1> = enum_init<core::option::Option::<core::bytes_31::bytes31>, 1>;
+
+bytes31_try_from_felt252([0], [1]) { fallthrough([2], [3]) 6([4]) }; // 0
+branch_align() -> (); // 1
+enum_init<core::option::Option::<core::bytes_31::bytes31>, 0>([3]) -> ([5]); // 2
+store_temp<RangeCheck>([2]) -> ([2]); // 3
+store_temp<core::option::Option::<core::bytes_31::bytes31>>([5]) -> ([5]); // 4
+return([2], [5]); // 5
+branch_align() -> (); // 6
+struct_construct<Unit>() -> ([6]); // 7
+enum_init<core::option::Option::<core::bytes_31::bytes31>, 1>([6]) -> ([7]); // 8
+store_temp<RangeCheck>([4]) -> ([4]); // 9
+store_temp<core::option::Option::<core::bytes_31::bytes31>>([7]) -> ([7]); // 10
+return([4], [7]); // 11
+
+test::foo@0([0]: RangeCheck, [1]: felt252) -> (RangeCheck, core::option::Option::<core::bytes_31::bytes31>);

--- a/Aegis/Tests/e2e_libfuncs/class_hash_aegis/class_hash_to_felt252.sierra
+++ b/Aegis/Tests/e2e_libfuncs/class_hash_aegis/class_hash_to_felt252.sierra
@@ -1,0 +1,11 @@
+type ClassHash = ClassHash [storable: true, drop: true, dup: true, zero_sized: false];
+type felt252 = felt252 [storable: true, drop: true, dup: true, zero_sized: false];
+
+libfunc class_hash_to_felt252 = class_hash_to_felt252;
+libfunc store_temp<felt252> = store_temp<felt252>;
+
+class_hash_to_felt252([0]) -> ([1]); // 0
+store_temp<felt252>([1]) -> ([1]); // 1
+return([1]); // 2
+
+test::foo@0([0]: ClassHash) -> (felt252);

--- a/Aegis/Tests/e2e_libfuncs/class_hash_aegis/class_hash_try_from_felt252.sierra
+++ b/Aegis/Tests/e2e_libfuncs/class_hash_aegis/class_hash_try_from_felt252.sierra
@@ -1,0 +1,28 @@
+type RangeCheck = RangeCheck [storable: true, drop: false, dup: false, zero_sized: false];
+type Unit = Struct<ut@Tuple> [storable: true, drop: true, dup: true, zero_sized: true];
+type ClassHash = ClassHash [storable: true, drop: true, dup: true, zero_sized: false];
+type core::option::Option::<core::starknet::class_hash::ClassHash> = Enum<ut@core::option::Option::<core::starknet::class_hash::ClassHash>, ClassHash, Unit> [storable: true, drop: true, dup: true, zero_sized: false];
+type felt252 = felt252 [storable: true, drop: true, dup: true, zero_sized: false];
+
+libfunc class_hash_try_from_felt252 = class_hash_try_from_felt252;
+libfunc branch_align = branch_align;
+libfunc enum_init<core::option::Option::<core::starknet::class_hash::ClassHash>, 0> = enum_init<core::option::Option::<core::starknet::class_hash::ClassHash>, 0>;
+libfunc store_temp<RangeCheck> = store_temp<RangeCheck>;
+libfunc store_temp<core::option::Option::<core::starknet::class_hash::ClassHash>> = store_temp<core::option::Option::<core::starknet::class_hash::ClassHash>>;
+libfunc struct_construct<Unit> = struct_construct<Unit>;
+libfunc enum_init<core::option::Option::<core::starknet::class_hash::ClassHash>, 1> = enum_init<core::option::Option::<core::starknet::class_hash::ClassHash>, 1>;
+
+class_hash_try_from_felt252([0], [1]) { fallthrough([2], [3]) 6([4]) }; // 0
+branch_align() -> (); // 1
+enum_init<core::option::Option::<core::starknet::class_hash::ClassHash>, 0>([3]) -> ([5]); // 2
+store_temp<RangeCheck>([2]) -> ([2]); // 3
+store_temp<core::option::Option::<core::starknet::class_hash::ClassHash>>([5]) -> ([5]); // 4
+return([2], [5]); // 5
+branch_align() -> (); // 6
+struct_construct<Unit>() -> ([6]); // 7
+enum_init<core::option::Option::<core::starknet::class_hash::ClassHash>, 1>([6]) -> ([7]); // 8
+store_temp<RangeCheck>([4]) -> ([4]); // 9
+store_temp<core::option::Option::<core::starknet::class_hash::ClassHash>>([7]) -> ([7]); // 10
+return([4], [7]); // 11
+
+test::foo@0([0]: RangeCheck, [1]: felt252) -> (RangeCheck, core::option::Option::<core::starknet::class_hash::ClassHash>);

--- a/Aegis/Tests/e2e_libfuncs/contract_address_aegis/contract_address_to_felt252.sierra
+++ b/Aegis/Tests/e2e_libfuncs/contract_address_aegis/contract_address_to_felt252.sierra
@@ -1,0 +1,11 @@
+type ContractAddress = ContractAddress [storable: true, drop: true, dup: true, zero_sized: false];
+type felt252 = felt252 [storable: true, drop: true, dup: true, zero_sized: false];
+
+libfunc contract_address_to_felt252 = contract_address_to_felt252;
+libfunc store_temp<felt252> = store_temp<felt252>;
+
+contract_address_to_felt252([0]) -> ([1]); // 0
+store_temp<felt252>([1]) -> ([1]); // 1
+return([1]); // 2
+
+test::foo@0([0]: ContractAddress) -> (felt252);

--- a/Aegis/Tests/e2e_libfuncs/contract_address_aegis/contract_address_try_from_felt252.sierra
+++ b/Aegis/Tests/e2e_libfuncs/contract_address_aegis/contract_address_try_from_felt252.sierra
@@ -1,0 +1,28 @@
+type RangeCheck = RangeCheck [storable: true, drop: false, dup: false, zero_sized: false];
+type Unit = Struct<ut@Tuple> [storable: true, drop: true, dup: true, zero_sized: true];
+type ContractAddress = ContractAddress [storable: true, drop: true, dup: true, zero_sized: false];
+type core::option::Option::<core::starknet::contract_address::ContractAddress> = Enum<ut@core::option::Option::<core::starknet::contract_address::ContractAddress>, ContractAddress, Unit> [storable: true, drop: true, dup: true, zero_sized: false];
+type felt252 = felt252 [storable: true, drop: true, dup: true, zero_sized: false];
+
+libfunc contract_address_try_from_felt252 = contract_address_try_from_felt252;
+libfunc branch_align = branch_align;
+libfunc enum_init<core::option::Option::<core::starknet::contract_address::ContractAddress>, 0> = enum_init<core::option::Option::<core::starknet::contract_address::ContractAddress>, 0>;
+libfunc store_temp<RangeCheck> = store_temp<RangeCheck>;
+libfunc store_temp<core::option::Option::<core::starknet::contract_address::ContractAddress>> = store_temp<core::option::Option::<core::starknet::contract_address::ContractAddress>>;
+libfunc struct_construct<Unit> = struct_construct<Unit>;
+libfunc enum_init<core::option::Option::<core::starknet::contract_address::ContractAddress>, 1> = enum_init<core::option::Option::<core::starknet::contract_address::ContractAddress>, 1>;
+
+contract_address_try_from_felt252([0], [1]) { fallthrough([2], [3]) 6([4]) }; // 0
+branch_align() -> (); // 1
+enum_init<core::option::Option::<core::starknet::contract_address::ContractAddress>, 0>([3]) -> ([5]); // 2
+store_temp<RangeCheck>([2]) -> ([2]); // 3
+store_temp<core::option::Option::<core::starknet::contract_address::ContractAddress>>([5]) -> ([5]); // 4
+return([2], [5]); // 5
+branch_align() -> (); // 6
+struct_construct<Unit>() -> ([6]); // 7
+enum_init<core::option::Option::<core::starknet::contract_address::ContractAddress>, 1>([6]) -> ([7]); // 8
+store_temp<RangeCheck>([4]) -> ([4]); // 9
+store_temp<core::option::Option::<core::starknet::contract_address::ContractAddress>>([7]) -> ([7]); // 10
+return([4], [7]); // 11
+
+test::foo@0([0]: RangeCheck, [1]: felt252) -> (RangeCheck, core::option::Option::<core::starknet::contract_address::ContractAddress>);

--- a/Aegis/Tests/e2e_libfuncs/ec_aegis/ec_neg.sierra
+++ b/Aegis/Tests/e2e_libfuncs/ec_aegis/ec_neg.sierra
@@ -1,0 +1,10 @@
+type EcPoint = EcPoint [storable: true, drop: true, dup: true, zero_sized: false];
+
+libfunc ec_neg = ec_neg;
+libfunc store_temp<EcPoint> = store_temp<EcPoint>;
+
+ec_neg([0]) -> ([1]); // 0
+store_temp<EcPoint>([1]) -> ([1]); // 1
+return([1]); // 2
+
+test::foo@0([0]: EcPoint) -> (EcPoint);

--- a/Aegis/Tests/e2e_libfuncs/ec_aegis/ec_point_from_x_nz.sierra
+++ b/Aegis/Tests/e2e_libfuncs/ec_aegis/ec_point_from_x_nz.sierra
@@ -1,0 +1,29 @@
+type RangeCheck = RangeCheck [storable: true, drop: false, dup: false, zero_sized: false];
+type Unit = Struct<ut@Tuple> [storable: true, drop: true, dup: true, zero_sized: true];
+type EcPoint = EcPoint [storable: true, drop: true, dup: true, zero_sized: false];
+type NonZero<EcPoint> = NonZero<EcPoint> [storable: true, drop: true, dup: true, zero_sized: false];
+type core::option::Option::<core::zeroable::NonZero::<core::ec::EcPoint>> = Enum<ut@core::option::Option::<core::zeroable::NonZero::<core::ec::EcPoint>>, NonZero<EcPoint>, Unit> [storable: true, drop: true, dup: true, zero_sized: false];
+type felt252 = felt252 [storable: true, drop: true, dup: true, zero_sized: false];
+
+libfunc ec_point_from_x_nz = ec_point_from_x_nz;
+libfunc branch_align = branch_align;
+libfunc enum_init<core::option::Option::<core::zeroable::NonZero::<core::ec::EcPoint>>, 0> = enum_init<core::option::Option::<core::zeroable::NonZero::<core::ec::EcPoint>>, 0>;
+libfunc store_temp<RangeCheck> = store_temp<RangeCheck>;
+libfunc store_temp<core::option::Option::<core::zeroable::NonZero::<core::ec::EcPoint>>> = store_temp<core::option::Option::<core::zeroable::NonZero::<core::ec::EcPoint>>>;
+libfunc struct_construct<Unit> = struct_construct<Unit>;
+libfunc enum_init<core::option::Option::<core::zeroable::NonZero::<core::ec::EcPoint>>, 1> = enum_init<core::option::Option::<core::zeroable::NonZero::<core::ec::EcPoint>>, 1>;
+
+ec_point_from_x_nz([0], [1]) { fallthrough([2], [3]) 6([4]) }; // 0
+branch_align() -> (); // 1
+enum_init<core::option::Option::<core::zeroable::NonZero::<core::ec::EcPoint>>, 0>([3]) -> ([5]); // 2
+store_temp<RangeCheck>([2]) -> ([2]); // 3
+store_temp<core::option::Option::<core::zeroable::NonZero::<core::ec::EcPoint>>>([5]) -> ([5]); // 4
+return([2], [5]); // 5
+branch_align() -> (); // 6
+struct_construct<Unit>() -> ([6]); // 7
+enum_init<core::option::Option::<core::zeroable::NonZero::<core::ec::EcPoint>>, 1>([6]) -> ([7]); // 8
+store_temp<RangeCheck>([4]) -> ([4]); // 9
+store_temp<core::option::Option::<core::zeroable::NonZero::<core::ec::EcPoint>>>([7]) -> ([7]); // 10
+return([4], [7]); // 11
+
+test::foo@0([0]: RangeCheck, [1]: felt252) -> (RangeCheck, core::option::Option::<core::zeroable::NonZero::<core::ec::EcPoint>>);

--- a/Aegis/Tests/e2e_libfuncs/ec_aegis/ec_point_is_zero.sierra
+++ b/Aegis/Tests/e2e_libfuncs/ec_aegis/ec_point_is_zero.sierra
@@ -1,0 +1,23 @@
+type EcPoint = EcPoint [storable: true, drop: true, dup: true, zero_sized: false];
+type felt252 = felt252 [storable: true, drop: true, dup: true, zero_sized: false];
+type NonZero<EcPoint> = NonZero<EcPoint> [storable: true, drop: true, dup: true, zero_sized: false];
+
+libfunc ec_point_is_zero = ec_point_is_zero;
+libfunc branch_align = branch_align;
+libfunc felt252_const<1> = felt252_const<1>;
+libfunc store_temp<felt252> = store_temp<felt252>;
+libfunc ec_point_unwrap = ec_point_unwrap;
+libfunc drop<felt252> = drop<felt252>;
+
+ec_point_is_zero([0]) { fallthrough() 5([1]) }; // 0
+branch_align() -> (); // 1
+felt252_const<1>() -> ([2]); // 2
+store_temp<felt252>([2]) -> ([2]); // 3
+return([2]); // 4
+branch_align() -> (); // 5
+ec_point_unwrap([1]) -> ([3], [4]); // 6
+drop<felt252>([4]) -> (); // 7
+store_temp<felt252>([3]) -> ([3]); // 8
+return([3]); // 9
+
+test::foo@0([0]: EcPoint) -> (felt252);

--- a/Aegis/Tests/e2e_libfuncs/ec_aegis/ec_point_try_new_nz.sierra
+++ b/Aegis/Tests/e2e_libfuncs/ec_aegis/ec_point_try_new_nz.sierra
@@ -1,0 +1,25 @@
+type felt252 = felt252 [storable: true, drop: true, dup: true, zero_sized: false];
+type Unit = Struct<ut@Tuple> [storable: true, drop: true, dup: true, zero_sized: true];
+type EcPoint = EcPoint [storable: true, drop: true, dup: true, zero_sized: false];
+type NonZero<EcPoint> = NonZero<EcPoint> [storable: true, drop: true, dup: true, zero_sized: false];
+type core::option::Option::<core::zeroable::NonZero::<core::ec::EcPoint>> = Enum<ut@core::option::Option::<core::zeroable::NonZero::<core::ec::EcPoint>>, NonZero<EcPoint>, Unit> [storable: true, drop: true, dup: true, zero_sized: false];
+
+libfunc ec_point_try_new_nz = ec_point_try_new_nz;
+libfunc branch_align = branch_align;
+libfunc enum_init<core::option::Option::<core::zeroable::NonZero::<core::ec::EcPoint>>, 0> = enum_init<core::option::Option::<core::zeroable::NonZero::<core::ec::EcPoint>>, 0>;
+libfunc store_temp<core::option::Option::<core::zeroable::NonZero::<core::ec::EcPoint>>> = store_temp<core::option::Option::<core::zeroable::NonZero::<core::ec::EcPoint>>>;
+libfunc struct_construct<Unit> = struct_construct<Unit>;
+libfunc enum_init<core::option::Option::<core::zeroable::NonZero::<core::ec::EcPoint>>, 1> = enum_init<core::option::Option::<core::zeroable::NonZero::<core::ec::EcPoint>>, 1>;
+
+ec_point_try_new_nz([0], [1]) { fallthrough([2]) 5() }; // 0
+branch_align() -> (); // 1
+enum_init<core::option::Option::<core::zeroable::NonZero::<core::ec::EcPoint>>, 0>([2]) -> ([3]); // 2
+store_temp<core::option::Option::<core::zeroable::NonZero::<core::ec::EcPoint>>>([3]) -> ([3]); // 3
+return([3]); // 4
+branch_align() -> (); // 5
+struct_construct<Unit>() -> ([4]); // 6
+enum_init<core::option::Option::<core::zeroable::NonZero::<core::ec::EcPoint>>, 1>([4]) -> ([5]); // 7
+store_temp<core::option::Option::<core::zeroable::NonZero::<core::ec::EcPoint>>>([5]) -> ([5]); // 8
+return([5]); // 9
+
+test::foo@0([0]: felt252, [1]: felt252) -> (core::option::Option::<core::zeroable::NonZero::<core::ec::EcPoint>>);

--- a/Aegis/Tests/e2e_libfuncs/ec_aegis/ec_point_unwrap.sierra
+++ b/Aegis/Tests/e2e_libfuncs/ec_aegis/ec_point_unwrap.sierra
@@ -1,0 +1,15 @@
+type EcPoint = EcPoint [storable: true, drop: true, dup: true, zero_sized: false];
+type NonZero<EcPoint> = NonZero<EcPoint> [storable: true, drop: true, dup: true, zero_sized: false];
+type felt252 = felt252 [storable: true, drop: true, dup: true, zero_sized: false];
+type Tuple<felt252, felt252> = Struct<ut@Tuple, felt252, felt252> [storable: true, drop: true, dup: true, zero_sized: false];
+
+libfunc ec_point_unwrap = ec_point_unwrap;
+libfunc struct_construct<Tuple<felt252, felt252>> = struct_construct<Tuple<felt252, felt252>>;
+libfunc store_temp<Tuple<felt252, felt252>> = store_temp<Tuple<felt252, felt252>>;
+
+ec_point_unwrap([0]) -> ([1], [2]); // 0
+struct_construct<Tuple<felt252, felt252>>([1], [2]) -> ([3]); // 1
+store_temp<Tuple<felt252, felt252>>([3]) -> ([3]); // 2
+return([3]); // 3
+
+test::foo@0([0]: NonZero<EcPoint>) -> (Tuple<felt252, felt252>);

--- a/Aegis/Tests/e2e_libfuncs/ec_aegis/ec_point_zero.sierra
+++ b/Aegis/Tests/e2e_libfuncs/ec_aegis/ec_point_zero.sierra
@@ -1,0 +1,10 @@
+type EcPoint = EcPoint [storable: true, drop: true, dup: true, zero_sized: false];
+
+libfunc ec_point_zero = ec_point_zero;
+libfunc store_temp<EcPoint> = store_temp<EcPoint>;
+
+ec_point_zero() -> ([0]); // 0
+store_temp<EcPoint>([0]) -> ([0]); // 1
+return([0]); // 2
+
+test::foo@0() -> (EcPoint);

--- a/Aegis/Tests/e2e_libfuncs/ec_aegis/ec_state_add.sierra
+++ b/Aegis/Tests/e2e_libfuncs/ec_aegis/ec_state_add.sierra
@@ -1,0 +1,15 @@
+type EcState = EcState [storable: true, drop: true, dup: true, zero_sized: false];
+type Unit = Struct<ut@Tuple> [storable: true, drop: true, dup: true, zero_sized: true];
+type EcPoint = EcPoint [storable: true, drop: true, dup: true, zero_sized: false];
+type NonZero<EcPoint> = NonZero<EcPoint> [storable: true, drop: true, dup: true, zero_sized: false];
+
+libfunc ec_state_add = ec_state_add;
+libfunc struct_construct<Unit> = struct_construct<Unit>;
+libfunc store_temp<EcState> = store_temp<EcState>;
+
+ec_state_add([0], [1]) -> ([2]); // 0
+struct_construct<Unit>() -> ([3]); // 1
+store_temp<EcState>([2]) -> ([2]); // 2
+return([2], [3]); // 3
+
+test::foo@0([0]: EcState, [1]: NonZero<EcPoint>) -> (EcState, Unit);

--- a/Aegis/Tests/e2e_libfuncs/ec_aegis/ec_state_add_mul.sierra
+++ b/Aegis/Tests/e2e_libfuncs/ec_aegis/ec_state_add_mul.sierra
@@ -1,0 +1,19 @@
+type EcOp = EcOp [storable: true, drop: false, dup: false, zero_sized: false];
+type Unit = Struct<ut@Tuple> [storable: true, drop: true, dup: true, zero_sized: true];
+type EcPoint = EcPoint [storable: true, drop: true, dup: true, zero_sized: false];
+type NonZero<EcPoint> = NonZero<EcPoint> [storable: true, drop: true, dup: true, zero_sized: false];
+type felt252 = felt252 [storable: true, drop: true, dup: true, zero_sized: false];
+type EcState = EcState [storable: true, drop: true, dup: true, zero_sized: false];
+
+libfunc ec_state_add_mul = ec_state_add_mul;
+libfunc struct_construct<Unit> = struct_construct<Unit>;
+libfunc store_temp<EcOp> = store_temp<EcOp>;
+libfunc store_temp<EcState> = store_temp<EcState>;
+
+ec_state_add_mul([0], [1], [2], [3]) -> ([4], [5]); // 0
+struct_construct<Unit>() -> ([6]); // 1
+store_temp<EcOp>([4]) -> ([4]); // 2
+store_temp<EcState>([5]) -> ([5]); // 3
+return([4], [5], [6]); // 4
+
+test::foo@0([0]: EcOp, [1]: EcState, [2]: felt252, [3]: NonZero<EcPoint>) -> (EcOp, EcState, Unit);

--- a/Aegis/Tests/e2e_libfuncs/ec_aegis/ec_state_init.sierra
+++ b/Aegis/Tests/e2e_libfuncs/ec_aegis/ec_state_init.sierra
@@ -1,0 +1,8 @@
+type EcState = EcState [storable: true, drop: true, dup: true, zero_sized: false];
+
+libfunc ec_state_init = ec_state_init;
+
+ec_state_init() -> ([0]); // 0
+return([0]); // 1
+
+test::foo@0() -> (EcState);

--- a/Aegis/Tests/e2e_libfuncs/ec_aegis/ec_state_try_finalize_nz.sierra
+++ b/Aegis/Tests/e2e_libfuncs/ec_aegis/ec_state_try_finalize_nz.sierra
@@ -1,0 +1,25 @@
+type EcState = EcState [storable: true, drop: true, dup: true, zero_sized: false];
+type Unit = Struct<ut@Tuple> [storable: true, drop: true, dup: true, zero_sized: true];
+type EcPoint = EcPoint [storable: true, drop: true, dup: true, zero_sized: false];
+type NonZero<EcPoint> = NonZero<EcPoint> [storable: true, drop: true, dup: true, zero_sized: false];
+type core::option::Option::<core::zeroable::NonZero::<core::ec::EcPoint>> = Enum<ut@core::option::Option::<core::zeroable::NonZero::<core::ec::EcPoint>>, NonZero<EcPoint>, Unit> [storable: true, drop: true, dup: true, zero_sized: false];
+
+libfunc ec_state_try_finalize_nz = ec_state_try_finalize_nz;
+libfunc branch_align = branch_align;
+libfunc enum_init<core::option::Option::<core::zeroable::NonZero::<core::ec::EcPoint>>, 0> = enum_init<core::option::Option::<core::zeroable::NonZero::<core::ec::EcPoint>>, 0>;
+libfunc store_temp<core::option::Option::<core::zeroable::NonZero::<core::ec::EcPoint>>> = store_temp<core::option::Option::<core::zeroable::NonZero::<core::ec::EcPoint>>>;
+libfunc struct_construct<Unit> = struct_construct<Unit>;
+libfunc enum_init<core::option::Option::<core::zeroable::NonZero::<core::ec::EcPoint>>, 1> = enum_init<core::option::Option::<core::zeroable::NonZero::<core::ec::EcPoint>>, 1>;
+
+ec_state_try_finalize_nz([0]) { fallthrough([1]) 5() }; // 0
+branch_align() -> (); // 1
+enum_init<core::option::Option::<core::zeroable::NonZero::<core::ec::EcPoint>>, 0>([1]) -> ([2]); // 2
+store_temp<core::option::Option::<core::zeroable::NonZero::<core::ec::EcPoint>>>([2]) -> ([2]); // 3
+return([2]); // 4
+branch_align() -> (); // 5
+struct_construct<Unit>() -> ([3]); // 6
+enum_init<core::option::Option::<core::zeroable::NonZero::<core::ec::EcPoint>>, 1>([3]) -> ([4]); // 7
+store_temp<core::option::Option::<core::zeroable::NonZero::<core::ec::EcPoint>>>([4]) -> ([4]); // 8
+return([4]); // 9
+
+test::foo@0([0]: EcState) -> (core::option::Option::<core::zeroable::NonZero::<core::ec::EcPoint>>);

--- a/Aegis/Tests/e2e_libfuncs/felt252_dict_aegis/felt252_dict_new.sierra
+++ b/Aegis/Tests/e2e_libfuncs/felt252_dict_aegis/felt252_dict_new.sierra
@@ -1,0 +1,14 @@
+type SegmentArena = SegmentArena [storable: true, drop: false, dup: false, zero_sized: false];
+type Felt252Dict<felt252> = Felt252Dict<felt252> [storable: true, drop: false, dup: false, zero_sized: false];
+type felt252 = felt252 [storable: true, drop: true, dup: true, zero_sized: false];
+
+libfunc felt252_dict_new<felt252> = felt252_dict_new<felt252>;
+libfunc store_temp<SegmentArena> = store_temp<SegmentArena>;
+libfunc store_temp<Felt252Dict<felt252>> = store_temp<Felt252Dict<felt252>>;
+
+felt252_dict_new<felt252>([0]) -> ([1], [2]); // 0
+store_temp<SegmentArena>([1]) -> ([1]); // 1
+store_temp<Felt252Dict<felt252>>([2]) -> ([2]); // 2
+return([1], [2]); // 3
+
+test::foo@0([0]: SegmentArena) -> (SegmentArena, Felt252Dict<felt252>);

--- a/Aegis/Tests/e2e_libfuncs/felt252_dict_aegis/felt252_dict_squash.sierra
+++ b/Aegis/Tests/e2e_libfuncs/felt252_dict_aegis/felt252_dict_squash.sierra
@@ -1,0 +1,23 @@
+type RangeCheck = RangeCheck [storable: true, drop: false, dup: false, zero_sized: false];
+type SquashedFelt252Dict<felt252> = SquashedFelt252Dict<felt252> [storable: true, drop: true, dup: false, zero_sized: false];
+type Felt252Dict<felt252> = Felt252Dict<felt252> [storable: true, drop: false, dup: false, zero_sized: false];
+type felt252 = felt252 [storable: true, drop: true, dup: true, zero_sized: false];
+type SegmentArena = SegmentArena [storable: true, drop: false, dup: false, zero_sized: false];
+type GasBuiltin = GasBuiltin [storable: true, drop: false, dup: false, zero_sized: false];
+
+libfunc disable_ap_tracking = disable_ap_tracking;
+libfunc felt252_dict_squash<felt252> = felt252_dict_squash<felt252>;
+libfunc store_temp<RangeCheck> = store_temp<RangeCheck>;
+libfunc store_temp<SegmentArena> = store_temp<SegmentArena>;
+libfunc store_temp<GasBuiltin> = store_temp<GasBuiltin>;
+libfunc store_temp<SquashedFelt252Dict<felt252>> = store_temp<SquashedFelt252Dict<felt252>>;
+
+disable_ap_tracking() -> (); // 0
+felt252_dict_squash<felt252>([0], [2], [1], [3]) -> ([4], [5], [6], [7]); // 1
+store_temp<RangeCheck>([4]) -> ([4]); // 2
+store_temp<SegmentArena>([6]) -> ([6]); // 3
+store_temp<GasBuiltin>([5]) -> ([5]); // 4
+store_temp<SquashedFelt252Dict<felt252>>([7]) -> ([7]); // 5
+return([4], [6], [5], [7]); // 6
+
+test::foo@0([0]: RangeCheck, [1]: SegmentArena, [2]: GasBuiltin, [3]: Felt252Dict<felt252>) -> (RangeCheck, SegmentArena, GasBuiltin, SquashedFelt252Dict<felt252>);

--- a/Aegis/Tests/e2e_libfuncs/gas_aegis/redeposit_gas.sierra
+++ b/Aegis/Tests/e2e_libfuncs/gas_aegis/redeposit_gas.sierra
@@ -1,0 +1,36 @@
+type felt252 = felt252 [storable: true, drop: true, dup: true, zero_sized: false];
+type GasBuiltin = GasBuiltin [storable: true, drop: false, dup: false, zero_sized: false];
+type Unit = Struct<ut@Tuple> [storable: true, drop: true, dup: true, zero_sized: true];
+type NonZero<felt252> = NonZero<felt252> [storable: true, drop: true, dup: true, zero_sized: false];
+
+libfunc felt252_is_zero = felt252_is_zero;
+libfunc branch_align = branch_align;
+libfunc function_call<user@test::bar> = function_call<user@test::bar>;
+libfunc drop<Unit> = drop<Unit>;
+libfunc struct_construct<Unit> = struct_construct<Unit>;
+libfunc store_temp<GasBuiltin> = store_temp<GasBuiltin>;
+libfunc drop<NonZero<felt252>> = drop<NonZero<felt252>>;
+libfunc redeposit_gas = redeposit_gas;
+
+felt252_is_zero([1]) { fallthrough() 11([2]) }; // 0
+branch_align() -> (); // 1
+function_call<user@test::bar>() -> ([3]); // 2
+drop<Unit>([3]) -> (); // 3
+function_call<user@test::bar>() -> ([4]); // 4
+drop<Unit>([4]) -> (); // 5
+function_call<user@test::bar>() -> ([5]); // 6
+drop<Unit>([5]) -> (); // 7
+struct_construct<Unit>() -> ([6]); // 8
+store_temp<GasBuiltin>([0]) -> ([0]); // 9
+return([0], [6]); // 10
+branch_align() -> (); // 11
+drop<NonZero<felt252>>([2]) -> (); // 12
+redeposit_gas([0]) -> ([7]); // 13
+struct_construct<Unit>() -> ([8]); // 14
+store_temp<GasBuiltin>([7]) -> ([7]); // 15
+return([7], [8]); // 16
+struct_construct<Unit>() -> ([0]); // 17
+return([0]); // 18
+
+test::foo@0([0]: GasBuiltin, [1]: felt252) -> (GasBuiltin, Unit);
+test::bar@17() -> (Unit);

--- a/Aegis/Tests/e2e_libfuncs/i128_aegis/i128_diff.sierra
+++ b/Aegis/Tests/e2e_libfuncs/i128_aegis/i128_diff.sierra
@@ -1,0 +1,25 @@
+type RangeCheck = RangeCheck [storable: true, drop: false, dup: false, zero_sized: false];
+type u128 = u128 [storable: true, drop: true, dup: true, zero_sized: false];
+type core::result::Result::<core::integer::u128, core::integer::u128> = Enum<ut@core::result::Result::<core::integer::u128, core::integer::u128>, u128, u128> [storable: true, drop: true, dup: true, zero_sized: false];
+type i128 = i128 [storable: true, drop: true, dup: true, zero_sized: false];
+
+libfunc i128_diff = i128_diff;
+libfunc branch_align = branch_align;
+libfunc enum_init<core::result::Result::<core::integer::u128, core::integer::u128>, 0> = enum_init<core::result::Result::<core::integer::u128, core::integer::u128>, 0>;
+libfunc store_temp<RangeCheck> = store_temp<RangeCheck>;
+libfunc store_temp<core::result::Result::<core::integer::u128, core::integer::u128>> = store_temp<core::result::Result::<core::integer::u128, core::integer::u128>>;
+libfunc enum_init<core::result::Result::<core::integer::u128, core::integer::u128>, 1> = enum_init<core::result::Result::<core::integer::u128, core::integer::u128>, 1>;
+
+i128_diff([0], [1], [2]) { fallthrough([3], [4]) 6([5], [6]) }; // 0
+branch_align() -> (); // 1
+enum_init<core::result::Result::<core::integer::u128, core::integer::u128>, 0>([4]) -> ([7]); // 2
+store_temp<RangeCheck>([3]) -> ([3]); // 3
+store_temp<core::result::Result::<core::integer::u128, core::integer::u128>>([7]) -> ([7]); // 4
+return([3], [7]); // 5
+branch_align() -> (); // 6
+enum_init<core::result::Result::<core::integer::u128, core::integer::u128>, 1>([6]) -> ([8]); // 7
+store_temp<RangeCheck>([5]) -> ([5]); // 8
+store_temp<core::result::Result::<core::integer::u128, core::integer::u128>>([8]) -> ([8]); // 9
+return([5], [8]); // 10
+
+test::foo@0([0]: RangeCheck, [1]: i128, [2]: i128) -> (RangeCheck, core::result::Result::<core::integer::u128, core::integer::u128>);

--- a/Aegis/Tests/e2e_libfuncs/i128_aegis/i128_eq.sierra
+++ b/Aegis/Tests/e2e_libfuncs/i128_aegis/i128_eq.sierra
@@ -1,0 +1,30 @@
+type i128 = i128 [storable: true, drop: true, dup: true, zero_sized: false];
+type Unit = Struct<ut@Tuple> [storable: true, drop: true, dup: true, zero_sized: true];
+type core::bool = Enum<ut@core::bool, Unit, Unit> [storable: true, drop: true, dup: true, zero_sized: false];
+
+libfunc i128_const<11> = i128_const<11>;
+libfunc i128_const<12> = i128_const<12>;
+libfunc store_temp<i128> = store_temp<i128>;
+libfunc i128_eq = i128_eq;
+libfunc branch_align = branch_align;
+libfunc struct_construct<Unit> = struct_construct<Unit>;
+libfunc enum_init<core::bool, 0> = enum_init<core::bool, 0>;
+libfunc store_temp<core::bool> = store_temp<core::bool>;
+libfunc enum_init<core::bool, 1> = enum_init<core::bool, 1>;
+
+i128_const<11>() -> ([0]); // 0
+i128_const<12>() -> ([1]); // 1
+store_temp<i128>([0]) -> ([0]); // 2
+i128_eq([0], [1]) { fallthrough() 9() }; // 3
+branch_align() -> (); // 4
+struct_construct<Unit>() -> ([2]); // 5
+enum_init<core::bool, 0>([2]) -> ([3]); // 6
+store_temp<core::bool>([3]) -> ([3]); // 7
+return([3]); // 8
+branch_align() -> (); // 9
+struct_construct<Unit>() -> ([4]); // 10
+enum_init<core::bool, 1>([4]) -> ([5]); // 11
+store_temp<core::bool>([5]) -> ([5]); // 12
+return([5]); // 13
+
+test::foo@0() -> (core::bool);

--- a/Aegis/Tests/e2e_libfuncs/i128_aegis/i128_is_zero.sierra
+++ b/Aegis/Tests/e2e_libfuncs/i128_aegis/i128_is_zero.sierra
@@ -1,0 +1,20 @@
+type i128 = i128 [storable: true, drop: true, dup: true, zero_sized: false];
+type NonZero<i128> = NonZero<i128> [storable: true, drop: true, dup: true, zero_sized: false];
+
+libfunc i128_is_zero = i128_is_zero;
+libfunc branch_align = branch_align;
+libfunc i128_const<123> = i128_const<123>;
+libfunc store_temp<i128> = store_temp<i128>;
+libfunc unwrap_non_zero<i128> = unwrap_non_zero<i128>;
+
+i128_is_zero([0]) { fallthrough() 5([1]) }; // 0
+branch_align() -> (); // 1
+i128_const<123>() -> ([2]); // 2
+store_temp<i128>([2]) -> ([2]); // 3
+return([2]); // 4
+branch_align() -> (); // 5
+unwrap_non_zero<i128>([1]) -> ([3]); // 6
+store_temp<i128>([3]) -> ([3]); // 7
+return([3]); // 8
+
+test::foo@0([0]: i128) -> (i128);

--- a/Aegis/Tests/e2e_libfuncs/i128_aegis/i128_overflowing_add_impl.sierra
+++ b/Aegis/Tests/e2e_libfuncs/i128_aegis/i128_overflowing_add_impl.sierra
@@ -1,0 +1,30 @@
+type RangeCheck = RangeCheck [storable: true, drop: false, dup: false, zero_sized: false];
+type i128 = i128 [storable: true, drop: true, dup: true, zero_sized: false];
+type core::integer::SignedIntegerResult::<core::integer::i128> = Enum<ut@core::integer::SignedIntegerResult::<core::integer::i128>, i128, i128, i128> [storable: true, drop: true, dup: true, zero_sized: false];
+
+libfunc i128_overflowing_add_impl = i128_overflowing_add_impl;
+libfunc branch_align = branch_align;
+libfunc enum_init<core::integer::SignedIntegerResult::<core::integer::i128>, 0> = enum_init<core::integer::SignedIntegerResult::<core::integer::i128>, 0>;
+libfunc store_temp<RangeCheck> = store_temp<RangeCheck>;
+libfunc store_temp<core::integer::SignedIntegerResult::<core::integer::i128>> = store_temp<core::integer::SignedIntegerResult::<core::integer::i128>>;
+libfunc enum_init<core::integer::SignedIntegerResult::<core::integer::i128>, 1> = enum_init<core::integer::SignedIntegerResult::<core::integer::i128>, 1>;
+libfunc enum_init<core::integer::SignedIntegerResult::<core::integer::i128>, 2> = enum_init<core::integer::SignedIntegerResult::<core::integer::i128>, 2>;
+
+i128_overflowing_add_impl([0], [1], [2]) { fallthrough([3], [4]) 6([5], [6]) 11([7], [8]) }; // 0
+branch_align() -> (); // 1
+enum_init<core::integer::SignedIntegerResult::<core::integer::i128>, 0>([4]) -> ([9]); // 2
+store_temp<RangeCheck>([3]) -> ([3]); // 3
+store_temp<core::integer::SignedIntegerResult::<core::integer::i128>>([9]) -> ([9]); // 4
+return([3], [9]); // 5
+branch_align() -> (); // 6
+enum_init<core::integer::SignedIntegerResult::<core::integer::i128>, 1>([6]) -> ([10]); // 7
+store_temp<RangeCheck>([5]) -> ([5]); // 8
+store_temp<core::integer::SignedIntegerResult::<core::integer::i128>>([10]) -> ([10]); // 9
+return([5], [10]); // 10
+branch_align() -> (); // 11
+enum_init<core::integer::SignedIntegerResult::<core::integer::i128>, 2>([8]) -> ([11]); // 12
+store_temp<RangeCheck>([7]) -> ([7]); // 13
+store_temp<core::integer::SignedIntegerResult::<core::integer::i128>>([11]) -> ([11]); // 14
+return([7], [11]); // 15
+
+test::foo@0([0]: RangeCheck, [1]: i128, [2]: i128) -> (RangeCheck, core::integer::SignedIntegerResult::<core::integer::i128>);

--- a/Aegis/Tests/e2e_libfuncs/i128_aegis/i128_overflowing_sub_impl.sierra
+++ b/Aegis/Tests/e2e_libfuncs/i128_aegis/i128_overflowing_sub_impl.sierra
@@ -1,0 +1,30 @@
+type RangeCheck = RangeCheck [storable: true, drop: false, dup: false, zero_sized: false];
+type i128 = i128 [storable: true, drop: true, dup: true, zero_sized: false];
+type core::integer::SignedIntegerResult::<core::integer::i128> = Enum<ut@core::integer::SignedIntegerResult::<core::integer::i128>, i128, i128, i128> [storable: true, drop: true, dup: true, zero_sized: false];
+
+libfunc i128_overflowing_sub_impl = i128_overflowing_sub_impl;
+libfunc branch_align = branch_align;
+libfunc enum_init<core::integer::SignedIntegerResult::<core::integer::i128>, 0> = enum_init<core::integer::SignedIntegerResult::<core::integer::i128>, 0>;
+libfunc store_temp<RangeCheck> = store_temp<RangeCheck>;
+libfunc store_temp<core::integer::SignedIntegerResult::<core::integer::i128>> = store_temp<core::integer::SignedIntegerResult::<core::integer::i128>>;
+libfunc enum_init<core::integer::SignedIntegerResult::<core::integer::i128>, 1> = enum_init<core::integer::SignedIntegerResult::<core::integer::i128>, 1>;
+libfunc enum_init<core::integer::SignedIntegerResult::<core::integer::i128>, 2> = enum_init<core::integer::SignedIntegerResult::<core::integer::i128>, 2>;
+
+i128_overflowing_sub_impl([0], [1], [2]) { fallthrough([3], [4]) 6([5], [6]) 11([7], [8]) }; // 0
+branch_align() -> (); // 1
+enum_init<core::integer::SignedIntegerResult::<core::integer::i128>, 0>([4]) -> ([9]); // 2
+store_temp<RangeCheck>([3]) -> ([3]); // 3
+store_temp<core::integer::SignedIntegerResult::<core::integer::i128>>([9]) -> ([9]); // 4
+return([3], [9]); // 5
+branch_align() -> (); // 6
+enum_init<core::integer::SignedIntegerResult::<core::integer::i128>, 1>([6]) -> ([10]); // 7
+store_temp<RangeCheck>([5]) -> ([5]); // 8
+store_temp<core::integer::SignedIntegerResult::<core::integer::i128>>([10]) -> ([10]); // 9
+return([5], [10]); // 10
+branch_align() -> (); // 11
+enum_init<core::integer::SignedIntegerResult::<core::integer::i128>, 2>([8]) -> ([11]); // 12
+store_temp<RangeCheck>([7]) -> ([7]); // 13
+store_temp<core::integer::SignedIntegerResult::<core::integer::i128>>([11]) -> ([11]); // 14
+return([7], [11]); // 15
+
+test::foo@0([0]: RangeCheck, [1]: i128, [2]: i128) -> (RangeCheck, core::integer::SignedIntegerResult::<core::integer::i128>);

--- a/Aegis/Tests/e2e_libfuncs/i128_aegis/i128_to_felt252.sierra
+++ b/Aegis/Tests/e2e_libfuncs/i128_aegis/i128_to_felt252.sierra
@@ -1,0 +1,11 @@
+type i128 = i128 [storable: true, drop: true, dup: true, zero_sized: false];
+type felt252 = felt252 [storable: true, drop: true, dup: true, zero_sized: false];
+
+libfunc i128_to_felt252 = i128_to_felt252;
+libfunc store_temp<felt252> = store_temp<felt252>;
+
+i128_to_felt252([0]) -> ([1]); // 0
+store_temp<felt252>([1]) -> ([1]); // 1
+return([1]); // 2
+
+test::foo@0([0]: i128) -> (felt252);

--- a/Aegis/Tests/e2e_libfuncs/i128_aegis/i128_try_from_felt252.sierra
+++ b/Aegis/Tests/e2e_libfuncs/i128_aegis/i128_try_from_felt252.sierra
@@ -1,0 +1,28 @@
+type RangeCheck = RangeCheck [storable: true, drop: false, dup: false, zero_sized: false];
+type Unit = Struct<ut@Tuple> [storable: true, drop: true, dup: true, zero_sized: true];
+type i128 = i128 [storable: true, drop: true, dup: true, zero_sized: false];
+type core::option::Option::<core::integer::i128> = Enum<ut@core::option::Option::<core::integer::i128>, i128, Unit> [storable: true, drop: true, dup: true, zero_sized: false];
+type felt252 = felt252 [storable: true, drop: true, dup: true, zero_sized: false];
+
+libfunc i128_try_from_felt252 = i128_try_from_felt252;
+libfunc branch_align = branch_align;
+libfunc enum_init<core::option::Option::<core::integer::i128>, 0> = enum_init<core::option::Option::<core::integer::i128>, 0>;
+libfunc store_temp<RangeCheck> = store_temp<RangeCheck>;
+libfunc store_temp<core::option::Option::<core::integer::i128>> = store_temp<core::option::Option::<core::integer::i128>>;
+libfunc struct_construct<Unit> = struct_construct<Unit>;
+libfunc enum_init<core::option::Option::<core::integer::i128>, 1> = enum_init<core::option::Option::<core::integer::i128>, 1>;
+
+i128_try_from_felt252([0], [1]) { fallthrough([2], [3]) 6([4]) }; // 0
+branch_align() -> (); // 1
+enum_init<core::option::Option::<core::integer::i128>, 0>([3]) -> ([5]); // 2
+store_temp<RangeCheck>([2]) -> ([2]); // 3
+store_temp<core::option::Option::<core::integer::i128>>([5]) -> ([5]); // 4
+return([2], [5]); // 5
+branch_align() -> (); // 6
+struct_construct<Unit>() -> ([6]); // 7
+enum_init<core::option::Option::<core::integer::i128>, 1>([6]) -> ([7]); // 8
+store_temp<RangeCheck>([4]) -> ([4]); // 9
+store_temp<core::option::Option::<core::integer::i128>>([7]) -> ([7]); // 10
+return([4], [7]); // 11
+
+test::foo@0([0]: RangeCheck, [1]: felt252) -> (RangeCheck, core::option::Option::<core::integer::i128>);

--- a/Aegis/Tests/e2e_libfuncs/i16_aegis/i16_diff.sierra
+++ b/Aegis/Tests/e2e_libfuncs/i16_aegis/i16_diff.sierra
@@ -1,0 +1,25 @@
+type RangeCheck = RangeCheck [storable: true, drop: false, dup: false, zero_sized: false];
+type u16 = u16 [storable: true, drop: true, dup: true, zero_sized: false];
+type core::result::Result::<core::integer::u16, core::integer::u16> = Enum<ut@core::result::Result::<core::integer::u16, core::integer::u16>, u16, u16> [storable: true, drop: true, dup: true, zero_sized: false];
+type i16 = i16 [storable: true, drop: true, dup: true, zero_sized: false];
+
+libfunc i16_diff = i16_diff;
+libfunc branch_align = branch_align;
+libfunc enum_init<core::result::Result::<core::integer::u16, core::integer::u16>, 0> = enum_init<core::result::Result::<core::integer::u16, core::integer::u16>, 0>;
+libfunc store_temp<RangeCheck> = store_temp<RangeCheck>;
+libfunc store_temp<core::result::Result::<core::integer::u16, core::integer::u16>> = store_temp<core::result::Result::<core::integer::u16, core::integer::u16>>;
+libfunc enum_init<core::result::Result::<core::integer::u16, core::integer::u16>, 1> = enum_init<core::result::Result::<core::integer::u16, core::integer::u16>, 1>;
+
+i16_diff([0], [1], [2]) { fallthrough([3], [4]) 6([5], [6]) }; // 0
+branch_align() -> (); // 1
+enum_init<core::result::Result::<core::integer::u16, core::integer::u16>, 0>([4]) -> ([7]); // 2
+store_temp<RangeCheck>([3]) -> ([3]); // 3
+store_temp<core::result::Result::<core::integer::u16, core::integer::u16>>([7]) -> ([7]); // 4
+return([3], [7]); // 5
+branch_align() -> (); // 6
+enum_init<core::result::Result::<core::integer::u16, core::integer::u16>, 1>([6]) -> ([8]); // 7
+store_temp<RangeCheck>([5]) -> ([5]); // 8
+store_temp<core::result::Result::<core::integer::u16, core::integer::u16>>([8]) -> ([8]); // 9
+return([5], [8]); // 10
+
+test::foo@0([0]: RangeCheck, [1]: i16, [2]: i16) -> (RangeCheck, core::result::Result::<core::integer::u16, core::integer::u16>);

--- a/Aegis/Tests/e2e_libfuncs/i16_aegis/i16_eq.sierra
+++ b/Aegis/Tests/e2e_libfuncs/i16_aegis/i16_eq.sierra
@@ -1,0 +1,30 @@
+type i16 = i16 [storable: true, drop: true, dup: true, zero_sized: false];
+type Unit = Struct<ut@Tuple> [storable: true, drop: true, dup: true, zero_sized: true];
+type core::bool = Enum<ut@core::bool, Unit, Unit> [storable: true, drop: true, dup: true, zero_sized: false];
+
+libfunc i16_const<11> = i16_const<11>;
+libfunc i16_const<12> = i16_const<12>;
+libfunc store_temp<i16> = store_temp<i16>;
+libfunc i16_eq = i16_eq;
+libfunc branch_align = branch_align;
+libfunc struct_construct<Unit> = struct_construct<Unit>;
+libfunc enum_init<core::bool, 0> = enum_init<core::bool, 0>;
+libfunc store_temp<core::bool> = store_temp<core::bool>;
+libfunc enum_init<core::bool, 1> = enum_init<core::bool, 1>;
+
+i16_const<11>() -> ([0]); // 0
+i16_const<12>() -> ([1]); // 1
+store_temp<i16>([0]) -> ([0]); // 2
+i16_eq([0], [1]) { fallthrough() 9() }; // 3
+branch_align() -> (); // 4
+struct_construct<Unit>() -> ([2]); // 5
+enum_init<core::bool, 0>([2]) -> ([3]); // 6
+store_temp<core::bool>([3]) -> ([3]); // 7
+return([3]); // 8
+branch_align() -> (); // 9
+struct_construct<Unit>() -> ([4]); // 10
+enum_init<core::bool, 1>([4]) -> ([5]); // 11
+store_temp<core::bool>([5]) -> ([5]); // 12
+return([5]); // 13
+
+test::foo@0() -> (core::bool);

--- a/Aegis/Tests/e2e_libfuncs/i16_aegis/i16_is_zero.sierra
+++ b/Aegis/Tests/e2e_libfuncs/i16_aegis/i16_is_zero.sierra
@@ -1,0 +1,20 @@
+type i16 = i16 [storable: true, drop: true, dup: true, zero_sized: false];
+type NonZero<i16> = NonZero<i16> [storable: true, drop: true, dup: true, zero_sized: false];
+
+libfunc i16_is_zero = i16_is_zero;
+libfunc branch_align = branch_align;
+libfunc i16_const<123> = i16_const<123>;
+libfunc store_temp<i16> = store_temp<i16>;
+libfunc unwrap_non_zero<i16> = unwrap_non_zero<i16>;
+
+i16_is_zero([0]) { fallthrough() 5([1]) }; // 0
+branch_align() -> (); // 1
+i16_const<123>() -> ([2]); // 2
+store_temp<i16>([2]) -> ([2]); // 3
+return([2]); // 4
+branch_align() -> (); // 5
+unwrap_non_zero<i16>([1]) -> ([3]); // 6
+store_temp<i16>([3]) -> ([3]); // 7
+return([3]); // 8
+
+test::foo@0([0]: i16) -> (i16);

--- a/Aegis/Tests/e2e_libfuncs/i16_aegis/i16_overflowing_add_impl.sierra
+++ b/Aegis/Tests/e2e_libfuncs/i16_aegis/i16_overflowing_add_impl.sierra
@@ -1,0 +1,30 @@
+type RangeCheck = RangeCheck [storable: true, drop: false, dup: false, zero_sized: false];
+type i16 = i16 [storable: true, drop: true, dup: true, zero_sized: false];
+type core::integer::SignedIntegerResult::<core::integer::i16> = Enum<ut@core::integer::SignedIntegerResult::<core::integer::i16>, i16, i16, i16> [storable: true, drop: true, dup: true, zero_sized: false];
+
+libfunc i16_overflowing_add_impl = i16_overflowing_add_impl;
+libfunc branch_align = branch_align;
+libfunc enum_init<core::integer::SignedIntegerResult::<core::integer::i16>, 0> = enum_init<core::integer::SignedIntegerResult::<core::integer::i16>, 0>;
+libfunc store_temp<RangeCheck> = store_temp<RangeCheck>;
+libfunc store_temp<core::integer::SignedIntegerResult::<core::integer::i16>> = store_temp<core::integer::SignedIntegerResult::<core::integer::i16>>;
+libfunc enum_init<core::integer::SignedIntegerResult::<core::integer::i16>, 1> = enum_init<core::integer::SignedIntegerResult::<core::integer::i16>, 1>;
+libfunc enum_init<core::integer::SignedIntegerResult::<core::integer::i16>, 2> = enum_init<core::integer::SignedIntegerResult::<core::integer::i16>, 2>;
+
+i16_overflowing_add_impl([0], [1], [2]) { fallthrough([3], [4]) 6([5], [6]) 11([7], [8]) }; // 0
+branch_align() -> (); // 1
+enum_init<core::integer::SignedIntegerResult::<core::integer::i16>, 0>([4]) -> ([9]); // 2
+store_temp<RangeCheck>([3]) -> ([3]); // 3
+store_temp<core::integer::SignedIntegerResult::<core::integer::i16>>([9]) -> ([9]); // 4
+return([3], [9]); // 5
+branch_align() -> (); // 6
+enum_init<core::integer::SignedIntegerResult::<core::integer::i16>, 1>([6]) -> ([10]); // 7
+store_temp<RangeCheck>([5]) -> ([5]); // 8
+store_temp<core::integer::SignedIntegerResult::<core::integer::i16>>([10]) -> ([10]); // 9
+return([5], [10]); // 10
+branch_align() -> (); // 11
+enum_init<core::integer::SignedIntegerResult::<core::integer::i16>, 2>([8]) -> ([11]); // 12
+store_temp<RangeCheck>([7]) -> ([7]); // 13
+store_temp<core::integer::SignedIntegerResult::<core::integer::i16>>([11]) -> ([11]); // 14
+return([7], [11]); // 15
+
+test::foo@0([0]: RangeCheck, [1]: i16, [2]: i16) -> (RangeCheck, core::integer::SignedIntegerResult::<core::integer::i16>);

--- a/Aegis/Tests/e2e_libfuncs/i16_aegis/i16_overflowing_sub_impl.sierra
+++ b/Aegis/Tests/e2e_libfuncs/i16_aegis/i16_overflowing_sub_impl.sierra
@@ -1,0 +1,30 @@
+type RangeCheck = RangeCheck [storable: true, drop: false, dup: false, zero_sized: false];
+type i16 = i16 [storable: true, drop: true, dup: true, zero_sized: false];
+type core::integer::SignedIntegerResult::<core::integer::i16> = Enum<ut@core::integer::SignedIntegerResult::<core::integer::i16>, i16, i16, i16> [storable: true, drop: true, dup: true, zero_sized: false];
+
+libfunc i16_overflowing_sub_impl = i16_overflowing_sub_impl;
+libfunc branch_align = branch_align;
+libfunc enum_init<core::integer::SignedIntegerResult::<core::integer::i16>, 0> = enum_init<core::integer::SignedIntegerResult::<core::integer::i16>, 0>;
+libfunc store_temp<RangeCheck> = store_temp<RangeCheck>;
+libfunc store_temp<core::integer::SignedIntegerResult::<core::integer::i16>> = store_temp<core::integer::SignedIntegerResult::<core::integer::i16>>;
+libfunc enum_init<core::integer::SignedIntegerResult::<core::integer::i16>, 1> = enum_init<core::integer::SignedIntegerResult::<core::integer::i16>, 1>;
+libfunc enum_init<core::integer::SignedIntegerResult::<core::integer::i16>, 2> = enum_init<core::integer::SignedIntegerResult::<core::integer::i16>, 2>;
+
+i16_overflowing_sub_impl([0], [1], [2]) { fallthrough([3], [4]) 6([5], [6]) 11([7], [8]) }; // 0
+branch_align() -> (); // 1
+enum_init<core::integer::SignedIntegerResult::<core::integer::i16>, 0>([4]) -> ([9]); // 2
+store_temp<RangeCheck>([3]) -> ([3]); // 3
+store_temp<core::integer::SignedIntegerResult::<core::integer::i16>>([9]) -> ([9]); // 4
+return([3], [9]); // 5
+branch_align() -> (); // 6
+enum_init<core::integer::SignedIntegerResult::<core::integer::i16>, 1>([6]) -> ([10]); // 7
+store_temp<RangeCheck>([5]) -> ([5]); // 8
+store_temp<core::integer::SignedIntegerResult::<core::integer::i16>>([10]) -> ([10]); // 9
+return([5], [10]); // 10
+branch_align() -> (); // 11
+enum_init<core::integer::SignedIntegerResult::<core::integer::i16>, 2>([8]) -> ([11]); // 12
+store_temp<RangeCheck>([7]) -> ([7]); // 13
+store_temp<core::integer::SignedIntegerResult::<core::integer::i16>>([11]) -> ([11]); // 14
+return([7], [11]); // 15
+
+test::foo@0([0]: RangeCheck, [1]: i16, [2]: i16) -> (RangeCheck, core::integer::SignedIntegerResult::<core::integer::i16>);

--- a/Aegis/Tests/e2e_libfuncs/i16_aegis/i16_to_felt252.sierra
+++ b/Aegis/Tests/e2e_libfuncs/i16_aegis/i16_to_felt252.sierra
@@ -1,0 +1,11 @@
+type i16 = i16 [storable: true, drop: true, dup: true, zero_sized: false];
+type felt252 = felt252 [storable: true, drop: true, dup: true, zero_sized: false];
+
+libfunc i16_to_felt252 = i16_to_felt252;
+libfunc store_temp<felt252> = store_temp<felt252>;
+
+i16_to_felt252([0]) -> ([1]); // 0
+store_temp<felt252>([1]) -> ([1]); // 1
+return([1]); // 2
+
+test::foo@0([0]: i16) -> (felt252);

--- a/Aegis/Tests/e2e_libfuncs/i16_aegis/i16_try_from_felt252.sierra
+++ b/Aegis/Tests/e2e_libfuncs/i16_aegis/i16_try_from_felt252.sierra
@@ -1,0 +1,28 @@
+type RangeCheck = RangeCheck [storable: true, drop: false, dup: false, zero_sized: false];
+type Unit = Struct<ut@Tuple> [storable: true, drop: true, dup: true, zero_sized: true];
+type i16 = i16 [storable: true, drop: true, dup: true, zero_sized: false];
+type core::option::Option::<core::integer::i16> = Enum<ut@core::option::Option::<core::integer::i16>, i16, Unit> [storable: true, drop: true, dup: true, zero_sized: false];
+type felt252 = felt252 [storable: true, drop: true, dup: true, zero_sized: false];
+
+libfunc i16_try_from_felt252 = i16_try_from_felt252;
+libfunc branch_align = branch_align;
+libfunc enum_init<core::option::Option::<core::integer::i16>, 0> = enum_init<core::option::Option::<core::integer::i16>, 0>;
+libfunc store_temp<RangeCheck> = store_temp<RangeCheck>;
+libfunc store_temp<core::option::Option::<core::integer::i16>> = store_temp<core::option::Option::<core::integer::i16>>;
+libfunc struct_construct<Unit> = struct_construct<Unit>;
+libfunc enum_init<core::option::Option::<core::integer::i16>, 1> = enum_init<core::option::Option::<core::integer::i16>, 1>;
+
+i16_try_from_felt252([0], [1]) { fallthrough([2], [3]) 6([4]) }; // 0
+branch_align() -> (); // 1
+enum_init<core::option::Option::<core::integer::i16>, 0>([3]) -> ([5]); // 2
+store_temp<RangeCheck>([2]) -> ([2]); // 3
+store_temp<core::option::Option::<core::integer::i16>>([5]) -> ([5]); // 4
+return([2], [5]); // 5
+branch_align() -> (); // 6
+struct_construct<Unit>() -> ([6]); // 7
+enum_init<core::option::Option::<core::integer::i16>, 1>([6]) -> ([7]); // 8
+store_temp<RangeCheck>([4]) -> ([4]); // 9
+store_temp<core::option::Option::<core::integer::i16>>([7]) -> ([7]); // 10
+return([4], [7]); // 11
+
+test::foo@0([0]: RangeCheck, [1]: felt252) -> (RangeCheck, core::option::Option::<core::integer::i16>);

--- a/Aegis/Tests/e2e_libfuncs/i16_aegis/i16_wide_mul.sierra
+++ b/Aegis/Tests/e2e_libfuncs/i16_aegis/i16_wide_mul.sierra
@@ -1,0 +1,11 @@
+type i16 = i16 [storable: true, drop: true, dup: true, zero_sized: false];
+type i32 = i32 [storable: true, drop: true, dup: true, zero_sized: false];
+
+libfunc i16_wide_mul = i16_wide_mul;
+libfunc store_temp<i32> = store_temp<i32>;
+
+i16_wide_mul([0], [1]) -> ([2]); // 0
+store_temp<i32>([2]) -> ([2]); // 1
+return([2]); // 2
+
+test::foo@0([0]: i16, [1]: i16) -> (i32);

--- a/Aegis/Tests/e2e_libfuncs/i32_aegis/i32_diff.sierra
+++ b/Aegis/Tests/e2e_libfuncs/i32_aegis/i32_diff.sierra
@@ -1,0 +1,25 @@
+type RangeCheck = RangeCheck [storable: true, drop: false, dup: false, zero_sized: false];
+type u32 = u32 [storable: true, drop: true, dup: true, zero_sized: false];
+type core::result::Result::<core::integer::u32, core::integer::u32> = Enum<ut@core::result::Result::<core::integer::u32, core::integer::u32>, u32, u32> [storable: true, drop: true, dup: true, zero_sized: false];
+type i32 = i32 [storable: true, drop: true, dup: true, zero_sized: false];
+
+libfunc i32_diff = i32_diff;
+libfunc branch_align = branch_align;
+libfunc enum_init<core::result::Result::<core::integer::u32, core::integer::u32>, 0> = enum_init<core::result::Result::<core::integer::u32, core::integer::u32>, 0>;
+libfunc store_temp<RangeCheck> = store_temp<RangeCheck>;
+libfunc store_temp<core::result::Result::<core::integer::u32, core::integer::u32>> = store_temp<core::result::Result::<core::integer::u32, core::integer::u32>>;
+libfunc enum_init<core::result::Result::<core::integer::u32, core::integer::u32>, 1> = enum_init<core::result::Result::<core::integer::u32, core::integer::u32>, 1>;
+
+i32_diff([0], [1], [2]) { fallthrough([3], [4]) 6([5], [6]) }; // 0
+branch_align() -> (); // 1
+enum_init<core::result::Result::<core::integer::u32, core::integer::u32>, 0>([4]) -> ([7]); // 2
+store_temp<RangeCheck>([3]) -> ([3]); // 3
+store_temp<core::result::Result::<core::integer::u32, core::integer::u32>>([7]) -> ([7]); // 4
+return([3], [7]); // 5
+branch_align() -> (); // 6
+enum_init<core::result::Result::<core::integer::u32, core::integer::u32>, 1>([6]) -> ([8]); // 7
+store_temp<RangeCheck>([5]) -> ([5]); // 8
+store_temp<core::result::Result::<core::integer::u32, core::integer::u32>>([8]) -> ([8]); // 9
+return([5], [8]); // 10
+
+test::foo@0([0]: RangeCheck, [1]: i32, [2]: i32) -> (RangeCheck, core::result::Result::<core::integer::u32, core::integer::u32>);

--- a/Aegis/Tests/e2e_libfuncs/i32_aegis/i32_eq.sierra
+++ b/Aegis/Tests/e2e_libfuncs/i32_aegis/i32_eq.sierra
@@ -1,0 +1,30 @@
+type i32 = i32 [storable: true, drop: true, dup: true, zero_sized: false];
+type Unit = Struct<ut@Tuple> [storable: true, drop: true, dup: true, zero_sized: true];
+type core::bool = Enum<ut@core::bool, Unit, Unit> [storable: true, drop: true, dup: true, zero_sized: false];
+
+libfunc i32_const<11> = i32_const<11>;
+libfunc i32_const<12> = i32_const<12>;
+libfunc store_temp<i32> = store_temp<i32>;
+libfunc i32_eq = i32_eq;
+libfunc branch_align = branch_align;
+libfunc struct_construct<Unit> = struct_construct<Unit>;
+libfunc enum_init<core::bool, 0> = enum_init<core::bool, 0>;
+libfunc store_temp<core::bool> = store_temp<core::bool>;
+libfunc enum_init<core::bool, 1> = enum_init<core::bool, 1>;
+
+i32_const<11>() -> ([0]); // 0
+i32_const<12>() -> ([1]); // 1
+store_temp<i32>([0]) -> ([0]); // 2
+i32_eq([0], [1]) { fallthrough() 9() }; // 3
+branch_align() -> (); // 4
+struct_construct<Unit>() -> ([2]); // 5
+enum_init<core::bool, 0>([2]) -> ([3]); // 6
+store_temp<core::bool>([3]) -> ([3]); // 7
+return([3]); // 8
+branch_align() -> (); // 9
+struct_construct<Unit>() -> ([4]); // 10
+enum_init<core::bool, 1>([4]) -> ([5]); // 11
+store_temp<core::bool>([5]) -> ([5]); // 12
+return([5]); // 13
+
+test::foo@0() -> (core::bool);

--- a/Aegis/Tests/e2e_libfuncs/i32_aegis/i32_is_zero.sierra
+++ b/Aegis/Tests/e2e_libfuncs/i32_aegis/i32_is_zero.sierra
@@ -1,0 +1,20 @@
+type i32 = i32 [storable: true, drop: true, dup: true, zero_sized: false];
+type NonZero<i32> = NonZero<i32> [storable: true, drop: true, dup: true, zero_sized: false];
+
+libfunc i32_is_zero = i32_is_zero;
+libfunc branch_align = branch_align;
+libfunc i32_const<123> = i32_const<123>;
+libfunc store_temp<i32> = store_temp<i32>;
+libfunc unwrap_non_zero<i32> = unwrap_non_zero<i32>;
+
+i32_is_zero([0]) { fallthrough() 5([1]) }; // 0
+branch_align() -> (); // 1
+i32_const<123>() -> ([2]); // 2
+store_temp<i32>([2]) -> ([2]); // 3
+return([2]); // 4
+branch_align() -> (); // 5
+unwrap_non_zero<i32>([1]) -> ([3]); // 6
+store_temp<i32>([3]) -> ([3]); // 7
+return([3]); // 8
+
+test::foo@0([0]: i32) -> (i32);

--- a/Aegis/Tests/e2e_libfuncs/i32_aegis/i32_overflowing_add_impl.sierra
+++ b/Aegis/Tests/e2e_libfuncs/i32_aegis/i32_overflowing_add_impl.sierra
@@ -1,0 +1,30 @@
+type RangeCheck = RangeCheck [storable: true, drop: false, dup: false, zero_sized: false];
+type i32 = i32 [storable: true, drop: true, dup: true, zero_sized: false];
+type core::integer::SignedIntegerResult::<core::integer::i32> = Enum<ut@core::integer::SignedIntegerResult::<core::integer::i32>, i32, i32, i32> [storable: true, drop: true, dup: true, zero_sized: false];
+
+libfunc i32_overflowing_add_impl = i32_overflowing_add_impl;
+libfunc branch_align = branch_align;
+libfunc enum_init<core::integer::SignedIntegerResult::<core::integer::i32>, 0> = enum_init<core::integer::SignedIntegerResult::<core::integer::i32>, 0>;
+libfunc store_temp<RangeCheck> = store_temp<RangeCheck>;
+libfunc store_temp<core::integer::SignedIntegerResult::<core::integer::i32>> = store_temp<core::integer::SignedIntegerResult::<core::integer::i32>>;
+libfunc enum_init<core::integer::SignedIntegerResult::<core::integer::i32>, 1> = enum_init<core::integer::SignedIntegerResult::<core::integer::i32>, 1>;
+libfunc enum_init<core::integer::SignedIntegerResult::<core::integer::i32>, 2> = enum_init<core::integer::SignedIntegerResult::<core::integer::i32>, 2>;
+
+i32_overflowing_add_impl([0], [1], [2]) { fallthrough([3], [4]) 6([5], [6]) 11([7], [8]) }; // 0
+branch_align() -> (); // 1
+enum_init<core::integer::SignedIntegerResult::<core::integer::i32>, 0>([4]) -> ([9]); // 2
+store_temp<RangeCheck>([3]) -> ([3]); // 3
+store_temp<core::integer::SignedIntegerResult::<core::integer::i32>>([9]) -> ([9]); // 4
+return([3], [9]); // 5
+branch_align() -> (); // 6
+enum_init<core::integer::SignedIntegerResult::<core::integer::i32>, 1>([6]) -> ([10]); // 7
+store_temp<RangeCheck>([5]) -> ([5]); // 8
+store_temp<core::integer::SignedIntegerResult::<core::integer::i32>>([10]) -> ([10]); // 9
+return([5], [10]); // 10
+branch_align() -> (); // 11
+enum_init<core::integer::SignedIntegerResult::<core::integer::i32>, 2>([8]) -> ([11]); // 12
+store_temp<RangeCheck>([7]) -> ([7]); // 13
+store_temp<core::integer::SignedIntegerResult::<core::integer::i32>>([11]) -> ([11]); // 14
+return([7], [11]); // 15
+
+test::foo@0([0]: RangeCheck, [1]: i32, [2]: i32) -> (RangeCheck, core::integer::SignedIntegerResult::<core::integer::i32>);

--- a/Aegis/Tests/e2e_libfuncs/i32_aegis/i32_overflowing_sub_impl.sierra
+++ b/Aegis/Tests/e2e_libfuncs/i32_aegis/i32_overflowing_sub_impl.sierra
@@ -1,0 +1,30 @@
+type RangeCheck = RangeCheck [storable: true, drop: false, dup: false, zero_sized: false];
+type i32 = i32 [storable: true, drop: true, dup: true, zero_sized: false];
+type core::integer::SignedIntegerResult::<core::integer::i32> = Enum<ut@core::integer::SignedIntegerResult::<core::integer::i32>, i32, i32, i32> [storable: true, drop: true, dup: true, zero_sized: false];
+
+libfunc i32_overflowing_sub_impl = i32_overflowing_sub_impl;
+libfunc branch_align = branch_align;
+libfunc enum_init<core::integer::SignedIntegerResult::<core::integer::i32>, 0> = enum_init<core::integer::SignedIntegerResult::<core::integer::i32>, 0>;
+libfunc store_temp<RangeCheck> = store_temp<RangeCheck>;
+libfunc store_temp<core::integer::SignedIntegerResult::<core::integer::i32>> = store_temp<core::integer::SignedIntegerResult::<core::integer::i32>>;
+libfunc enum_init<core::integer::SignedIntegerResult::<core::integer::i32>, 1> = enum_init<core::integer::SignedIntegerResult::<core::integer::i32>, 1>;
+libfunc enum_init<core::integer::SignedIntegerResult::<core::integer::i32>, 2> = enum_init<core::integer::SignedIntegerResult::<core::integer::i32>, 2>;
+
+i32_overflowing_sub_impl([0], [1], [2]) { fallthrough([3], [4]) 6([5], [6]) 11([7], [8]) }; // 0
+branch_align() -> (); // 1
+enum_init<core::integer::SignedIntegerResult::<core::integer::i32>, 0>([4]) -> ([9]); // 2
+store_temp<RangeCheck>([3]) -> ([3]); // 3
+store_temp<core::integer::SignedIntegerResult::<core::integer::i32>>([9]) -> ([9]); // 4
+return([3], [9]); // 5
+branch_align() -> (); // 6
+enum_init<core::integer::SignedIntegerResult::<core::integer::i32>, 1>([6]) -> ([10]); // 7
+store_temp<RangeCheck>([5]) -> ([5]); // 8
+store_temp<core::integer::SignedIntegerResult::<core::integer::i32>>([10]) -> ([10]); // 9
+return([5], [10]); // 10
+branch_align() -> (); // 11
+enum_init<core::integer::SignedIntegerResult::<core::integer::i32>, 2>([8]) -> ([11]); // 12
+store_temp<RangeCheck>([7]) -> ([7]); // 13
+store_temp<core::integer::SignedIntegerResult::<core::integer::i32>>([11]) -> ([11]); // 14
+return([7], [11]); // 15
+
+test::foo@0([0]: RangeCheck, [1]: i32, [2]: i32) -> (RangeCheck, core::integer::SignedIntegerResult::<core::integer::i32>);

--- a/Aegis/Tests/e2e_libfuncs/i32_aegis/i32_to_felt252.sierra
+++ b/Aegis/Tests/e2e_libfuncs/i32_aegis/i32_to_felt252.sierra
@@ -1,0 +1,11 @@
+type i32 = i32 [storable: true, drop: true, dup: true, zero_sized: false];
+type felt252 = felt252 [storable: true, drop: true, dup: true, zero_sized: false];
+
+libfunc i32_to_felt252 = i32_to_felt252;
+libfunc store_temp<felt252> = store_temp<felt252>;
+
+i32_to_felt252([0]) -> ([1]); // 0
+store_temp<felt252>([1]) -> ([1]); // 1
+return([1]); // 2
+
+test::foo@0([0]: i32) -> (felt252);

--- a/Aegis/Tests/e2e_libfuncs/i32_aegis/i32_try_from_felt252.sierra
+++ b/Aegis/Tests/e2e_libfuncs/i32_aegis/i32_try_from_felt252.sierra
@@ -1,0 +1,28 @@
+type RangeCheck = RangeCheck [storable: true, drop: false, dup: false, zero_sized: false];
+type Unit = Struct<ut@Tuple> [storable: true, drop: true, dup: true, zero_sized: true];
+type i32 = i32 [storable: true, drop: true, dup: true, zero_sized: false];
+type core::option::Option::<core::integer::i32> = Enum<ut@core::option::Option::<core::integer::i32>, i32, Unit> [storable: true, drop: true, dup: true, zero_sized: false];
+type felt252 = felt252 [storable: true, drop: true, dup: true, zero_sized: false];
+
+libfunc i32_try_from_felt252 = i32_try_from_felt252;
+libfunc branch_align = branch_align;
+libfunc enum_init<core::option::Option::<core::integer::i32>, 0> = enum_init<core::option::Option::<core::integer::i32>, 0>;
+libfunc store_temp<RangeCheck> = store_temp<RangeCheck>;
+libfunc store_temp<core::option::Option::<core::integer::i32>> = store_temp<core::option::Option::<core::integer::i32>>;
+libfunc struct_construct<Unit> = struct_construct<Unit>;
+libfunc enum_init<core::option::Option::<core::integer::i32>, 1> = enum_init<core::option::Option::<core::integer::i32>, 1>;
+
+i32_try_from_felt252([0], [1]) { fallthrough([2], [3]) 6([4]) }; // 0
+branch_align() -> (); // 1
+enum_init<core::option::Option::<core::integer::i32>, 0>([3]) -> ([5]); // 2
+store_temp<RangeCheck>([2]) -> ([2]); // 3
+store_temp<core::option::Option::<core::integer::i32>>([5]) -> ([5]); // 4
+return([2], [5]); // 5
+branch_align() -> (); // 6
+struct_construct<Unit>() -> ([6]); // 7
+enum_init<core::option::Option::<core::integer::i32>, 1>([6]) -> ([7]); // 8
+store_temp<RangeCheck>([4]) -> ([4]); // 9
+store_temp<core::option::Option::<core::integer::i32>>([7]) -> ([7]); // 10
+return([4], [7]); // 11
+
+test::foo@0([0]: RangeCheck, [1]: felt252) -> (RangeCheck, core::option::Option::<core::integer::i32>);

--- a/Aegis/Tests/e2e_libfuncs/i32_aegis/i32_wide_mul.sierra
+++ b/Aegis/Tests/e2e_libfuncs/i32_aegis/i32_wide_mul.sierra
@@ -1,0 +1,11 @@
+type i32 = i32 [storable: true, drop: true, dup: true, zero_sized: false];
+type i64 = i64 [storable: true, drop: true, dup: true, zero_sized: false];
+
+libfunc i32_wide_mul = i32_wide_mul;
+libfunc store_temp<i64> = store_temp<i64>;
+
+i32_wide_mul([0], [1]) -> ([2]); // 0
+store_temp<i64>([2]) -> ([2]); // 1
+return([2]); // 2
+
+test::foo@0([0]: i32, [1]: i32) -> (i64);

--- a/Aegis/Tests/e2e_libfuncs/i64_aegis/i64_diff.sierra
+++ b/Aegis/Tests/e2e_libfuncs/i64_aegis/i64_diff.sierra
@@ -1,0 +1,25 @@
+type RangeCheck = RangeCheck [storable: true, drop: false, dup: false, zero_sized: false];
+type u64 = u64 [storable: true, drop: true, dup: true, zero_sized: false];
+type core::result::Result::<core::integer::u64, core::integer::u64> = Enum<ut@core::result::Result::<core::integer::u64, core::integer::u64>, u64, u64> [storable: true, drop: true, dup: true, zero_sized: false];
+type i64 = i64 [storable: true, drop: true, dup: true, zero_sized: false];
+
+libfunc i64_diff = i64_diff;
+libfunc branch_align = branch_align;
+libfunc enum_init<core::result::Result::<core::integer::u64, core::integer::u64>, 0> = enum_init<core::result::Result::<core::integer::u64, core::integer::u64>, 0>;
+libfunc store_temp<RangeCheck> = store_temp<RangeCheck>;
+libfunc store_temp<core::result::Result::<core::integer::u64, core::integer::u64>> = store_temp<core::result::Result::<core::integer::u64, core::integer::u64>>;
+libfunc enum_init<core::result::Result::<core::integer::u64, core::integer::u64>, 1> = enum_init<core::result::Result::<core::integer::u64, core::integer::u64>, 1>;
+
+i64_diff([0], [1], [2]) { fallthrough([3], [4]) 6([5], [6]) }; // 0
+branch_align() -> (); // 1
+enum_init<core::result::Result::<core::integer::u64, core::integer::u64>, 0>([4]) -> ([7]); // 2
+store_temp<RangeCheck>([3]) -> ([3]); // 3
+store_temp<core::result::Result::<core::integer::u64, core::integer::u64>>([7]) -> ([7]); // 4
+return([3], [7]); // 5
+branch_align() -> (); // 6
+enum_init<core::result::Result::<core::integer::u64, core::integer::u64>, 1>([6]) -> ([8]); // 7
+store_temp<RangeCheck>([5]) -> ([5]); // 8
+store_temp<core::result::Result::<core::integer::u64, core::integer::u64>>([8]) -> ([8]); // 9
+return([5], [8]); // 10
+
+test::foo@0([0]: RangeCheck, [1]: i64, [2]: i64) -> (RangeCheck, core::result::Result::<core::integer::u64, core::integer::u64>);

--- a/Aegis/Tests/e2e_libfuncs/i64_aegis/i64_eq.sierra
+++ b/Aegis/Tests/e2e_libfuncs/i64_aegis/i64_eq.sierra
@@ -1,0 +1,30 @@
+type i64 = i64 [storable: true, drop: true, dup: true, zero_sized: false];
+type Unit = Struct<ut@Tuple> [storable: true, drop: true, dup: true, zero_sized: true];
+type core::bool = Enum<ut@core::bool, Unit, Unit> [storable: true, drop: true, dup: true, zero_sized: false];
+
+libfunc i64_const<11> = i64_const<11>;
+libfunc i64_const<12> = i64_const<12>;
+libfunc store_temp<i64> = store_temp<i64>;
+libfunc i64_eq = i64_eq;
+libfunc branch_align = branch_align;
+libfunc struct_construct<Unit> = struct_construct<Unit>;
+libfunc enum_init<core::bool, 0> = enum_init<core::bool, 0>;
+libfunc store_temp<core::bool> = store_temp<core::bool>;
+libfunc enum_init<core::bool, 1> = enum_init<core::bool, 1>;
+
+i64_const<11>() -> ([0]); // 0
+i64_const<12>() -> ([1]); // 1
+store_temp<i64>([0]) -> ([0]); // 2
+i64_eq([0], [1]) { fallthrough() 9() }; // 3
+branch_align() -> (); // 4
+struct_construct<Unit>() -> ([2]); // 5
+enum_init<core::bool, 0>([2]) -> ([3]); // 6
+store_temp<core::bool>([3]) -> ([3]); // 7
+return([3]); // 8
+branch_align() -> (); // 9
+struct_construct<Unit>() -> ([4]); // 10
+enum_init<core::bool, 1>([4]) -> ([5]); // 11
+store_temp<core::bool>([5]) -> ([5]); // 12
+return([5]); // 13
+
+test::foo@0() -> (core::bool);

--- a/Aegis/Tests/e2e_libfuncs/i64_aegis/i64_is_zero.sierra
+++ b/Aegis/Tests/e2e_libfuncs/i64_aegis/i64_is_zero.sierra
@@ -1,0 +1,20 @@
+type i64 = i64 [storable: true, drop: true, dup: true, zero_sized: false];
+type NonZero<i64> = NonZero<i64> [storable: true, drop: true, dup: true, zero_sized: false];
+
+libfunc i64_is_zero = i64_is_zero;
+libfunc branch_align = branch_align;
+libfunc i64_const<123> = i64_const<123>;
+libfunc store_temp<i64> = store_temp<i64>;
+libfunc unwrap_non_zero<i64> = unwrap_non_zero<i64>;
+
+i64_is_zero([0]) { fallthrough() 5([1]) }; // 0
+branch_align() -> (); // 1
+i64_const<123>() -> ([2]); // 2
+store_temp<i64>([2]) -> ([2]); // 3
+return([2]); // 4
+branch_align() -> (); // 5
+unwrap_non_zero<i64>([1]) -> ([3]); // 6
+store_temp<i64>([3]) -> ([3]); // 7
+return([3]); // 8
+
+test::foo@0([0]: i64) -> (i64);

--- a/Aegis/Tests/e2e_libfuncs/i64_aegis/i64_overflowing_add_impl.sierra
+++ b/Aegis/Tests/e2e_libfuncs/i64_aegis/i64_overflowing_add_impl.sierra
@@ -1,0 +1,30 @@
+type RangeCheck = RangeCheck [storable: true, drop: false, dup: false, zero_sized: false];
+type i64 = i64 [storable: true, drop: true, dup: true, zero_sized: false];
+type core::integer::SignedIntegerResult::<core::integer::i64> = Enum<ut@core::integer::SignedIntegerResult::<core::integer::i64>, i64, i64, i64> [storable: true, drop: true, dup: true, zero_sized: false];
+
+libfunc i64_overflowing_add_impl = i64_overflowing_add_impl;
+libfunc branch_align = branch_align;
+libfunc enum_init<core::integer::SignedIntegerResult::<core::integer::i64>, 0> = enum_init<core::integer::SignedIntegerResult::<core::integer::i64>, 0>;
+libfunc store_temp<RangeCheck> = store_temp<RangeCheck>;
+libfunc store_temp<core::integer::SignedIntegerResult::<core::integer::i64>> = store_temp<core::integer::SignedIntegerResult::<core::integer::i64>>;
+libfunc enum_init<core::integer::SignedIntegerResult::<core::integer::i64>, 1> = enum_init<core::integer::SignedIntegerResult::<core::integer::i64>, 1>;
+libfunc enum_init<core::integer::SignedIntegerResult::<core::integer::i64>, 2> = enum_init<core::integer::SignedIntegerResult::<core::integer::i64>, 2>;
+
+i64_overflowing_add_impl([0], [1], [2]) { fallthrough([3], [4]) 6([5], [6]) 11([7], [8]) }; // 0
+branch_align() -> (); // 1
+enum_init<core::integer::SignedIntegerResult::<core::integer::i64>, 0>([4]) -> ([9]); // 2
+store_temp<RangeCheck>([3]) -> ([3]); // 3
+store_temp<core::integer::SignedIntegerResult::<core::integer::i64>>([9]) -> ([9]); // 4
+return([3], [9]); // 5
+branch_align() -> (); // 6
+enum_init<core::integer::SignedIntegerResult::<core::integer::i64>, 1>([6]) -> ([10]); // 7
+store_temp<RangeCheck>([5]) -> ([5]); // 8
+store_temp<core::integer::SignedIntegerResult::<core::integer::i64>>([10]) -> ([10]); // 9
+return([5], [10]); // 10
+branch_align() -> (); // 11
+enum_init<core::integer::SignedIntegerResult::<core::integer::i64>, 2>([8]) -> ([11]); // 12
+store_temp<RangeCheck>([7]) -> ([7]); // 13
+store_temp<core::integer::SignedIntegerResult::<core::integer::i64>>([11]) -> ([11]); // 14
+return([7], [11]); // 15
+
+test::foo@0([0]: RangeCheck, [1]: i64, [2]: i64) -> (RangeCheck, core::integer::SignedIntegerResult::<core::integer::i64>);

--- a/Aegis/Tests/e2e_libfuncs/i64_aegis/i64_overflowing_sub_impl.sierra
+++ b/Aegis/Tests/e2e_libfuncs/i64_aegis/i64_overflowing_sub_impl.sierra
@@ -1,0 +1,30 @@
+type RangeCheck = RangeCheck [storable: true, drop: false, dup: false, zero_sized: false];
+type i64 = i64 [storable: true, drop: true, dup: true, zero_sized: false];
+type core::integer::SignedIntegerResult::<core::integer::i64> = Enum<ut@core::integer::SignedIntegerResult::<core::integer::i64>, i64, i64, i64> [storable: true, drop: true, dup: true, zero_sized: false];
+
+libfunc i64_overflowing_sub_impl = i64_overflowing_sub_impl;
+libfunc branch_align = branch_align;
+libfunc enum_init<core::integer::SignedIntegerResult::<core::integer::i64>, 0> = enum_init<core::integer::SignedIntegerResult::<core::integer::i64>, 0>;
+libfunc store_temp<RangeCheck> = store_temp<RangeCheck>;
+libfunc store_temp<core::integer::SignedIntegerResult::<core::integer::i64>> = store_temp<core::integer::SignedIntegerResult::<core::integer::i64>>;
+libfunc enum_init<core::integer::SignedIntegerResult::<core::integer::i64>, 1> = enum_init<core::integer::SignedIntegerResult::<core::integer::i64>, 1>;
+libfunc enum_init<core::integer::SignedIntegerResult::<core::integer::i64>, 2> = enum_init<core::integer::SignedIntegerResult::<core::integer::i64>, 2>;
+
+i64_overflowing_sub_impl([0], [1], [2]) { fallthrough([3], [4]) 6([5], [6]) 11([7], [8]) }; // 0
+branch_align() -> (); // 1
+enum_init<core::integer::SignedIntegerResult::<core::integer::i64>, 0>([4]) -> ([9]); // 2
+store_temp<RangeCheck>([3]) -> ([3]); // 3
+store_temp<core::integer::SignedIntegerResult::<core::integer::i64>>([9]) -> ([9]); // 4
+return([3], [9]); // 5
+branch_align() -> (); // 6
+enum_init<core::integer::SignedIntegerResult::<core::integer::i64>, 1>([6]) -> ([10]); // 7
+store_temp<RangeCheck>([5]) -> ([5]); // 8
+store_temp<core::integer::SignedIntegerResult::<core::integer::i64>>([10]) -> ([10]); // 9
+return([5], [10]); // 10
+branch_align() -> (); // 11
+enum_init<core::integer::SignedIntegerResult::<core::integer::i64>, 2>([8]) -> ([11]); // 12
+store_temp<RangeCheck>([7]) -> ([7]); // 13
+store_temp<core::integer::SignedIntegerResult::<core::integer::i64>>([11]) -> ([11]); // 14
+return([7], [11]); // 15
+
+test::foo@0([0]: RangeCheck, [1]: i64, [2]: i64) -> (RangeCheck, core::integer::SignedIntegerResult::<core::integer::i64>);

--- a/Aegis/Tests/e2e_libfuncs/i64_aegis/i64_to_felt252.sierra
+++ b/Aegis/Tests/e2e_libfuncs/i64_aegis/i64_to_felt252.sierra
@@ -1,0 +1,11 @@
+type i64 = i64 [storable: true, drop: true, dup: true, zero_sized: false];
+type felt252 = felt252 [storable: true, drop: true, dup: true, zero_sized: false];
+
+libfunc i64_to_felt252 = i64_to_felt252;
+libfunc store_temp<felt252> = store_temp<felt252>;
+
+i64_to_felt252([0]) -> ([1]); // 0
+store_temp<felt252>([1]) -> ([1]); // 1
+return([1]); // 2
+
+test::foo@0([0]: i64) -> (felt252);

--- a/Aegis/Tests/e2e_libfuncs/i64_aegis/i64_try_from_felt252.sierra
+++ b/Aegis/Tests/e2e_libfuncs/i64_aegis/i64_try_from_felt252.sierra
@@ -1,0 +1,28 @@
+type RangeCheck = RangeCheck [storable: true, drop: false, dup: false, zero_sized: false];
+type Unit = Struct<ut@Tuple> [storable: true, drop: true, dup: true, zero_sized: true];
+type i64 = i64 [storable: true, drop: true, dup: true, zero_sized: false];
+type core::option::Option::<core::integer::i64> = Enum<ut@core::option::Option::<core::integer::i64>, i64, Unit> [storable: true, drop: true, dup: true, zero_sized: false];
+type felt252 = felt252 [storable: true, drop: true, dup: true, zero_sized: false];
+
+libfunc i64_try_from_felt252 = i64_try_from_felt252;
+libfunc branch_align = branch_align;
+libfunc enum_init<core::option::Option::<core::integer::i64>, 0> = enum_init<core::option::Option::<core::integer::i64>, 0>;
+libfunc store_temp<RangeCheck> = store_temp<RangeCheck>;
+libfunc store_temp<core::option::Option::<core::integer::i64>> = store_temp<core::option::Option::<core::integer::i64>>;
+libfunc struct_construct<Unit> = struct_construct<Unit>;
+libfunc enum_init<core::option::Option::<core::integer::i64>, 1> = enum_init<core::option::Option::<core::integer::i64>, 1>;
+
+i64_try_from_felt252([0], [1]) { fallthrough([2], [3]) 6([4]) }; // 0
+branch_align() -> (); // 1
+enum_init<core::option::Option::<core::integer::i64>, 0>([3]) -> ([5]); // 2
+store_temp<RangeCheck>([2]) -> ([2]); // 3
+store_temp<core::option::Option::<core::integer::i64>>([5]) -> ([5]); // 4
+return([2], [5]); // 5
+branch_align() -> (); // 6
+struct_construct<Unit>() -> ([6]); // 7
+enum_init<core::option::Option::<core::integer::i64>, 1>([6]) -> ([7]); // 8
+store_temp<RangeCheck>([4]) -> ([4]); // 9
+store_temp<core::option::Option::<core::integer::i64>>([7]) -> ([7]); // 10
+return([4], [7]); // 11
+
+test::foo@0([0]: RangeCheck, [1]: felt252) -> (RangeCheck, core::option::Option::<core::integer::i64>);

--- a/Aegis/Tests/e2e_libfuncs/i64_aegis/i64_wide_mul.sierra
+++ b/Aegis/Tests/e2e_libfuncs/i64_aegis/i64_wide_mul.sierra
@@ -1,0 +1,11 @@
+type i64 = i64 [storable: true, drop: true, dup: true, zero_sized: false];
+type i128 = i128 [storable: true, drop: true, dup: true, zero_sized: false];
+
+libfunc i64_wide_mul = i64_wide_mul;
+libfunc store_temp<i128> = store_temp<i128>;
+
+i64_wide_mul([0], [1]) -> ([2]); // 0
+store_temp<i128>([2]) -> ([2]); // 1
+return([2]); // 2
+
+test::foo@0([0]: i64, [1]: i64) -> (i128);

--- a/Aegis/Tests/e2e_libfuncs/i8_aegis/i8_diff.sierra
+++ b/Aegis/Tests/e2e_libfuncs/i8_aegis/i8_diff.sierra
@@ -1,0 +1,25 @@
+type RangeCheck = RangeCheck [storable: true, drop: false, dup: false, zero_sized: false];
+type u8 = u8 [storable: true, drop: true, dup: true, zero_sized: false];
+type core::result::Result::<core::integer::u8, core::integer::u8> = Enum<ut@core::result::Result::<core::integer::u8, core::integer::u8>, u8, u8> [storable: true, drop: true, dup: true, zero_sized: false];
+type i8 = i8 [storable: true, drop: true, dup: true, zero_sized: false];
+
+libfunc i8_diff = i8_diff;
+libfunc branch_align = branch_align;
+libfunc enum_init<core::result::Result::<core::integer::u8, core::integer::u8>, 0> = enum_init<core::result::Result::<core::integer::u8, core::integer::u8>, 0>;
+libfunc store_temp<RangeCheck> = store_temp<RangeCheck>;
+libfunc store_temp<core::result::Result::<core::integer::u8, core::integer::u8>> = store_temp<core::result::Result::<core::integer::u8, core::integer::u8>>;
+libfunc enum_init<core::result::Result::<core::integer::u8, core::integer::u8>, 1> = enum_init<core::result::Result::<core::integer::u8, core::integer::u8>, 1>;
+
+i8_diff([0], [1], [2]) { fallthrough([3], [4]) 6([5], [6]) }; // 0
+branch_align() -> (); // 1
+enum_init<core::result::Result::<core::integer::u8, core::integer::u8>, 0>([4]) -> ([7]); // 2
+store_temp<RangeCheck>([3]) -> ([3]); // 3
+store_temp<core::result::Result::<core::integer::u8, core::integer::u8>>([7]) -> ([7]); // 4
+return([3], [7]); // 5
+branch_align() -> (); // 6
+enum_init<core::result::Result::<core::integer::u8, core::integer::u8>, 1>([6]) -> ([8]); // 7
+store_temp<RangeCheck>([5]) -> ([5]); // 8
+store_temp<core::result::Result::<core::integer::u8, core::integer::u8>>([8]) -> ([8]); // 9
+return([5], [8]); // 10
+
+test::foo@0([0]: RangeCheck, [1]: i8, [2]: i8) -> (RangeCheck, core::result::Result::<core::integer::u8, core::integer::u8>);

--- a/Aegis/Tests/e2e_libfuncs/i8_aegis/i8_eq.sierra
+++ b/Aegis/Tests/e2e_libfuncs/i8_aegis/i8_eq.sierra
@@ -1,0 +1,30 @@
+type i8 = i8 [storable: true, drop: true, dup: true, zero_sized: false];
+type Unit = Struct<ut@Tuple> [storable: true, drop: true, dup: true, zero_sized: true];
+type core::bool = Enum<ut@core::bool, Unit, Unit> [storable: true, drop: true, dup: true, zero_sized: false];
+
+libfunc i8_const<11> = i8_const<11>;
+libfunc i8_const<12> = i8_const<12>;
+libfunc store_temp<i8> = store_temp<i8>;
+libfunc i8_eq = i8_eq;
+libfunc branch_align = branch_align;
+libfunc struct_construct<Unit> = struct_construct<Unit>;
+libfunc enum_init<core::bool, 0> = enum_init<core::bool, 0>;
+libfunc store_temp<core::bool> = store_temp<core::bool>;
+libfunc enum_init<core::bool, 1> = enum_init<core::bool, 1>;
+
+i8_const<11>() -> ([0]); // 0
+i8_const<12>() -> ([1]); // 1
+store_temp<i8>([0]) -> ([0]); // 2
+i8_eq([0], [1]) { fallthrough() 9() }; // 3
+branch_align() -> (); // 4
+struct_construct<Unit>() -> ([2]); // 5
+enum_init<core::bool, 0>([2]) -> ([3]); // 6
+store_temp<core::bool>([3]) -> ([3]); // 7
+return([3]); // 8
+branch_align() -> (); // 9
+struct_construct<Unit>() -> ([4]); // 10
+enum_init<core::bool, 1>([4]) -> ([5]); // 11
+store_temp<core::bool>([5]) -> ([5]); // 12
+return([5]); // 13
+
+test::foo@0() -> (core::bool);

--- a/Aegis/Tests/e2e_libfuncs/i8_aegis/i8_is_zero.sierra
+++ b/Aegis/Tests/e2e_libfuncs/i8_aegis/i8_is_zero.sierra
@@ -1,0 +1,20 @@
+type i8 = i8 [storable: true, drop: true, dup: true, zero_sized: false];
+type NonZero<i8> = NonZero<i8> [storable: true, drop: true, dup: true, zero_sized: false];
+
+libfunc i8_is_zero = i8_is_zero;
+libfunc branch_align = branch_align;
+libfunc i8_const<123> = i8_const<123>;
+libfunc store_temp<i8> = store_temp<i8>;
+libfunc unwrap_non_zero<i8> = unwrap_non_zero<i8>;
+
+i8_is_zero([0]) { fallthrough() 5([1]) }; // 0
+branch_align() -> (); // 1
+i8_const<123>() -> ([2]); // 2
+store_temp<i8>([2]) -> ([2]); // 3
+return([2]); // 4
+branch_align() -> (); // 5
+unwrap_non_zero<i8>([1]) -> ([3]); // 6
+store_temp<i8>([3]) -> ([3]); // 7
+return([3]); // 8
+
+test::foo@0([0]: i8) -> (i8);

--- a/Aegis/Tests/e2e_libfuncs/i8_aegis/i8_overflowing_add_impl.sierra
+++ b/Aegis/Tests/e2e_libfuncs/i8_aegis/i8_overflowing_add_impl.sierra
@@ -1,0 +1,30 @@
+type RangeCheck = RangeCheck [storable: true, drop: false, dup: false, zero_sized: false];
+type i8 = i8 [storable: true, drop: true, dup: true, zero_sized: false];
+type core::integer::SignedIntegerResult::<core::integer::i8> = Enum<ut@core::integer::SignedIntegerResult::<core::integer::i8>, i8, i8, i8> [storable: true, drop: true, dup: true, zero_sized: false];
+
+libfunc i8_overflowing_add_impl = i8_overflowing_add_impl;
+libfunc branch_align = branch_align;
+libfunc enum_init<core::integer::SignedIntegerResult::<core::integer::i8>, 0> = enum_init<core::integer::SignedIntegerResult::<core::integer::i8>, 0>;
+libfunc store_temp<RangeCheck> = store_temp<RangeCheck>;
+libfunc store_temp<core::integer::SignedIntegerResult::<core::integer::i8>> = store_temp<core::integer::SignedIntegerResult::<core::integer::i8>>;
+libfunc enum_init<core::integer::SignedIntegerResult::<core::integer::i8>, 1> = enum_init<core::integer::SignedIntegerResult::<core::integer::i8>, 1>;
+libfunc enum_init<core::integer::SignedIntegerResult::<core::integer::i8>, 2> = enum_init<core::integer::SignedIntegerResult::<core::integer::i8>, 2>;
+
+i8_overflowing_add_impl([0], [1], [2]) { fallthrough([3], [4]) 6([5], [6]) 11([7], [8]) }; // 0
+branch_align() -> (); // 1
+enum_init<core::integer::SignedIntegerResult::<core::integer::i8>, 0>([4]) -> ([9]); // 2
+store_temp<RangeCheck>([3]) -> ([3]); // 3
+store_temp<core::integer::SignedIntegerResult::<core::integer::i8>>([9]) -> ([9]); // 4
+return([3], [9]); // 5
+branch_align() -> (); // 6
+enum_init<core::integer::SignedIntegerResult::<core::integer::i8>, 1>([6]) -> ([10]); // 7
+store_temp<RangeCheck>([5]) -> ([5]); // 8
+store_temp<core::integer::SignedIntegerResult::<core::integer::i8>>([10]) -> ([10]); // 9
+return([5], [10]); // 10
+branch_align() -> (); // 11
+enum_init<core::integer::SignedIntegerResult::<core::integer::i8>, 2>([8]) -> ([11]); // 12
+store_temp<RangeCheck>([7]) -> ([7]); // 13
+store_temp<core::integer::SignedIntegerResult::<core::integer::i8>>([11]) -> ([11]); // 14
+return([7], [11]); // 15
+
+test::foo@0([0]: RangeCheck, [1]: i8, [2]: i8) -> (RangeCheck, core::integer::SignedIntegerResult::<core::integer::i8>);

--- a/Aegis/Tests/e2e_libfuncs/i8_aegis/i8_overflowing_sub_impl.sierra
+++ b/Aegis/Tests/e2e_libfuncs/i8_aegis/i8_overflowing_sub_impl.sierra
@@ -1,0 +1,30 @@
+type RangeCheck = RangeCheck [storable: true, drop: false, dup: false, zero_sized: false];
+type i8 = i8 [storable: true, drop: true, dup: true, zero_sized: false];
+type core::integer::SignedIntegerResult::<core::integer::i8> = Enum<ut@core::integer::SignedIntegerResult::<core::integer::i8>, i8, i8, i8> [storable: true, drop: true, dup: true, zero_sized: false];
+
+libfunc i8_overflowing_sub_impl = i8_overflowing_sub_impl;
+libfunc branch_align = branch_align;
+libfunc enum_init<core::integer::SignedIntegerResult::<core::integer::i8>, 0> = enum_init<core::integer::SignedIntegerResult::<core::integer::i8>, 0>;
+libfunc store_temp<RangeCheck> = store_temp<RangeCheck>;
+libfunc store_temp<core::integer::SignedIntegerResult::<core::integer::i8>> = store_temp<core::integer::SignedIntegerResult::<core::integer::i8>>;
+libfunc enum_init<core::integer::SignedIntegerResult::<core::integer::i8>, 1> = enum_init<core::integer::SignedIntegerResult::<core::integer::i8>, 1>;
+libfunc enum_init<core::integer::SignedIntegerResult::<core::integer::i8>, 2> = enum_init<core::integer::SignedIntegerResult::<core::integer::i8>, 2>;
+
+i8_overflowing_sub_impl([0], [1], [2]) { fallthrough([3], [4]) 6([5], [6]) 11([7], [8]) }; // 0
+branch_align() -> (); // 1
+enum_init<core::integer::SignedIntegerResult::<core::integer::i8>, 0>([4]) -> ([9]); // 2
+store_temp<RangeCheck>([3]) -> ([3]); // 3
+store_temp<core::integer::SignedIntegerResult::<core::integer::i8>>([9]) -> ([9]); // 4
+return([3], [9]); // 5
+branch_align() -> (); // 6
+enum_init<core::integer::SignedIntegerResult::<core::integer::i8>, 1>([6]) -> ([10]); // 7
+store_temp<RangeCheck>([5]) -> ([5]); // 8
+store_temp<core::integer::SignedIntegerResult::<core::integer::i8>>([10]) -> ([10]); // 9
+return([5], [10]); // 10
+branch_align() -> (); // 11
+enum_init<core::integer::SignedIntegerResult::<core::integer::i8>, 2>([8]) -> ([11]); // 12
+store_temp<RangeCheck>([7]) -> ([7]); // 13
+store_temp<core::integer::SignedIntegerResult::<core::integer::i8>>([11]) -> ([11]); // 14
+return([7], [11]); // 15
+
+test::foo@0([0]: RangeCheck, [1]: i8, [2]: i8) -> (RangeCheck, core::integer::SignedIntegerResult::<core::integer::i8>);

--- a/Aegis/Tests/e2e_libfuncs/i8_aegis/i8_to_felt252.sierra
+++ b/Aegis/Tests/e2e_libfuncs/i8_aegis/i8_to_felt252.sierra
@@ -1,0 +1,11 @@
+type i8 = i8 [storable: true, drop: true, dup: true, zero_sized: false];
+type felt252 = felt252 [storable: true, drop: true, dup: true, zero_sized: false];
+
+libfunc i8_to_felt252 = i8_to_felt252;
+libfunc store_temp<felt252> = store_temp<felt252>;
+
+i8_to_felt252([0]) -> ([1]); // 0
+store_temp<felt252>([1]) -> ([1]); // 1
+return([1]); // 2
+
+test::foo@0([0]: i8) -> (felt252);

--- a/Aegis/Tests/e2e_libfuncs/i8_aegis/i8_try_from_felt252.sierra
+++ b/Aegis/Tests/e2e_libfuncs/i8_aegis/i8_try_from_felt252.sierra
@@ -1,0 +1,28 @@
+type RangeCheck = RangeCheck [storable: true, drop: false, dup: false, zero_sized: false];
+type Unit = Struct<ut@Tuple> [storable: true, drop: true, dup: true, zero_sized: true];
+type i8 = i8 [storable: true, drop: true, dup: true, zero_sized: false];
+type core::option::Option::<core::integer::i8> = Enum<ut@core::option::Option::<core::integer::i8>, i8, Unit> [storable: true, drop: true, dup: true, zero_sized: false];
+type felt252 = felt252 [storable: true, drop: true, dup: true, zero_sized: false];
+
+libfunc i8_try_from_felt252 = i8_try_from_felt252;
+libfunc branch_align = branch_align;
+libfunc enum_init<core::option::Option::<core::integer::i8>, 0> = enum_init<core::option::Option::<core::integer::i8>, 0>;
+libfunc store_temp<RangeCheck> = store_temp<RangeCheck>;
+libfunc store_temp<core::option::Option::<core::integer::i8>> = store_temp<core::option::Option::<core::integer::i8>>;
+libfunc struct_construct<Unit> = struct_construct<Unit>;
+libfunc enum_init<core::option::Option::<core::integer::i8>, 1> = enum_init<core::option::Option::<core::integer::i8>, 1>;
+
+i8_try_from_felt252([0], [1]) { fallthrough([2], [3]) 6([4]) }; // 0
+branch_align() -> (); // 1
+enum_init<core::option::Option::<core::integer::i8>, 0>([3]) -> ([5]); // 2
+store_temp<RangeCheck>([2]) -> ([2]); // 3
+store_temp<core::option::Option::<core::integer::i8>>([5]) -> ([5]); // 4
+return([2], [5]); // 5
+branch_align() -> (); // 6
+struct_construct<Unit>() -> ([6]); // 7
+enum_init<core::option::Option::<core::integer::i8>, 1>([6]) -> ([7]); // 8
+store_temp<RangeCheck>([4]) -> ([4]); // 9
+store_temp<core::option::Option::<core::integer::i8>>([7]) -> ([7]); // 10
+return([4], [7]); // 11
+
+test::foo@0([0]: RangeCheck, [1]: felt252) -> (RangeCheck, core::option::Option::<core::integer::i8>);

--- a/Aegis/Tests/e2e_libfuncs/i8_aegis/i8_wide_mul.sierra
+++ b/Aegis/Tests/e2e_libfuncs/i8_aegis/i8_wide_mul.sierra
@@ -1,0 +1,11 @@
+type i8 = i8 [storable: true, drop: true, dup: true, zero_sized: false];
+type i16 = i16 [storable: true, drop: true, dup: true, zero_sized: false];
+
+libfunc i8_wide_mul = i8_wide_mul;
+libfunc store_temp<i16> = store_temp<i16>;
+
+i8_wide_mul([0], [1]) -> ([2]); // 0
+store_temp<i16>([2]) -> ([2]); // 1
+return([2]); // 2
+
+test::foo@0([0]: i8, [1]: i8) -> (i16);

--- a/Aegis/Tests/e2e_libfuncs/nullable_aegis/match_nullable.sierra
+++ b/Aegis/Tests/e2e_libfuncs/nullable_aegis/match_nullable.sierra
@@ -1,0 +1,19 @@
+type Nullable<felt252> = Nullable<felt252> [storable: true, drop: true, dup: true, zero_sized: false];
+type Box<felt252> = Box<felt252> [storable: true, drop: true, dup: true, zero_sized: false];
+type felt252 = felt252 [storable: true, drop: true, dup: true, zero_sized: false];
+
+libfunc match_nullable<felt252> = match_nullable<felt252>;
+libfunc branch_align = branch_align;
+libfunc store_temp<Box<felt252>> = store_temp<Box<felt252>>;
+libfunc drop<Box<felt252>> = drop<Box<felt252>>;
+
+match_nullable<felt252>([0]) { fallthrough() 4([2]) }; // 0
+branch_align() -> (); // 1
+store_temp<Box<felt252>>([1]) -> ([1]); // 2
+return([1]); // 3
+branch_align() -> (); // 4
+drop<Box<felt252>>([1]) -> (); // 5
+store_temp<Box<felt252>>([2]) -> ([2]); // 6
+return([2]); // 7
+
+test::foo@0([0]: Nullable<felt252>, [1]: Box<felt252>) -> (Box<felt252>);

--- a/Aegis/Tests/e2e_libfuncs/nullable_aegis/null.sierra
+++ b/Aegis/Tests/e2e_libfuncs/nullable_aegis/null.sierra
@@ -1,0 +1,11 @@
+type Nullable<felt252> = Nullable<felt252> [storable: true, drop: true, dup: true, zero_sized: false];
+type felt252 = felt252 [storable: true, drop: true, dup: true, zero_sized: false];
+
+libfunc null<felt252> = null<felt252>;
+libfunc store_temp<Nullable<felt252>> = store_temp<Nullable<felt252>>;
+
+null<felt252>() -> ([0]); // 0
+store_temp<Nullable<felt252>>([0]) -> ([0]); // 1
+return([0]); // 2
+
+test::foo@0() -> (Nullable<felt252>);

--- a/Aegis/Tests/e2e_libfuncs/nullable_aegis/nullable snapshot matching.sierra
+++ b/Aegis/Tests/e2e_libfuncs/nullable_aegis/nullable snapshot matching.sierra
@@ -1,0 +1,25 @@
+type Nullable<Array<felt252>> = Nullable<Array<felt252>> [storable: true, drop: true, dup: false, zero_sized: false];
+type Snapshot<Nullable<Array<felt252>>> = Snapshot<Nullable<Array<felt252>>> [storable: true, drop: true, dup: true, zero_sized: false];
+type Box<Snapshot<Array<felt252>>> = Box<Snapshot<Array<felt252>>> [storable: true, drop: true, dup: true, zero_sized: false];
+type Array<felt252> = Array<felt252> [storable: true, drop: true, dup: false, zero_sized: false];
+type Snapshot<Array<felt252>> = Snapshot<Array<felt252>> [storable: true, drop: true, dup: true, zero_sized: false];
+type felt252 = felt252 [storable: true, drop: true, dup: true, zero_sized: false];
+type Nullable<Snapshot<Array<felt252>>> = Nullable<Snapshot<Array<felt252>>> [storable: true, drop: true, dup: true, zero_sized: false];
+
+libfunc nullable_forward_snapshot<Array<felt252>> = nullable_forward_snapshot<Array<felt252>>;
+libfunc match_nullable<Snapshot<Array<felt252>>> = match_nullable<Snapshot<Array<felt252>>>;
+libfunc branch_align = branch_align;
+libfunc store_temp<Box<Snapshot<Array<felt252>>>> = store_temp<Box<Snapshot<Array<felt252>>>>;
+libfunc drop<Box<Snapshot<Array<felt252>>>> = drop<Box<Snapshot<Array<felt252>>>>;
+
+nullable_forward_snapshot<Array<felt252>>([0]) -> ([2]); // 0
+match_nullable<Snapshot<Array<felt252>>>([2]) { fallthrough() 5([3]) }; // 1
+branch_align() -> (); // 2
+store_temp<Box<Snapshot<Array<felt252>>>>([1]) -> ([1]); // 3
+return([1]); // 4
+branch_align() -> (); // 5
+drop<Box<Snapshot<Array<felt252>>>>([1]) -> (); // 6
+store_temp<Box<Snapshot<Array<felt252>>>>([3]) -> ([3]); // 7
+return([3]); // 8
+
+test::foo@0([0]: Snapshot<Nullable<Array<felt252>>>, [1]: Box<Snapshot<Array<felt252>>>) -> (Box<Snapshot<Array<felt252>>>);

--- a/Aegis/Tests/e2e_libfuncs/nullable_aegis/nullable.sierra
+++ b/Aegis/Tests/e2e_libfuncs/nullable_aegis/nullable.sierra
@@ -1,0 +1,30 @@
+type Unit = Struct<ut@Tuple> [storable: true, drop: true, dup: true, zero_sized: true];
+type felt252 = felt252 [storable: true, drop: true, dup: true, zero_sized: false];
+type Nullable<Unit> = Nullable<Unit> [storable: true, drop: true, dup: true, zero_sized: false];
+type Box<Unit> = Box<Unit> [storable: true, drop: true, dup: true, zero_sized: false];
+
+libfunc struct_construct<Unit> = struct_construct<Unit>;
+libfunc into_box<Unit> = into_box<Unit>;
+libfunc nullable_from_box<Unit> = nullable_from_box<Unit>;
+libfunc match_nullable<Unit> = match_nullable<Unit>;
+libfunc branch_align = branch_align;
+libfunc felt252_const<0> = felt252_const<0>;
+libfunc store_temp<felt252> = store_temp<felt252>;
+libfunc drop<Box<Unit>> = drop<Box<Unit>>;
+libfunc felt252_const<1> = felt252_const<1>;
+
+struct_construct<Unit>() -> ([0]); // 0
+into_box<Unit>([0]) -> ([1]); // 1
+nullable_from_box<Unit>([1]) -> ([2]); // 2
+match_nullable<Unit>([2]) { fallthrough() 8([3]) }; // 3
+branch_align() -> (); // 4
+felt252_const<0>() -> ([4]); // 5
+store_temp<felt252>([4]) -> ([4]); // 6
+return([4]); // 7
+branch_align() -> (); // 8
+drop<Box<Unit>>([3]) -> (); // 9
+felt252_const<1>() -> ([5]); // 10
+store_temp<felt252>([5]) -> ([5]); // 11
+return([5]); // 12
+
+test::foo@0() -> (felt252);

--- a/Aegis/Tests/e2e_libfuncs/nullable_aegis/nullable_forward_snapshot.sierra
+++ b/Aegis/Tests/e2e_libfuncs/nullable_aegis/nullable_forward_snapshot.sierra
@@ -1,0 +1,15 @@
+type Nullable<Array<felt252>> = Nullable<Array<felt252>> [storable: true, drop: true, dup: false, zero_sized: false];
+type Snapshot<Nullable<Array<felt252>>> = Snapshot<Nullable<Array<felt252>>> [storable: true, drop: true, dup: true, zero_sized: false];
+type Nullable<Snapshot<Array<felt252>>> = Nullable<Snapshot<Array<felt252>>> [storable: true, drop: true, dup: true, zero_sized: false];
+type Array<felt252> = Array<felt252> [storable: true, drop: true, dup: false, zero_sized: false];
+type Snapshot<Array<felt252>> = Snapshot<Array<felt252>> [storable: true, drop: true, dup: true, zero_sized: false];
+type felt252 = felt252 [storable: true, drop: true, dup: true, zero_sized: false];
+
+libfunc nullable_forward_snapshot<Array<felt252>> = nullable_forward_snapshot<Array<felt252>>;
+libfunc store_temp<Nullable<Snapshot<Array<felt252>>>> = store_temp<Nullable<Snapshot<Array<felt252>>>>;
+
+nullable_forward_snapshot<Array<felt252>>([0]) -> ([1]); // 0
+store_temp<Nullable<Snapshot<Array<felt252>>>>([1]) -> ([1]); // 1
+return([1]); // 2
+
+test::foo@0([0]: Snapshot<Nullable<Array<felt252>>>) -> (Nullable<Snapshot<Array<felt252>>>);

--- a/Aegis/Tests/e2e_libfuncs/nullable_aegis/nullable_from_box.sierra
+++ b/Aegis/Tests/e2e_libfuncs/nullable_aegis/nullable_from_box.sierra
@@ -1,0 +1,12 @@
+type Box<felt252> = Box<felt252> [storable: true, drop: true, dup: true, zero_sized: false];
+type Nullable<felt252> = Nullable<felt252> [storable: true, drop: true, dup: true, zero_sized: false];
+type felt252 = felt252 [storable: true, drop: true, dup: true, zero_sized: false];
+
+libfunc nullable_from_box<felt252> = nullable_from_box<felt252>;
+libfunc store_temp<Nullable<felt252>> = store_temp<Nullable<felt252>>;
+
+nullable_from_box<felt252>([0]) -> ([1]); // 0
+store_temp<Nullable<felt252>>([1]) -> ([1]); // 1
+return([1]); // 2
+
+test::foo@0([0]: Box<felt252>) -> (Nullable<felt252>);

--- a/Aegis/Tests/e2e_libfuncs/poseidon_aegis/hades_permutation.sierra
+++ b/Aegis/Tests/e2e_libfuncs/poseidon_aegis/hades_permutation.sierra
@@ -1,0 +1,16 @@
+type Poseidon = Poseidon [storable: true, drop: false, dup: false, zero_sized: false];
+type felt252 = felt252 [storable: true, drop: true, dup: true, zero_sized: false];
+type Tuple<felt252, felt252, felt252> = Struct<ut@Tuple, felt252, felt252, felt252> [storable: true, drop: true, dup: true, zero_sized: false];
+
+libfunc hades_permutation = hades_permutation;
+libfunc struct_construct<Tuple<felt252, felt252, felt252>> = struct_construct<Tuple<felt252, felt252, felt252>>;
+libfunc store_temp<Poseidon> = store_temp<Poseidon>;
+libfunc store_temp<Tuple<felt252, felt252, felt252>> = store_temp<Tuple<felt252, felt252, felt252>>;
+
+hades_permutation([0], [1], [2], [3]) -> ([4], [5], [6], [7]); // 0
+struct_construct<Tuple<felt252, felt252, felt252>>([5], [6], [7]) -> ([8]); // 1
+store_temp<Poseidon>([4]) -> ([4]); // 2
+store_temp<Tuple<felt252, felt252, felt252>>([8]) -> ([8]); // 3
+return([4], [8]); // 4
+
+test::foo@0([0]: Poseidon, [1]: felt252, [2]: felt252, [3]: felt252) -> (Poseidon, Tuple<felt252, felt252, felt252>);

--- a/Aegis/Tests/e2e_libfuncs/secp256k1_aegis/secp256k1_add_syscall.sierra
+++ b/Aegis/Tests/e2e_libfuncs/secp256k1_aegis/secp256k1_add_syscall.sierra
@@ -1,0 +1,30 @@
+type GasBuiltin = GasBuiltin [storable: true, drop: false, dup: false, zero_sized: false];
+type Secp256k1Point = Secp256k1Point [storable: true, drop: true, dup: true, zero_sized: false];
+type Array<felt252> = Array<felt252> [storable: true, drop: true, dup: false, zero_sized: false];
+type core::result::Result::<core::starknet::secp256k1::Secp256k1Point, core::array::Array::<core::felt252>> = Enum<ut@core::result::Result::<core::starknet::secp256k1::Secp256k1Point, core::array::Array::<core::felt252>>, Secp256k1Point, Array<felt252>> [storable: true, drop: true, dup: false, zero_sized: false];
+type felt252 = felt252 [storable: true, drop: true, dup: true, zero_sized: false];
+type System = System [storable: true, drop: false, dup: false, zero_sized: false];
+
+libfunc secp256k1_add_syscall = secp256k1_add_syscall;
+libfunc branch_align = branch_align;
+libfunc enum_init<core::result::Result::<core::starknet::secp256k1::Secp256k1Point, core::array::Array::<core::felt252>>, 0> = enum_init<core::result::Result::<core::starknet::secp256k1::Secp256k1Point, core::array::Array::<core::felt252>>, 0>;
+libfunc store_temp<GasBuiltin> = store_temp<GasBuiltin>;
+libfunc store_temp<System> = store_temp<System>;
+libfunc store_temp<core::result::Result::<core::starknet::secp256k1::Secp256k1Point, core::array::Array::<core::felt252>>> = store_temp<core::result::Result::<core::starknet::secp256k1::Secp256k1Point, core::array::Array::<core::felt252>>>;
+libfunc enum_init<core::result::Result::<core::starknet::secp256k1::Secp256k1Point, core::array::Array::<core::felt252>>, 1> = enum_init<core::result::Result::<core::starknet::secp256k1::Secp256k1Point, core::array::Array::<core::felt252>>, 1>;
+
+secp256k1_add_syscall([0], [1], [2], [3]) { fallthrough([4], [5], [6]) 7([7], [8], [9]) }; // 0
+branch_align() -> (); // 1
+enum_init<core::result::Result::<core::starknet::secp256k1::Secp256k1Point, core::array::Array::<core::felt252>>, 0>([6]) -> ([10]); // 2
+store_temp<GasBuiltin>([4]) -> ([4]); // 3
+store_temp<System>([5]) -> ([5]); // 4
+store_temp<core::result::Result::<core::starknet::secp256k1::Secp256k1Point, core::array::Array::<core::felt252>>>([10]) -> ([10]); // 5
+return([4], [5], [10]); // 6
+branch_align() -> (); // 7
+enum_init<core::result::Result::<core::starknet::secp256k1::Secp256k1Point, core::array::Array::<core::felt252>>, 1>([9]) -> ([11]); // 8
+store_temp<GasBuiltin>([7]) -> ([7]); // 9
+store_temp<System>([8]) -> ([8]); // 10
+store_temp<core::result::Result::<core::starknet::secp256k1::Secp256k1Point, core::array::Array::<core::felt252>>>([11]) -> ([11]); // 11
+return([7], [8], [11]); // 12
+
+test::foo@0([0]: GasBuiltin, [1]: System, [2]: Secp256k1Point, [3]: Secp256k1Point) -> (GasBuiltin, System, core::result::Result::<core::starknet::secp256k1::Secp256k1Point, core::array::Array::<core::felt252>>);

--- a/Aegis/Tests/e2e_libfuncs/secp256k1_aegis/secp256k1_get_point_from_x_syscall.sierra
+++ b/Aegis/Tests/e2e_libfuncs/secp256k1_aegis/secp256k1_get_point_from_x_syscall.sierra
@@ -1,0 +1,35 @@
+type GasBuiltin = GasBuiltin [storable: true, drop: false, dup: false, zero_sized: false];
+type Secp256k1Point = Secp256k1Point [storable: true, drop: true, dup: true, zero_sized: false];
+type Unit = Struct<ut@Tuple> [storable: true, drop: true, dup: true, zero_sized: true];
+type core::option::Option::<core::starknet::secp256k1::Secp256k1Point> = Enum<ut@core::option::Option::<core::starknet::secp256k1::Secp256k1Point>, Secp256k1Point, Unit> [storable: true, drop: true, dup: true, zero_sized: false];
+type Array<felt252> = Array<felt252> [storable: true, drop: true, dup: false, zero_sized: false];
+type core::result::Result::<core::option::Option::<core::starknet::secp256k1::Secp256k1Point>, core::array::Array::<core::felt252>> = Enum<ut@core::result::Result::<core::option::Option::<core::starknet::secp256k1::Secp256k1Point>, core::array::Array::<core::felt252>>, core::option::Option::<core::starknet::secp256k1::Secp256k1Point>, Array<felt252>> [storable: true, drop: true, dup: false, zero_sized: false];
+type felt252 = felt252 [storable: true, drop: true, dup: true, zero_sized: false];
+type core::bool = Enum<ut@core::bool, Unit, Unit> [storable: true, drop: true, dup: true, zero_sized: false];
+type u128 = u128 [storable: true, drop: true, dup: true, zero_sized: false];
+type core::integer::u256 = Struct<ut@core::integer::u256, u128, u128> [storable: true, drop: true, dup: true, zero_sized: false];
+type System = System [storable: true, drop: false, dup: false, zero_sized: false];
+
+libfunc secp256k1_get_point_from_x_syscall = secp256k1_get_point_from_x_syscall;
+libfunc branch_align = branch_align;
+libfunc enum_init<core::result::Result::<core::option::Option::<core::starknet::secp256k1::Secp256k1Point>, core::array::Array::<core::felt252>>, 0> = enum_init<core::result::Result::<core::option::Option::<core::starknet::secp256k1::Secp256k1Point>, core::array::Array::<core::felt252>>, 0>;
+libfunc store_temp<GasBuiltin> = store_temp<GasBuiltin>;
+libfunc store_temp<System> = store_temp<System>;
+libfunc store_temp<core::result::Result::<core::option::Option::<core::starknet::secp256k1::Secp256k1Point>, core::array::Array::<core::felt252>>> = store_temp<core::result::Result::<core::option::Option::<core::starknet::secp256k1::Secp256k1Point>, core::array::Array::<core::felt252>>>;
+libfunc enum_init<core::result::Result::<core::option::Option::<core::starknet::secp256k1::Secp256k1Point>, core::array::Array::<core::felt252>>, 1> = enum_init<core::result::Result::<core::option::Option::<core::starknet::secp256k1::Secp256k1Point>, core::array::Array::<core::felt252>>, 1>;
+
+secp256k1_get_point_from_x_syscall([0], [1], [2], [3]) { fallthrough([4], [5], [6]) 7([7], [8], [9]) }; // 0
+branch_align() -> (); // 1
+enum_init<core::result::Result::<core::option::Option::<core::starknet::secp256k1::Secp256k1Point>, core::array::Array::<core::felt252>>, 0>([6]) -> ([10]); // 2
+store_temp<GasBuiltin>([4]) -> ([4]); // 3
+store_temp<System>([5]) -> ([5]); // 4
+store_temp<core::result::Result::<core::option::Option::<core::starknet::secp256k1::Secp256k1Point>, core::array::Array::<core::felt252>>>([10]) -> ([10]); // 5
+return([4], [5], [10]); // 6
+branch_align() -> (); // 7
+enum_init<core::result::Result::<core::option::Option::<core::starknet::secp256k1::Secp256k1Point>, core::array::Array::<core::felt252>>, 1>([9]) -> ([11]); // 8
+store_temp<GasBuiltin>([7]) -> ([7]); // 9
+store_temp<System>([8]) -> ([8]); // 10
+store_temp<core::result::Result::<core::option::Option::<core::starknet::secp256k1::Secp256k1Point>, core::array::Array::<core::felt252>>>([11]) -> ([11]); // 11
+return([7], [8], [11]); // 12
+
+test::foo@0([0]: GasBuiltin, [1]: System, [2]: core::integer::u256, [3]: core::bool) -> (GasBuiltin, System, core::result::Result::<core::option::Option::<core::starknet::secp256k1::Secp256k1Point>, core::array::Array::<core::felt252>>);

--- a/Aegis/Tests/e2e_libfuncs/secp256k1_aegis/secp256k1_get_xy_syscall.sierra
+++ b/Aegis/Tests/e2e_libfuncs/secp256k1_aegis/secp256k1_get_xy_syscall.sierra
@@ -1,0 +1,35 @@
+type GasBuiltin = GasBuiltin [storable: true, drop: false, dup: false, zero_sized: false];
+type u128 = u128 [storable: true, drop: true, dup: true, zero_sized: false];
+type core::integer::u256 = Struct<ut@core::integer::u256, u128, u128> [storable: true, drop: true, dup: true, zero_sized: false];
+type Tuple<core::integer::u256, core::integer::u256> = Struct<ut@Tuple, core::integer::u256, core::integer::u256> [storable: true, drop: true, dup: true, zero_sized: false];
+type Array<felt252> = Array<felt252> [storable: true, drop: true, dup: false, zero_sized: false];
+type core::result::Result::<(core::integer::u256, core::integer::u256), core::array::Array::<core::felt252>> = Enum<ut@core::result::Result::<(core::integer::u256, core::integer::u256), core::array::Array::<core::felt252>>, Tuple<core::integer::u256, core::integer::u256>, Array<felt252>> [storable: true, drop: true, dup: false, zero_sized: false];
+type felt252 = felt252 [storable: true, drop: true, dup: true, zero_sized: false];
+type Secp256k1Point = Secp256k1Point [storable: true, drop: true, dup: true, zero_sized: false];
+type System = System [storable: true, drop: false, dup: false, zero_sized: false];
+
+libfunc secp256k1_get_xy_syscall = secp256k1_get_xy_syscall;
+libfunc branch_align = branch_align;
+libfunc struct_construct<Tuple<core::integer::u256, core::integer::u256>> = struct_construct<Tuple<core::integer::u256, core::integer::u256>>;
+libfunc enum_init<core::result::Result::<(core::integer::u256, core::integer::u256), core::array::Array::<core::felt252>>, 0> = enum_init<core::result::Result::<(core::integer::u256, core::integer::u256), core::array::Array::<core::felt252>>, 0>;
+libfunc store_temp<GasBuiltin> = store_temp<GasBuiltin>;
+libfunc store_temp<System> = store_temp<System>;
+libfunc store_temp<core::result::Result::<(core::integer::u256, core::integer::u256), core::array::Array::<core::felt252>>> = store_temp<core::result::Result::<(core::integer::u256, core::integer::u256), core::array::Array::<core::felt252>>>;
+libfunc enum_init<core::result::Result::<(core::integer::u256, core::integer::u256), core::array::Array::<core::felt252>>, 1> = enum_init<core::result::Result::<(core::integer::u256, core::integer::u256), core::array::Array::<core::felt252>>, 1>;
+
+secp256k1_get_xy_syscall([0], [1], [2]) { fallthrough([3], [4], [5], [6]) 8([7], [8], [9]) }; // 0
+branch_align() -> (); // 1
+struct_construct<Tuple<core::integer::u256, core::integer::u256>>([5], [6]) -> ([10]); // 2
+enum_init<core::result::Result::<(core::integer::u256, core::integer::u256), core::array::Array::<core::felt252>>, 0>([10]) -> ([11]); // 3
+store_temp<GasBuiltin>([3]) -> ([3]); // 4
+store_temp<System>([4]) -> ([4]); // 5
+store_temp<core::result::Result::<(core::integer::u256, core::integer::u256), core::array::Array::<core::felt252>>>([11]) -> ([11]); // 6
+return([3], [4], [11]); // 7
+branch_align() -> (); // 8
+enum_init<core::result::Result::<(core::integer::u256, core::integer::u256), core::array::Array::<core::felt252>>, 1>([9]) -> ([12]); // 9
+store_temp<GasBuiltin>([7]) -> ([7]); // 10
+store_temp<System>([8]) -> ([8]); // 11
+store_temp<core::result::Result::<(core::integer::u256, core::integer::u256), core::array::Array::<core::felt252>>>([12]) -> ([12]); // 12
+return([7], [8], [12]); // 13
+
+test::foo@0([0]: GasBuiltin, [1]: System, [2]: Secp256k1Point) -> (GasBuiltin, System, core::result::Result::<(core::integer::u256, core::integer::u256), core::array::Array::<core::felt252>>);

--- a/Aegis/Tests/e2e_libfuncs/secp256k1_aegis/secp256k1_mul_syscall.sierra
+++ b/Aegis/Tests/e2e_libfuncs/secp256k1_aegis/secp256k1_mul_syscall.sierra
@@ -1,0 +1,32 @@
+type GasBuiltin = GasBuiltin [storable: true, drop: false, dup: false, zero_sized: false];
+type Secp256k1Point = Secp256k1Point [storable: true, drop: true, dup: true, zero_sized: false];
+type Array<felt252> = Array<felt252> [storable: true, drop: true, dup: false, zero_sized: false];
+type core::result::Result::<core::starknet::secp256k1::Secp256k1Point, core::array::Array::<core::felt252>> = Enum<ut@core::result::Result::<core::starknet::secp256k1::Secp256k1Point, core::array::Array::<core::felt252>>, Secp256k1Point, Array<felt252>> [storable: true, drop: true, dup: false, zero_sized: false];
+type felt252 = felt252 [storable: true, drop: true, dup: true, zero_sized: false];
+type u128 = u128 [storable: true, drop: true, dup: true, zero_sized: false];
+type core::integer::u256 = Struct<ut@core::integer::u256, u128, u128> [storable: true, drop: true, dup: true, zero_sized: false];
+type System = System [storable: true, drop: false, dup: false, zero_sized: false];
+
+libfunc secp256k1_mul_syscall = secp256k1_mul_syscall;
+libfunc branch_align = branch_align;
+libfunc enum_init<core::result::Result::<core::starknet::secp256k1::Secp256k1Point, core::array::Array::<core::felt252>>, 0> = enum_init<core::result::Result::<core::starknet::secp256k1::Secp256k1Point, core::array::Array::<core::felt252>>, 0>;
+libfunc store_temp<GasBuiltin> = store_temp<GasBuiltin>;
+libfunc store_temp<System> = store_temp<System>;
+libfunc store_temp<core::result::Result::<core::starknet::secp256k1::Secp256k1Point, core::array::Array::<core::felt252>>> = store_temp<core::result::Result::<core::starknet::secp256k1::Secp256k1Point, core::array::Array::<core::felt252>>>;
+libfunc enum_init<core::result::Result::<core::starknet::secp256k1::Secp256k1Point, core::array::Array::<core::felt252>>, 1> = enum_init<core::result::Result::<core::starknet::secp256k1::Secp256k1Point, core::array::Array::<core::felt252>>, 1>;
+
+secp256k1_mul_syscall([0], [1], [2], [3]) { fallthrough([4], [5], [6]) 7([7], [8], [9]) }; // 0
+branch_align() -> (); // 1
+enum_init<core::result::Result::<core::starknet::secp256k1::Secp256k1Point, core::array::Array::<core::felt252>>, 0>([6]) -> ([10]); // 2
+store_temp<GasBuiltin>([4]) -> ([4]); // 3
+store_temp<System>([5]) -> ([5]); // 4
+store_temp<core::result::Result::<core::starknet::secp256k1::Secp256k1Point, core::array::Array::<core::felt252>>>([10]) -> ([10]); // 5
+return([4], [5], [10]); // 6
+branch_align() -> (); // 7
+enum_init<core::result::Result::<core::starknet::secp256k1::Secp256k1Point, core::array::Array::<core::felt252>>, 1>([9]) -> ([11]); // 8
+store_temp<GasBuiltin>([7]) -> ([7]); // 9
+store_temp<System>([8]) -> ([8]); // 10
+store_temp<core::result::Result::<core::starknet::secp256k1::Secp256k1Point, core::array::Array::<core::felt252>>>([11]) -> ([11]); // 11
+return([7], [8], [11]); // 12
+
+test::foo@0([0]: GasBuiltin, [1]: System, [2]: Secp256k1Point, [3]: core::integer::u256) -> (GasBuiltin, System, core::result::Result::<core::starknet::secp256k1::Secp256k1Point, core::array::Array::<core::felt252>>);

--- a/Aegis/Tests/e2e_libfuncs/secp256k1_aegis/secp256k1_new_syscall.sierra
+++ b/Aegis/Tests/e2e_libfuncs/secp256k1_aegis/secp256k1_new_syscall.sierra
@@ -1,0 +1,34 @@
+type GasBuiltin = GasBuiltin [storable: true, drop: false, dup: false, zero_sized: false];
+type Secp256k1Point = Secp256k1Point [storable: true, drop: true, dup: true, zero_sized: false];
+type Unit = Struct<ut@Tuple> [storable: true, drop: true, dup: true, zero_sized: true];
+type core::option::Option::<core::starknet::secp256k1::Secp256k1Point> = Enum<ut@core::option::Option::<core::starknet::secp256k1::Secp256k1Point>, Secp256k1Point, Unit> [storable: true, drop: true, dup: true, zero_sized: false];
+type Array<felt252> = Array<felt252> [storable: true, drop: true, dup: false, zero_sized: false];
+type core::result::Result::<core::option::Option::<core::starknet::secp256k1::Secp256k1Point>, core::array::Array::<core::felt252>> = Enum<ut@core::result::Result::<core::option::Option::<core::starknet::secp256k1::Secp256k1Point>, core::array::Array::<core::felt252>>, core::option::Option::<core::starknet::secp256k1::Secp256k1Point>, Array<felt252>> [storable: true, drop: true, dup: false, zero_sized: false];
+type felt252 = felt252 [storable: true, drop: true, dup: true, zero_sized: false];
+type u128 = u128 [storable: true, drop: true, dup: true, zero_sized: false];
+type core::integer::u256 = Struct<ut@core::integer::u256, u128, u128> [storable: true, drop: true, dup: true, zero_sized: false];
+type System = System [storable: true, drop: false, dup: false, zero_sized: false];
+
+libfunc secp256k1_new_syscall = secp256k1_new_syscall;
+libfunc branch_align = branch_align;
+libfunc enum_init<core::result::Result::<core::option::Option::<core::starknet::secp256k1::Secp256k1Point>, core::array::Array::<core::felt252>>, 0> = enum_init<core::result::Result::<core::option::Option::<core::starknet::secp256k1::Secp256k1Point>, core::array::Array::<core::felt252>>, 0>;
+libfunc store_temp<GasBuiltin> = store_temp<GasBuiltin>;
+libfunc store_temp<System> = store_temp<System>;
+libfunc store_temp<core::result::Result::<core::option::Option::<core::starknet::secp256k1::Secp256k1Point>, core::array::Array::<core::felt252>>> = store_temp<core::result::Result::<core::option::Option::<core::starknet::secp256k1::Secp256k1Point>, core::array::Array::<core::felt252>>>;
+libfunc enum_init<core::result::Result::<core::option::Option::<core::starknet::secp256k1::Secp256k1Point>, core::array::Array::<core::felt252>>, 1> = enum_init<core::result::Result::<core::option::Option::<core::starknet::secp256k1::Secp256k1Point>, core::array::Array::<core::felt252>>, 1>;
+
+secp256k1_new_syscall([0], [1], [2], [3]) { fallthrough([4], [5], [6]) 7([7], [8], [9]) }; // 0
+branch_align() -> (); // 1
+enum_init<core::result::Result::<core::option::Option::<core::starknet::secp256k1::Secp256k1Point>, core::array::Array::<core::felt252>>, 0>([6]) -> ([10]); // 2
+store_temp<GasBuiltin>([4]) -> ([4]); // 3
+store_temp<System>([5]) -> ([5]); // 4
+store_temp<core::result::Result::<core::option::Option::<core::starknet::secp256k1::Secp256k1Point>, core::array::Array::<core::felt252>>>([10]) -> ([10]); // 5
+return([4], [5], [10]); // 6
+branch_align() -> (); // 7
+enum_init<core::result::Result::<core::option::Option::<core::starknet::secp256k1::Secp256k1Point>, core::array::Array::<core::felt252>>, 1>([9]) -> ([11]); // 8
+store_temp<GasBuiltin>([7]) -> ([7]); // 9
+store_temp<System>([8]) -> ([8]); // 10
+store_temp<core::result::Result::<core::option::Option::<core::starknet::secp256k1::Secp256k1Point>, core::array::Array::<core::felt252>>>([11]) -> ([11]); // 11
+return([7], [8], [11]); // 12
+
+test::foo@0([0]: GasBuiltin, [1]: System, [2]: core::integer::u256, [3]: core::integer::u256) -> (GasBuiltin, System, core::result::Result::<core::option::Option::<core::starknet::secp256k1::Secp256k1Point>, core::array::Array::<core::felt252>>);

--- a/Aegis/Tests/e2e_libfuncs/secp256r1_aegis/secp256r1_add_syscall.sierra
+++ b/Aegis/Tests/e2e_libfuncs/secp256r1_aegis/secp256r1_add_syscall.sierra
@@ -1,0 +1,30 @@
+type GasBuiltin = GasBuiltin [storable: true, drop: false, dup: false, zero_sized: false];
+type Secp256r1Point = Secp256r1Point [storable: true, drop: true, dup: true, zero_sized: false];
+type Array<felt252> = Array<felt252> [storable: true, drop: true, dup: false, zero_sized: false];
+type core::result::Result::<core::starknet::secp256r1::Secp256r1Point, core::array::Array::<core::felt252>> = Enum<ut@core::result::Result::<core::starknet::secp256r1::Secp256r1Point, core::array::Array::<core::felt252>>, Secp256r1Point, Array<felt252>> [storable: true, drop: true, dup: false, zero_sized: false];
+type felt252 = felt252 [storable: true, drop: true, dup: true, zero_sized: false];
+type System = System [storable: true, drop: false, dup: false, zero_sized: false];
+
+libfunc secp256r1_add_syscall = secp256r1_add_syscall;
+libfunc branch_align = branch_align;
+libfunc enum_init<core::result::Result::<core::starknet::secp256r1::Secp256r1Point, core::array::Array::<core::felt252>>, 0> = enum_init<core::result::Result::<core::starknet::secp256r1::Secp256r1Point, core::array::Array::<core::felt252>>, 0>;
+libfunc store_temp<GasBuiltin> = store_temp<GasBuiltin>;
+libfunc store_temp<System> = store_temp<System>;
+libfunc store_temp<core::result::Result::<core::starknet::secp256r1::Secp256r1Point, core::array::Array::<core::felt252>>> = store_temp<core::result::Result::<core::starknet::secp256r1::Secp256r1Point, core::array::Array::<core::felt252>>>;
+libfunc enum_init<core::result::Result::<core::starknet::secp256r1::Secp256r1Point, core::array::Array::<core::felt252>>, 1> = enum_init<core::result::Result::<core::starknet::secp256r1::Secp256r1Point, core::array::Array::<core::felt252>>, 1>;
+
+secp256r1_add_syscall([0], [1], [2], [3]) { fallthrough([4], [5], [6]) 7([7], [8], [9]) }; // 0
+branch_align() -> (); // 1
+enum_init<core::result::Result::<core::starknet::secp256r1::Secp256r1Point, core::array::Array::<core::felt252>>, 0>([6]) -> ([10]); // 2
+store_temp<GasBuiltin>([4]) -> ([4]); // 3
+store_temp<System>([5]) -> ([5]); // 4
+store_temp<core::result::Result::<core::starknet::secp256r1::Secp256r1Point, core::array::Array::<core::felt252>>>([10]) -> ([10]); // 5
+return([4], [5], [10]); // 6
+branch_align() -> (); // 7
+enum_init<core::result::Result::<core::starknet::secp256r1::Secp256r1Point, core::array::Array::<core::felt252>>, 1>([9]) -> ([11]); // 8
+store_temp<GasBuiltin>([7]) -> ([7]); // 9
+store_temp<System>([8]) -> ([8]); // 10
+store_temp<core::result::Result::<core::starknet::secp256r1::Secp256r1Point, core::array::Array::<core::felt252>>>([11]) -> ([11]); // 11
+return([7], [8], [11]); // 12
+
+test::foo@0([0]: GasBuiltin, [1]: System, [2]: Secp256r1Point, [3]: Secp256r1Point) -> (GasBuiltin, System, core::result::Result::<core::starknet::secp256r1::Secp256r1Point, core::array::Array::<core::felt252>>);

--- a/Aegis/Tests/e2e_libfuncs/secp256r1_aegis/secp256r1_get_point_from_x_syscall.sierra
+++ b/Aegis/Tests/e2e_libfuncs/secp256r1_aegis/secp256r1_get_point_from_x_syscall.sierra
@@ -1,0 +1,35 @@
+type GasBuiltin = GasBuiltin [storable: true, drop: false, dup: false, zero_sized: false];
+type Secp256r1Point = Secp256r1Point [storable: true, drop: true, dup: true, zero_sized: false];
+type Unit = Struct<ut@Tuple> [storable: true, drop: true, dup: true, zero_sized: true];
+type core::option::Option::<core::starknet::secp256r1::Secp256r1Point> = Enum<ut@core::option::Option::<core::starknet::secp256r1::Secp256r1Point>, Secp256r1Point, Unit> [storable: true, drop: true, dup: true, zero_sized: false];
+type Array<felt252> = Array<felt252> [storable: true, drop: true, dup: false, zero_sized: false];
+type core::result::Result::<core::option::Option::<core::starknet::secp256r1::Secp256r1Point>, core::array::Array::<core::felt252>> = Enum<ut@core::result::Result::<core::option::Option::<core::starknet::secp256r1::Secp256r1Point>, core::array::Array::<core::felt252>>, core::option::Option::<core::starknet::secp256r1::Secp256r1Point>, Array<felt252>> [storable: true, drop: true, dup: false, zero_sized: false];
+type felt252 = felt252 [storable: true, drop: true, dup: true, zero_sized: false];
+type core::bool = Enum<ut@core::bool, Unit, Unit> [storable: true, drop: true, dup: true, zero_sized: false];
+type u128 = u128 [storable: true, drop: true, dup: true, zero_sized: false];
+type core::integer::u256 = Struct<ut@core::integer::u256, u128, u128> [storable: true, drop: true, dup: true, zero_sized: false];
+type System = System [storable: true, drop: false, dup: false, zero_sized: false];
+
+libfunc secp256r1_get_point_from_x_syscall = secp256r1_get_point_from_x_syscall;
+libfunc branch_align = branch_align;
+libfunc enum_init<core::result::Result::<core::option::Option::<core::starknet::secp256r1::Secp256r1Point>, core::array::Array::<core::felt252>>, 0> = enum_init<core::result::Result::<core::option::Option::<core::starknet::secp256r1::Secp256r1Point>, core::array::Array::<core::felt252>>, 0>;
+libfunc store_temp<GasBuiltin> = store_temp<GasBuiltin>;
+libfunc store_temp<System> = store_temp<System>;
+libfunc store_temp<core::result::Result::<core::option::Option::<core::starknet::secp256r1::Secp256r1Point>, core::array::Array::<core::felt252>>> = store_temp<core::result::Result::<core::option::Option::<core::starknet::secp256r1::Secp256r1Point>, core::array::Array::<core::felt252>>>;
+libfunc enum_init<core::result::Result::<core::option::Option::<core::starknet::secp256r1::Secp256r1Point>, core::array::Array::<core::felt252>>, 1> = enum_init<core::result::Result::<core::option::Option::<core::starknet::secp256r1::Secp256r1Point>, core::array::Array::<core::felt252>>, 1>;
+
+secp256r1_get_point_from_x_syscall([0], [1], [2], [3]) { fallthrough([4], [5], [6]) 7([7], [8], [9]) }; // 0
+branch_align() -> (); // 1
+enum_init<core::result::Result::<core::option::Option::<core::starknet::secp256r1::Secp256r1Point>, core::array::Array::<core::felt252>>, 0>([6]) -> ([10]); // 2
+store_temp<GasBuiltin>([4]) -> ([4]); // 3
+store_temp<System>([5]) -> ([5]); // 4
+store_temp<core::result::Result::<core::option::Option::<core::starknet::secp256r1::Secp256r1Point>, core::array::Array::<core::felt252>>>([10]) -> ([10]); // 5
+return([4], [5], [10]); // 6
+branch_align() -> (); // 7
+enum_init<core::result::Result::<core::option::Option::<core::starknet::secp256r1::Secp256r1Point>, core::array::Array::<core::felt252>>, 1>([9]) -> ([11]); // 8
+store_temp<GasBuiltin>([7]) -> ([7]); // 9
+store_temp<System>([8]) -> ([8]); // 10
+store_temp<core::result::Result::<core::option::Option::<core::starknet::secp256r1::Secp256r1Point>, core::array::Array::<core::felt252>>>([11]) -> ([11]); // 11
+return([7], [8], [11]); // 12
+
+test::foo@0([0]: GasBuiltin, [1]: System, [2]: core::integer::u256, [3]: core::bool) -> (GasBuiltin, System, core::result::Result::<core::option::Option::<core::starknet::secp256r1::Secp256r1Point>, core::array::Array::<core::felt252>>);

--- a/Aegis/Tests/e2e_libfuncs/secp256r1_aegis/secp256r1_get_xy_syscall.sierra
+++ b/Aegis/Tests/e2e_libfuncs/secp256r1_aegis/secp256r1_get_xy_syscall.sierra
@@ -1,0 +1,35 @@
+type GasBuiltin = GasBuiltin [storable: true, drop: false, dup: false, zero_sized: false];
+type u128 = u128 [storable: true, drop: true, dup: true, zero_sized: false];
+type core::integer::u256 = Struct<ut@core::integer::u256, u128, u128> [storable: true, drop: true, dup: true, zero_sized: false];
+type Tuple<core::integer::u256, core::integer::u256> = Struct<ut@Tuple, core::integer::u256, core::integer::u256> [storable: true, drop: true, dup: true, zero_sized: false];
+type Array<felt252> = Array<felt252> [storable: true, drop: true, dup: false, zero_sized: false];
+type core::result::Result::<(core::integer::u256, core::integer::u256), core::array::Array::<core::felt252>> = Enum<ut@core::result::Result::<(core::integer::u256, core::integer::u256), core::array::Array::<core::felt252>>, Tuple<core::integer::u256, core::integer::u256>, Array<felt252>> [storable: true, drop: true, dup: false, zero_sized: false];
+type felt252 = felt252 [storable: true, drop: true, dup: true, zero_sized: false];
+type Secp256r1Point = Secp256r1Point [storable: true, drop: true, dup: true, zero_sized: false];
+type System = System [storable: true, drop: false, dup: false, zero_sized: false];
+
+libfunc secp256r1_get_xy_syscall = secp256r1_get_xy_syscall;
+libfunc branch_align = branch_align;
+libfunc struct_construct<Tuple<core::integer::u256, core::integer::u256>> = struct_construct<Tuple<core::integer::u256, core::integer::u256>>;
+libfunc enum_init<core::result::Result::<(core::integer::u256, core::integer::u256), core::array::Array::<core::felt252>>, 0> = enum_init<core::result::Result::<(core::integer::u256, core::integer::u256), core::array::Array::<core::felt252>>, 0>;
+libfunc store_temp<GasBuiltin> = store_temp<GasBuiltin>;
+libfunc store_temp<System> = store_temp<System>;
+libfunc store_temp<core::result::Result::<(core::integer::u256, core::integer::u256), core::array::Array::<core::felt252>>> = store_temp<core::result::Result::<(core::integer::u256, core::integer::u256), core::array::Array::<core::felt252>>>;
+libfunc enum_init<core::result::Result::<(core::integer::u256, core::integer::u256), core::array::Array::<core::felt252>>, 1> = enum_init<core::result::Result::<(core::integer::u256, core::integer::u256), core::array::Array::<core::felt252>>, 1>;
+
+secp256r1_get_xy_syscall([0], [1], [2]) { fallthrough([3], [4], [5], [6]) 8([7], [8], [9]) }; // 0
+branch_align() -> (); // 1
+struct_construct<Tuple<core::integer::u256, core::integer::u256>>([5], [6]) -> ([10]); // 2
+enum_init<core::result::Result::<(core::integer::u256, core::integer::u256), core::array::Array::<core::felt252>>, 0>([10]) -> ([11]); // 3
+store_temp<GasBuiltin>([3]) -> ([3]); // 4
+store_temp<System>([4]) -> ([4]); // 5
+store_temp<core::result::Result::<(core::integer::u256, core::integer::u256), core::array::Array::<core::felt252>>>([11]) -> ([11]); // 6
+return([3], [4], [11]); // 7
+branch_align() -> (); // 8
+enum_init<core::result::Result::<(core::integer::u256, core::integer::u256), core::array::Array::<core::felt252>>, 1>([9]) -> ([12]); // 9
+store_temp<GasBuiltin>([7]) -> ([7]); // 10
+store_temp<System>([8]) -> ([8]); // 11
+store_temp<core::result::Result::<(core::integer::u256, core::integer::u256), core::array::Array::<core::felt252>>>([12]) -> ([12]); // 12
+return([7], [8], [12]); // 13
+
+test::foo@0([0]: GasBuiltin, [1]: System, [2]: Secp256r1Point) -> (GasBuiltin, System, core::result::Result::<(core::integer::u256, core::integer::u256), core::array::Array::<core::felt252>>);

--- a/Aegis/Tests/e2e_libfuncs/secp256r1_aegis/secp256r1_mul_syscall.sierra
+++ b/Aegis/Tests/e2e_libfuncs/secp256r1_aegis/secp256r1_mul_syscall.sierra
@@ -1,0 +1,32 @@
+type GasBuiltin = GasBuiltin [storable: true, drop: false, dup: false, zero_sized: false];
+type Secp256r1Point = Secp256r1Point [storable: true, drop: true, dup: true, zero_sized: false];
+type Array<felt252> = Array<felt252> [storable: true, drop: true, dup: false, zero_sized: false];
+type core::result::Result::<core::starknet::secp256r1::Secp256r1Point, core::array::Array::<core::felt252>> = Enum<ut@core::result::Result::<core::starknet::secp256r1::Secp256r1Point, core::array::Array::<core::felt252>>, Secp256r1Point, Array<felt252>> [storable: true, drop: true, dup: false, zero_sized: false];
+type felt252 = felt252 [storable: true, drop: true, dup: true, zero_sized: false];
+type u128 = u128 [storable: true, drop: true, dup: true, zero_sized: false];
+type core::integer::u256 = Struct<ut@core::integer::u256, u128, u128> [storable: true, drop: true, dup: true, zero_sized: false];
+type System = System [storable: true, drop: false, dup: false, zero_sized: false];
+
+libfunc secp256r1_mul_syscall = secp256r1_mul_syscall;
+libfunc branch_align = branch_align;
+libfunc enum_init<core::result::Result::<core::starknet::secp256r1::Secp256r1Point, core::array::Array::<core::felt252>>, 0> = enum_init<core::result::Result::<core::starknet::secp256r1::Secp256r1Point, core::array::Array::<core::felt252>>, 0>;
+libfunc store_temp<GasBuiltin> = store_temp<GasBuiltin>;
+libfunc store_temp<System> = store_temp<System>;
+libfunc store_temp<core::result::Result::<core::starknet::secp256r1::Secp256r1Point, core::array::Array::<core::felt252>>> = store_temp<core::result::Result::<core::starknet::secp256r1::Secp256r1Point, core::array::Array::<core::felt252>>>;
+libfunc enum_init<core::result::Result::<core::starknet::secp256r1::Secp256r1Point, core::array::Array::<core::felt252>>, 1> = enum_init<core::result::Result::<core::starknet::secp256r1::Secp256r1Point, core::array::Array::<core::felt252>>, 1>;
+
+secp256r1_mul_syscall([0], [1], [2], [3]) { fallthrough([4], [5], [6]) 7([7], [8], [9]) }; // 0
+branch_align() -> (); // 1
+enum_init<core::result::Result::<core::starknet::secp256r1::Secp256r1Point, core::array::Array::<core::felt252>>, 0>([6]) -> ([10]); // 2
+store_temp<GasBuiltin>([4]) -> ([4]); // 3
+store_temp<System>([5]) -> ([5]); // 4
+store_temp<core::result::Result::<core::starknet::secp256r1::Secp256r1Point, core::array::Array::<core::felt252>>>([10]) -> ([10]); // 5
+return([4], [5], [10]); // 6
+branch_align() -> (); // 7
+enum_init<core::result::Result::<core::starknet::secp256r1::Secp256r1Point, core::array::Array::<core::felt252>>, 1>([9]) -> ([11]); // 8
+store_temp<GasBuiltin>([7]) -> ([7]); // 9
+store_temp<System>([8]) -> ([8]); // 10
+store_temp<core::result::Result::<core::starknet::secp256r1::Secp256r1Point, core::array::Array::<core::felt252>>>([11]) -> ([11]); // 11
+return([7], [8], [11]); // 12
+
+test::foo@0([0]: GasBuiltin, [1]: System, [2]: Secp256r1Point, [3]: core::integer::u256) -> (GasBuiltin, System, core::result::Result::<core::starknet::secp256r1::Secp256r1Point, core::array::Array::<core::felt252>>);

--- a/Aegis/Tests/e2e_libfuncs/secp256r1_aegis/secp256r1_new_syscall.sierra
+++ b/Aegis/Tests/e2e_libfuncs/secp256r1_aegis/secp256r1_new_syscall.sierra
@@ -1,0 +1,34 @@
+type GasBuiltin = GasBuiltin [storable: true, drop: false, dup: false, zero_sized: false];
+type Secp256r1Point = Secp256r1Point [storable: true, drop: true, dup: true, zero_sized: false];
+type Unit = Struct<ut@Tuple> [storable: true, drop: true, dup: true, zero_sized: true];
+type core::option::Option::<core::starknet::secp256r1::Secp256r1Point> = Enum<ut@core::option::Option::<core::starknet::secp256r1::Secp256r1Point>, Secp256r1Point, Unit> [storable: true, drop: true, dup: true, zero_sized: false];
+type Array<felt252> = Array<felt252> [storable: true, drop: true, dup: false, zero_sized: false];
+type core::result::Result::<core::option::Option::<core::starknet::secp256r1::Secp256r1Point>, core::array::Array::<core::felt252>> = Enum<ut@core::result::Result::<core::option::Option::<core::starknet::secp256r1::Secp256r1Point>, core::array::Array::<core::felt252>>, core::option::Option::<core::starknet::secp256r1::Secp256r1Point>, Array<felt252>> [storable: true, drop: true, dup: false, zero_sized: false];
+type felt252 = felt252 [storable: true, drop: true, dup: true, zero_sized: false];
+type u128 = u128 [storable: true, drop: true, dup: true, zero_sized: false];
+type core::integer::u256 = Struct<ut@core::integer::u256, u128, u128> [storable: true, drop: true, dup: true, zero_sized: false];
+type System = System [storable: true, drop: false, dup: false, zero_sized: false];
+
+libfunc secp256r1_new_syscall = secp256r1_new_syscall;
+libfunc branch_align = branch_align;
+libfunc enum_init<core::result::Result::<core::option::Option::<core::starknet::secp256r1::Secp256r1Point>, core::array::Array::<core::felt252>>, 0> = enum_init<core::result::Result::<core::option::Option::<core::starknet::secp256r1::Secp256r1Point>, core::array::Array::<core::felt252>>, 0>;
+libfunc store_temp<GasBuiltin> = store_temp<GasBuiltin>;
+libfunc store_temp<System> = store_temp<System>;
+libfunc store_temp<core::result::Result::<core::option::Option::<core::starknet::secp256r1::Secp256r1Point>, core::array::Array::<core::felt252>>> = store_temp<core::result::Result::<core::option::Option::<core::starknet::secp256r1::Secp256r1Point>, core::array::Array::<core::felt252>>>;
+libfunc enum_init<core::result::Result::<core::option::Option::<core::starknet::secp256r1::Secp256r1Point>, core::array::Array::<core::felt252>>, 1> = enum_init<core::result::Result::<core::option::Option::<core::starknet::secp256r1::Secp256r1Point>, core::array::Array::<core::felt252>>, 1>;
+
+secp256r1_new_syscall([0], [1], [2], [3]) { fallthrough([4], [5], [6]) 7([7], [8], [9]) }; // 0
+branch_align() -> (); // 1
+enum_init<core::result::Result::<core::option::Option::<core::starknet::secp256r1::Secp256r1Point>, core::array::Array::<core::felt252>>, 0>([6]) -> ([10]); // 2
+store_temp<GasBuiltin>([4]) -> ([4]); // 3
+store_temp<System>([5]) -> ([5]); // 4
+store_temp<core::result::Result::<core::option::Option::<core::starknet::secp256r1::Secp256r1Point>, core::array::Array::<core::felt252>>>([10]) -> ([10]); // 5
+return([4], [5], [10]); // 6
+branch_align() -> (); // 7
+enum_init<core::result::Result::<core::option::Option::<core::starknet::secp256r1::Secp256r1Point>, core::array::Array::<core::felt252>>, 1>([9]) -> ([11]); // 8
+store_temp<GasBuiltin>([7]) -> ([7]); // 9
+store_temp<System>([8]) -> ([8]); // 10
+store_temp<core::result::Result::<core::option::Option::<core::starknet::secp256r1::Secp256r1Point>, core::array::Array::<core::felt252>>>([11]) -> ([11]); // 11
+return([7], [8], [11]); // 12
+
+test::foo@0([0]: GasBuiltin, [1]: System, [2]: core::integer::u256, [3]: core::integer::u256) -> (GasBuiltin, System, core::result::Result::<core::option::Option::<core::starknet::secp256r1::Secp256r1Point>, core::array::Array::<core::felt252>>);

--- a/Aegis/Tests/e2e_libfuncs/storage_address_aegis/storage_address_from_base_and_offset.sierra
+++ b/Aegis/Tests/e2e_libfuncs/storage_address_aegis/storage_address_from_base_and_offset.sierra
@@ -1,0 +1,12 @@
+type StorageBaseAddress = StorageBaseAddress [storable: true, drop: true, dup: true, zero_sized: false];
+type StorageAddress = StorageAddress [storable: true, drop: true, dup: true, zero_sized: false];
+type u8 = u8 [storable: true, drop: true, dup: true, zero_sized: false];
+
+libfunc storage_address_from_base_and_offset = storage_address_from_base_and_offset;
+libfunc store_temp<StorageAddress> = store_temp<StorageAddress>;
+
+storage_address_from_base_and_offset([0], [1]) -> ([2]); // 0
+store_temp<StorageAddress>([2]) -> ([2]); // 1
+return([2]); // 2
+
+test::foo@0([0]: StorageBaseAddress, [1]: u8) -> (StorageAddress);

--- a/Aegis/Tests/e2e_libfuncs/storage_address_aegis/storage_address_try_from_felt252.sierra
+++ b/Aegis/Tests/e2e_libfuncs/storage_address_aegis/storage_address_try_from_felt252.sierra
@@ -1,0 +1,28 @@
+type RangeCheck = RangeCheck [storable: true, drop: false, dup: false, zero_sized: false];
+type Unit = Struct<ut@Tuple> [storable: true, drop: true, dup: true, zero_sized: true];
+type StorageAddress = StorageAddress [storable: true, drop: true, dup: true, zero_sized: false];
+type core::option::Option::<core::starknet::storage_access::StorageAddress> = Enum<ut@core::option::Option::<core::starknet::storage_access::StorageAddress>, StorageAddress, Unit> [storable: true, drop: true, dup: true, zero_sized: false];
+type felt252 = felt252 [storable: true, drop: true, dup: true, zero_sized: false];
+
+libfunc storage_address_try_from_felt252 = storage_address_try_from_felt252;
+libfunc branch_align = branch_align;
+libfunc enum_init<core::option::Option::<core::starknet::storage_access::StorageAddress>, 0> = enum_init<core::option::Option::<core::starknet::storage_access::StorageAddress>, 0>;
+libfunc store_temp<RangeCheck> = store_temp<RangeCheck>;
+libfunc store_temp<core::option::Option::<core::starknet::storage_access::StorageAddress>> = store_temp<core::option::Option::<core::starknet::storage_access::StorageAddress>>;
+libfunc struct_construct<Unit> = struct_construct<Unit>;
+libfunc enum_init<core::option::Option::<core::starknet::storage_access::StorageAddress>, 1> = enum_init<core::option::Option::<core::starknet::storage_access::StorageAddress>, 1>;
+
+storage_address_try_from_felt252([0], [1]) { fallthrough([2], [3]) 6([4]) }; // 0
+branch_align() -> (); // 1
+enum_init<core::option::Option::<core::starknet::storage_access::StorageAddress>, 0>([3]) -> ([5]); // 2
+store_temp<RangeCheck>([2]) -> ([2]); // 3
+store_temp<core::option::Option::<core::starknet::storage_access::StorageAddress>>([5]) -> ([5]); // 4
+return([2], [5]); // 5
+branch_align() -> (); // 6
+struct_construct<Unit>() -> ([6]); // 7
+enum_init<core::option::Option::<core::starknet::storage_access::StorageAddress>, 1>([6]) -> ([7]); // 8
+store_temp<RangeCheck>([4]) -> ([4]); // 9
+store_temp<core::option::Option::<core::starknet::storage_access::StorageAddress>>([7]) -> ([7]); // 10
+return([4], [7]); // 11
+
+test::foo@0([0]: RangeCheck, [1]: felt252) -> (RangeCheck, core::option::Option::<core::starknet::storage_access::StorageAddress>);

--- a/Aegis/Tests/e2e_libfuncs/storage_address_aegis/storage_base_address_from_felt252.sierra
+++ b/Aegis/Tests/e2e_libfuncs/storage_address_aegis/storage_base_address_from_felt252.sierra
@@ -1,0 +1,14 @@
+type RangeCheck = RangeCheck [storable: true, drop: false, dup: false, zero_sized: false];
+type StorageBaseAddress = StorageBaseAddress [storable: true, drop: true, dup: true, zero_sized: false];
+type felt252 = felt252 [storable: true, drop: true, dup: true, zero_sized: false];
+
+libfunc storage_base_address_from_felt252 = storage_base_address_from_felt252;
+libfunc store_temp<RangeCheck> = store_temp<RangeCheck>;
+libfunc store_temp<StorageBaseAddress> = store_temp<StorageBaseAddress>;
+
+storage_base_address_from_felt252([0], [1]) -> ([2], [3]); // 0
+store_temp<RangeCheck>([2]) -> ([2]); // 1
+store_temp<StorageBaseAddress>([3]) -> ([3]); // 2
+return([2], [3]); // 3
+
+test::foo@0([0]: RangeCheck, [1]: felt252) -> (RangeCheck, StorageBaseAddress);

--- a/Aegis/Tests/e2e_libfuncs/syscalls_aegis/call_contract_syscall.sierra
+++ b/Aegis/Tests/e2e_libfuncs/syscalls_aegis/call_contract_syscall.sierra
@@ -1,0 +1,32 @@
+type GasBuiltin = GasBuiltin [storable: true, drop: false, dup: false, zero_sized: false];
+type Array<felt252> = Array<felt252> [storable: true, drop: true, dup: false, zero_sized: false];
+type Snapshot<Array<felt252>> = Snapshot<Array<felt252>> [storable: true, drop: true, dup: true, zero_sized: false];
+type core::array::Span::<core::felt252> = Struct<ut@core::array::Span::<core::felt252>, Snapshot<Array<felt252>>> [storable: true, drop: true, dup: true, zero_sized: false];
+type core::result::Result::<core::array::Span::<core::felt252>, core::array::Array::<core::felt252>> = Enum<ut@core::result::Result::<core::array::Span::<core::felt252>, core::array::Array::<core::felt252>>, core::array::Span::<core::felt252>, Array<felt252>> [storable: true, drop: true, dup: false, zero_sized: false];
+type felt252 = felt252 [storable: true, drop: true, dup: true, zero_sized: false];
+type ContractAddress = ContractAddress [storable: true, drop: true, dup: true, zero_sized: false];
+type System = System [storable: true, drop: false, dup: false, zero_sized: false];
+
+libfunc call_contract_syscall = call_contract_syscall;
+libfunc branch_align = branch_align;
+libfunc enum_init<core::result::Result::<core::array::Span::<core::felt252>, core::array::Array::<core::felt252>>, 0> = enum_init<core::result::Result::<core::array::Span::<core::felt252>, core::array::Array::<core::felt252>>, 0>;
+libfunc store_temp<GasBuiltin> = store_temp<GasBuiltin>;
+libfunc store_temp<System> = store_temp<System>;
+libfunc store_temp<core::result::Result::<core::array::Span::<core::felt252>, core::array::Array::<core::felt252>>> = store_temp<core::result::Result::<core::array::Span::<core::felt252>, core::array::Array::<core::felt252>>>;
+libfunc enum_init<core::result::Result::<core::array::Span::<core::felt252>, core::array::Array::<core::felt252>>, 1> = enum_init<core::result::Result::<core::array::Span::<core::felt252>, core::array::Array::<core::felt252>>, 1>;
+
+call_contract_syscall([0], [1], [2], [3], [4]) { fallthrough([5], [6], [7]) 7([8], [9], [10]) }; // 0
+branch_align() -> (); // 1
+enum_init<core::result::Result::<core::array::Span::<core::felt252>, core::array::Array::<core::felt252>>, 0>([7]) -> ([11]); // 2
+store_temp<GasBuiltin>([5]) -> ([5]); // 3
+store_temp<System>([6]) -> ([6]); // 4
+store_temp<core::result::Result::<core::array::Span::<core::felt252>, core::array::Array::<core::felt252>>>([11]) -> ([11]); // 5
+return([5], [6], [11]); // 6
+branch_align() -> (); // 7
+enum_init<core::result::Result::<core::array::Span::<core::felt252>, core::array::Array::<core::felt252>>, 1>([10]) -> ([12]); // 8
+store_temp<GasBuiltin>([8]) -> ([8]); // 9
+store_temp<System>([9]) -> ([9]); // 10
+store_temp<core::result::Result::<core::array::Span::<core::felt252>, core::array::Array::<core::felt252>>>([12]) -> ([12]); // 11
+return([8], [9], [12]); // 12
+
+test::foo@0([0]: GasBuiltin, [1]: System, [2]: ContractAddress, [3]: felt252, [4]: core::array::Span::<core::felt252>) -> (GasBuiltin, System, core::result::Result::<core::array::Span::<core::felt252>, core::array::Array::<core::felt252>>);

--- a/Aegis/Tests/e2e_libfuncs/syscalls_aegis/deploy_syscall.sierra
+++ b/Aegis/Tests/e2e_libfuncs/syscalls_aegis/deploy_syscall.sierra
@@ -1,0 +1,38 @@
+type GasBuiltin = GasBuiltin [storable: true, drop: false, dup: false, zero_sized: false];
+type ContractAddress = ContractAddress [storable: true, drop: true, dup: true, zero_sized: false];
+type Array<felt252> = Array<felt252> [storable: true, drop: true, dup: false, zero_sized: false];
+type Snapshot<Array<felt252>> = Snapshot<Array<felt252>> [storable: true, drop: true, dup: true, zero_sized: false];
+type core::array::Span::<core::felt252> = Struct<ut@core::array::Span::<core::felt252>, Snapshot<Array<felt252>>> [storable: true, drop: true, dup: true, zero_sized: false];
+type Tuple<ContractAddress, core::array::Span::<core::felt252>> = Struct<ut@Tuple, ContractAddress, core::array::Span::<core::felt252>> [storable: true, drop: true, dup: true, zero_sized: false];
+type core::result::Result::<(core::starknet::contract_address::ContractAddress, core::array::Span::<core::felt252>), core::array::Array::<core::felt252>> = Enum<ut@core::result::Result::<(core::starknet::contract_address::ContractAddress, core::array::Span::<core::felt252>), core::array::Array::<core::felt252>>, Tuple<ContractAddress, core::array::Span::<core::felt252>>, Array<felt252>> [storable: true, drop: true, dup: false, zero_sized: false];
+type Unit = Struct<ut@Tuple> [storable: true, drop: true, dup: true, zero_sized: true];
+type core::bool = Enum<ut@core::bool, Unit, Unit> [storable: true, drop: true, dup: true, zero_sized: false];
+type felt252 = felt252 [storable: true, drop: true, dup: true, zero_sized: false];
+type ClassHash = ClassHash [storable: true, drop: true, dup: true, zero_sized: false];
+type System = System [storable: true, drop: false, dup: false, zero_sized: false];
+
+libfunc deploy_syscall = deploy_syscall;
+libfunc branch_align = branch_align;
+libfunc struct_construct<Tuple<ContractAddress, core::array::Span::<core::felt252>>> = struct_construct<Tuple<ContractAddress, core::array::Span::<core::felt252>>>;
+libfunc enum_init<core::result::Result::<(core::starknet::contract_address::ContractAddress, core::array::Span::<core::felt252>), core::array::Array::<core::felt252>>, 0> = enum_init<core::result::Result::<(core::starknet::contract_address::ContractAddress, core::array::Span::<core::felt252>), core::array::Array::<core::felt252>>, 0>;
+libfunc store_temp<GasBuiltin> = store_temp<GasBuiltin>;
+libfunc store_temp<System> = store_temp<System>;
+libfunc store_temp<core::result::Result::<(core::starknet::contract_address::ContractAddress, core::array::Span::<core::felt252>), core::array::Array::<core::felt252>>> = store_temp<core::result::Result::<(core::starknet::contract_address::ContractAddress, core::array::Span::<core::felt252>), core::array::Array::<core::felt252>>>;
+libfunc enum_init<core::result::Result::<(core::starknet::contract_address::ContractAddress, core::array::Span::<core::felt252>), core::array::Array::<core::felt252>>, 1> = enum_init<core::result::Result::<(core::starknet::contract_address::ContractAddress, core::array::Span::<core::felt252>), core::array::Array::<core::felt252>>, 1>;
+
+deploy_syscall([0], [1], [2], [3], [4], [5]) { fallthrough([6], [7], [8], [9]) 8([10], [11], [12]) }; // 0
+branch_align() -> (); // 1
+struct_construct<Tuple<ContractAddress, core::array::Span::<core::felt252>>>([8], [9]) -> ([13]); // 2
+enum_init<core::result::Result::<(core::starknet::contract_address::ContractAddress, core::array::Span::<core::felt252>), core::array::Array::<core::felt252>>, 0>([13]) -> ([14]); // 3
+store_temp<GasBuiltin>([6]) -> ([6]); // 4
+store_temp<System>([7]) -> ([7]); // 5
+store_temp<core::result::Result::<(core::starknet::contract_address::ContractAddress, core::array::Span::<core::felt252>), core::array::Array::<core::felt252>>>([14]) -> ([14]); // 6
+return([6], [7], [14]); // 7
+branch_align() -> (); // 8
+enum_init<core::result::Result::<(core::starknet::contract_address::ContractAddress, core::array::Span::<core::felt252>), core::array::Array::<core::felt252>>, 1>([12]) -> ([15]); // 9
+store_temp<GasBuiltin>([10]) -> ([10]); // 10
+store_temp<System>([11]) -> ([11]); // 11
+store_temp<core::result::Result::<(core::starknet::contract_address::ContractAddress, core::array::Span::<core::felt252>), core::array::Array::<core::felt252>>>([15]) -> ([15]); // 12
+return([10], [11], [15]); // 13
+
+test::foo@0([0]: GasBuiltin, [1]: System, [2]: ClassHash, [3]: felt252, [4]: core::array::Span::<core::felt252>, [5]: core::bool) -> (GasBuiltin, System, core::result::Result::<(core::starknet::contract_address::ContractAddress, core::array::Span::<core::felt252>), core::array::Array::<core::felt252>>);

--- a/Aegis/Tests/e2e_libfuncs/syscalls_aegis/emit_event_syscall.sierra
+++ b/Aegis/Tests/e2e_libfuncs/syscalls_aegis/emit_event_syscall.sierra
@@ -1,0 +1,34 @@
+type GasBuiltin = GasBuiltin [storable: true, drop: false, dup: false, zero_sized: false];
+type Unit = Struct<ut@Tuple> [storable: true, drop: true, dup: true, zero_sized: true];
+type Array<felt252> = Array<felt252> [storable: true, drop: true, dup: false, zero_sized: false];
+type core::result::Result::<(), core::array::Array::<core::felt252>> = Enum<ut@core::result::Result::<(), core::array::Array::<core::felt252>>, Unit, Array<felt252>> [storable: true, drop: true, dup: false, zero_sized: false];
+type felt252 = felt252 [storable: true, drop: true, dup: true, zero_sized: false];
+type Snapshot<Array<felt252>> = Snapshot<Array<felt252>> [storable: true, drop: true, dup: true, zero_sized: false];
+type core::array::Span::<core::felt252> = Struct<ut@core::array::Span::<core::felt252>, Snapshot<Array<felt252>>> [storable: true, drop: true, dup: true, zero_sized: false];
+type System = System [storable: true, drop: false, dup: false, zero_sized: false];
+
+libfunc emit_event_syscall = emit_event_syscall;
+libfunc branch_align = branch_align;
+libfunc struct_construct<Unit> = struct_construct<Unit>;
+libfunc enum_init<core::result::Result::<(), core::array::Array::<core::felt252>>, 0> = enum_init<core::result::Result::<(), core::array::Array::<core::felt252>>, 0>;
+libfunc store_temp<GasBuiltin> = store_temp<GasBuiltin>;
+libfunc store_temp<System> = store_temp<System>;
+libfunc store_temp<core::result::Result::<(), core::array::Array::<core::felt252>>> = store_temp<core::result::Result::<(), core::array::Array::<core::felt252>>>;
+libfunc enum_init<core::result::Result::<(), core::array::Array::<core::felt252>>, 1> = enum_init<core::result::Result::<(), core::array::Array::<core::felt252>>, 1>;
+
+emit_event_syscall([0], [1], [2], [3]) { fallthrough([4], [5]) 8([6], [7], [8]) }; // 0
+branch_align() -> (); // 1
+struct_construct<Unit>() -> ([9]); // 2
+enum_init<core::result::Result::<(), core::array::Array::<core::felt252>>, 0>([9]) -> ([10]); // 3
+store_temp<GasBuiltin>([4]) -> ([4]); // 4
+store_temp<System>([5]) -> ([5]); // 5
+store_temp<core::result::Result::<(), core::array::Array::<core::felt252>>>([10]) -> ([10]); // 6
+return([4], [5], [10]); // 7
+branch_align() -> (); // 8
+enum_init<core::result::Result::<(), core::array::Array::<core::felt252>>, 1>([8]) -> ([11]); // 9
+store_temp<GasBuiltin>([6]) -> ([6]); // 10
+store_temp<System>([7]) -> ([7]); // 11
+store_temp<core::result::Result::<(), core::array::Array::<core::felt252>>>([11]) -> ([11]); // 12
+return([6], [7], [11]); // 13
+
+test::foo@0([0]: GasBuiltin, [1]: System, [2]: core::array::Span::<core::felt252>, [3]: core::array::Span::<core::felt252>) -> (GasBuiltin, System, core::result::Result::<(), core::array::Array::<core::felt252>>);

--- a/Aegis/Tests/e2e_libfuncs/syscalls_aegis/get_block_hash_syscall.sierra
+++ b/Aegis/Tests/e2e_libfuncs/syscalls_aegis/get_block_hash_syscall.sierra
@@ -1,0 +1,30 @@
+type GasBuiltin = GasBuiltin [storable: true, drop: false, dup: false, zero_sized: false];
+type felt252 = felt252 [storable: true, drop: true, dup: true, zero_sized: false];
+type Array<felt252> = Array<felt252> [storable: true, drop: true, dup: false, zero_sized: false];
+type core::result::Result::<core::felt252, core::array::Array::<core::felt252>> = Enum<ut@core::result::Result::<core::felt252, core::array::Array::<core::felt252>>, felt252, Array<felt252>> [storable: true, drop: true, dup: false, zero_sized: false];
+type u64 = u64 [storable: true, drop: true, dup: true, zero_sized: false];
+type System = System [storable: true, drop: false, dup: false, zero_sized: false];
+
+libfunc get_block_hash_syscall = get_block_hash_syscall;
+libfunc branch_align = branch_align;
+libfunc enum_init<core::result::Result::<core::felt252, core::array::Array::<core::felt252>>, 0> = enum_init<core::result::Result::<core::felt252, core::array::Array::<core::felt252>>, 0>;
+libfunc store_temp<GasBuiltin> = store_temp<GasBuiltin>;
+libfunc store_temp<System> = store_temp<System>;
+libfunc store_temp<core::result::Result::<core::felt252, core::array::Array::<core::felt252>>> = store_temp<core::result::Result::<core::felt252, core::array::Array::<core::felt252>>>;
+libfunc enum_init<core::result::Result::<core::felt252, core::array::Array::<core::felt252>>, 1> = enum_init<core::result::Result::<core::felt252, core::array::Array::<core::felt252>>, 1>;
+
+get_block_hash_syscall([0], [1], [2]) { fallthrough([3], [4], [5]) 7([6], [7], [8]) }; // 0
+branch_align() -> (); // 1
+enum_init<core::result::Result::<core::felt252, core::array::Array::<core::felt252>>, 0>([5]) -> ([9]); // 2
+store_temp<GasBuiltin>([3]) -> ([3]); // 3
+store_temp<System>([4]) -> ([4]); // 4
+store_temp<core::result::Result::<core::felt252, core::array::Array::<core::felt252>>>([9]) -> ([9]); // 5
+return([3], [4], [9]); // 6
+branch_align() -> (); // 7
+enum_init<core::result::Result::<core::felt252, core::array::Array::<core::felt252>>, 1>([8]) -> ([10]); // 8
+store_temp<GasBuiltin>([6]) -> ([6]); // 9
+store_temp<System>([7]) -> ([7]); // 10
+store_temp<core::result::Result::<core::felt252, core::array::Array::<core::felt252>>>([10]) -> ([10]); // 11
+return([6], [7], [10]); // 12
+
+test::foo@0([0]: GasBuiltin, [1]: System, [2]: u64) -> (GasBuiltin, System, core::result::Result::<core::felt252, core::array::Array::<core::felt252>>);

--- a/Aegis/Tests/e2e_libfuncs/syscalls_aegis/get_execution_info_syscall.sierra
+++ b/Aegis/Tests/e2e_libfuncs/syscalls_aegis/get_execution_info_syscall.sierra
@@ -1,0 +1,40 @@
+type GasBuiltin = GasBuiltin [storable: true, drop: false, dup: false, zero_sized: false];
+type Box<core::starknet::info::ExecutionInfo> = Box<core::starknet::info::ExecutionInfo> [storable: true, drop: true, dup: true, zero_sized: false];
+type Array<felt252> = Array<felt252> [storable: true, drop: true, dup: false, zero_sized: false];
+type core::result::Result::<core::box::Box::<core::starknet::info::ExecutionInfo>, core::array::Array::<core::felt252>> = Enum<ut@core::result::Result::<core::box::Box::<core::starknet::info::ExecutionInfo>, core::array::Array::<core::felt252>>, Box<core::starknet::info::ExecutionInfo>, Array<felt252>> [storable: true, drop: true, dup: false, zero_sized: false];
+type felt252 = felt252 [storable: true, drop: true, dup: true, zero_sized: false];
+type Box<core::starknet::info::BlockInfo> = Box<core::starknet::info::BlockInfo> [storable: true, drop: true, dup: true, zero_sized: false];
+type Box<core::starknet::info::TxInfo> = Box<core::starknet::info::TxInfo> [storable: true, drop: true, dup: true, zero_sized: false];
+type ContractAddress = ContractAddress [storable: true, drop: true, dup: true, zero_sized: false];
+type core::starknet::info::ExecutionInfo = Struct<ut@core::starknet::info::ExecutionInfo, Box<core::starknet::info::BlockInfo>, Box<core::starknet::info::TxInfo>, ContractAddress, ContractAddress, felt252> [storable: true, drop: true, dup: true, zero_sized: false];
+type u128 = u128 [storable: true, drop: true, dup: true, zero_sized: false];
+type Snapshot<Array<felt252>> = Snapshot<Array<felt252>> [storable: true, drop: true, dup: true, zero_sized: false];
+type core::array::Span::<core::felt252> = Struct<ut@core::array::Span::<core::felt252>, Snapshot<Array<felt252>>> [storable: true, drop: true, dup: true, zero_sized: false];
+type core::starknet::info::TxInfo = Struct<ut@core::starknet::info::TxInfo, felt252, ContractAddress, u128, core::array::Span::<core::felt252>, felt252, felt252, felt252> [storable: true, drop: true, dup: true, zero_sized: false];
+type u64 = u64 [storable: true, drop: true, dup: true, zero_sized: false];
+type core::starknet::info::BlockInfo = Struct<ut@core::starknet::info::BlockInfo, u64, u64, ContractAddress> [storable: true, drop: true, dup: true, zero_sized: false];
+type System = System [storable: true, drop: false, dup: false, zero_sized: false];
+
+libfunc get_execution_info_syscall = get_execution_info_syscall;
+libfunc branch_align = branch_align;
+libfunc enum_init<core::result::Result::<core::box::Box::<core::starknet::info::ExecutionInfo>, core::array::Array::<core::felt252>>, 0> = enum_init<core::result::Result::<core::box::Box::<core::starknet::info::ExecutionInfo>, core::array::Array::<core::felt252>>, 0>;
+libfunc store_temp<GasBuiltin> = store_temp<GasBuiltin>;
+libfunc store_temp<System> = store_temp<System>;
+libfunc store_temp<core::result::Result::<core::box::Box::<core::starknet::info::ExecutionInfo>, core::array::Array::<core::felt252>>> = store_temp<core::result::Result::<core::box::Box::<core::starknet::info::ExecutionInfo>, core::array::Array::<core::felt252>>>;
+libfunc enum_init<core::result::Result::<core::box::Box::<core::starknet::info::ExecutionInfo>, core::array::Array::<core::felt252>>, 1> = enum_init<core::result::Result::<core::box::Box::<core::starknet::info::ExecutionInfo>, core::array::Array::<core::felt252>>, 1>;
+
+get_execution_info_syscall([0], [1]) { fallthrough([2], [3], [4]) 7([5], [6], [7]) }; // 0
+branch_align() -> (); // 1
+enum_init<core::result::Result::<core::box::Box::<core::starknet::info::ExecutionInfo>, core::array::Array::<core::felt252>>, 0>([4]) -> ([8]); // 2
+store_temp<GasBuiltin>([2]) -> ([2]); // 3
+store_temp<System>([3]) -> ([3]); // 4
+store_temp<core::result::Result::<core::box::Box::<core::starknet::info::ExecutionInfo>, core::array::Array::<core::felt252>>>([8]) -> ([8]); // 5
+return([2], [3], [8]); // 6
+branch_align() -> (); // 7
+enum_init<core::result::Result::<core::box::Box::<core::starknet::info::ExecutionInfo>, core::array::Array::<core::felt252>>, 1>([7]) -> ([9]); // 8
+store_temp<GasBuiltin>([5]) -> ([5]); // 9
+store_temp<System>([6]) -> ([6]); // 10
+store_temp<core::result::Result::<core::box::Box::<core::starknet::info::ExecutionInfo>, core::array::Array::<core::felt252>>>([9]) -> ([9]); // 11
+return([5], [6], [9]); // 12
+
+test::foo@0([0]: GasBuiltin, [1]: System) -> (GasBuiltin, System, core::result::Result::<core::box::Box::<core::starknet::info::ExecutionInfo>, core::array::Array::<core::felt252>>);

--- a/Aegis/Tests/e2e_libfuncs/syscalls_aegis/get_execution_info_v2_syscall.sierra
+++ b/Aegis/Tests/e2e_libfuncs/syscalls_aegis/get_execution_info_v2_syscall.sierra
@@ -1,0 +1,45 @@
+type GasBuiltin = GasBuiltin [storable: true, drop: false, dup: false, zero_sized: false];
+type Box<core::starknet::info::v2::ExecutionInfo> = Box<core::starknet::info::v2::ExecutionInfo> [storable: true, drop: true, dup: true, zero_sized: false];
+type Array<felt252> = Array<felt252> [storable: true, drop: true, dup: false, zero_sized: false];
+type core::result::Result::<core::box::Box::<core::starknet::info::v2::ExecutionInfo>, core::array::Array::<core::felt252>> = Enum<ut@core::result::Result::<core::box::Box::<core::starknet::info::v2::ExecutionInfo>, core::array::Array::<core::felt252>>, Box<core::starknet::info::v2::ExecutionInfo>, Array<felt252>> [storable: true, drop: true, dup: false, zero_sized: false];
+type felt252 = felt252 [storable: true, drop: true, dup: true, zero_sized: false];
+type Box<core::starknet::info::BlockInfo> = Box<core::starknet::info::BlockInfo> [storable: true, drop: true, dup: true, zero_sized: false];
+type Box<core::starknet::info::v2::TxInfo> = Box<core::starknet::info::v2::TxInfo> [storable: true, drop: true, dup: true, zero_sized: false];
+type ContractAddress = ContractAddress [storable: true, drop: true, dup: true, zero_sized: false];
+type core::starknet::info::v2::ExecutionInfo = Struct<ut@core::starknet::info::v2::ExecutionInfo, Box<core::starknet::info::BlockInfo>, Box<core::starknet::info::v2::TxInfo>, ContractAddress, ContractAddress, felt252> [storable: true, drop: true, dup: true, zero_sized: false];
+type u128 = u128 [storable: true, drop: true, dup: true, zero_sized: false];
+type Snapshot<Array<felt252>> = Snapshot<Array<felt252>> [storable: true, drop: true, dup: true, zero_sized: false];
+type core::array::Span::<core::felt252> = Struct<ut@core::array::Span::<core::felt252>, Snapshot<Array<felt252>>> [storable: true, drop: true, dup: true, zero_sized: false];
+type Array<core::starknet::info::v2::ResourceBounds> = Array<core::starknet::info::v2::ResourceBounds> [storable: true, drop: true, dup: false, zero_sized: false];
+type Snapshot<Array<core::starknet::info::v2::ResourceBounds>> = Snapshot<Array<core::starknet::info::v2::ResourceBounds>> [storable: true, drop: true, dup: true, zero_sized: false];
+type core::array::Span::<core::starknet::info::v2::ResourceBounds> = Struct<ut@core::array::Span::<core::starknet::info::v2::ResourceBounds>, Snapshot<Array<core::starknet::info::v2::ResourceBounds>>> [storable: true, drop: true, dup: true, zero_sized: false];
+type u32 = u32 [storable: true, drop: true, dup: true, zero_sized: false];
+type core::starknet::info::v2::TxInfo = Struct<ut@core::starknet::info::v2::TxInfo, felt252, ContractAddress, u128, core::array::Span::<core::felt252>, felt252, felt252, felt252, core::array::Span::<core::starknet::info::v2::ResourceBounds>, u128, core::array::Span::<core::felt252>, u32, u32, core::array::Span::<core::felt252>> [storable: true, drop: true, dup: true, zero_sized: false];
+type u64 = u64 [storable: true, drop: true, dup: true, zero_sized: false];
+type core::starknet::info::BlockInfo = Struct<ut@core::starknet::info::BlockInfo, u64, u64, ContractAddress> [storable: true, drop: true, dup: true, zero_sized: false];
+type core::starknet::info::v2::ResourceBounds = Struct<ut@core::starknet::info::v2::ResourceBounds, felt252, u64, u128> [storable: true, drop: true, dup: true, zero_sized: false];
+type System = System [storable: true, drop: false, dup: false, zero_sized: false];
+
+libfunc get_execution_info_v2_syscall = get_execution_info_v2_syscall;
+libfunc branch_align = branch_align;
+libfunc enum_init<core::result::Result::<core::box::Box::<core::starknet::info::v2::ExecutionInfo>, core::array::Array::<core::felt252>>, 0> = enum_init<core::result::Result::<core::box::Box::<core::starknet::info::v2::ExecutionInfo>, core::array::Array::<core::felt252>>, 0>;
+libfunc store_temp<GasBuiltin> = store_temp<GasBuiltin>;
+libfunc store_temp<System> = store_temp<System>;
+libfunc store_temp<core::result::Result::<core::box::Box::<core::starknet::info::v2::ExecutionInfo>, core::array::Array::<core::felt252>>> = store_temp<core::result::Result::<core::box::Box::<core::starknet::info::v2::ExecutionInfo>, core::array::Array::<core::felt252>>>;
+libfunc enum_init<core::result::Result::<core::box::Box::<core::starknet::info::v2::ExecutionInfo>, core::array::Array::<core::felt252>>, 1> = enum_init<core::result::Result::<core::box::Box::<core::starknet::info::v2::ExecutionInfo>, core::array::Array::<core::felt252>>, 1>;
+
+get_execution_info_v2_syscall([0], [1]) { fallthrough([2], [3], [4]) 7([5], [6], [7]) }; // 0
+branch_align() -> (); // 1
+enum_init<core::result::Result::<core::box::Box::<core::starknet::info::v2::ExecutionInfo>, core::array::Array::<core::felt252>>, 0>([4]) -> ([8]); // 2
+store_temp<GasBuiltin>([2]) -> ([2]); // 3
+store_temp<System>([3]) -> ([3]); // 4
+store_temp<core::result::Result::<core::box::Box::<core::starknet::info::v2::ExecutionInfo>, core::array::Array::<core::felt252>>>([8]) -> ([8]); // 5
+return([2], [3], [8]); // 6
+branch_align() -> (); // 7
+enum_init<core::result::Result::<core::box::Box::<core::starknet::info::v2::ExecutionInfo>, core::array::Array::<core::felt252>>, 1>([7]) -> ([9]); // 8
+store_temp<GasBuiltin>([5]) -> ([5]); // 9
+store_temp<System>([6]) -> ([6]); // 10
+store_temp<core::result::Result::<core::box::Box::<core::starknet::info::v2::ExecutionInfo>, core::array::Array::<core::felt252>>>([9]) -> ([9]); // 11
+return([5], [6], [9]); // 12
+
+test::foo@0([0]: GasBuiltin, [1]: System) -> (GasBuiltin, System, core::result::Result::<core::box::Box::<core::starknet::info::v2::ExecutionInfo>, core::array::Array::<core::felt252>>);

--- a/Aegis/Tests/e2e_libfuncs/syscalls_aegis/keccak.sierra
+++ b/Aegis/Tests/e2e_libfuncs/syscalls_aegis/keccak.sierra
@@ -1,0 +1,43 @@
+type Array<u64> = Array<u64> [storable: true, drop: true, dup: false, zero_sized: false];
+type u128 = u128 [storable: true, drop: true, dup: true, zero_sized: false];
+type core::integer::u256 = Struct<ut@core::integer::u256, u128, u128> [storable: true, drop: true, dup: true, zero_sized: false];
+type Array<felt252> = Array<felt252> [storable: true, drop: true, dup: false, zero_sized: false];
+type core::result::Result::<core::integer::u256, core::array::Array::<core::felt252>> = Enum<ut@core::result::Result::<core::integer::u256, core::array::Array::<core::felt252>>, core::integer::u256, Array<felt252>> [storable: true, drop: true, dup: false, zero_sized: false];
+type u64 = u64 [storable: true, drop: true, dup: true, zero_sized: false];
+type felt252 = felt252 [storable: true, drop: true, dup: true, zero_sized: false];
+type System = System [storable: true, drop: false, dup: false, zero_sized: false];
+type GasBuiltin = GasBuiltin [storable: true, drop: false, dup: false, zero_sized: false];
+type Snapshot<Array<u64>> = Snapshot<Array<u64>> [storable: true, drop: true, dup: true, zero_sized: false];
+type core::array::Span::<core::integer::u64> = Struct<ut@core::array::Span::<core::integer::u64>, Snapshot<Array<u64>>> [storable: true, drop: true, dup: true, zero_sized: false];
+
+libfunc snapshot_take<Array<u64>> = snapshot_take<Array<u64>>;
+libfunc drop<Array<u64>> = drop<Array<u64>>;
+libfunc struct_construct<core::array::Span::<core::integer::u64>> = struct_construct<core::array::Span::<core::integer::u64>>;
+libfunc store_temp<core::array::Span::<core::integer::u64>> = store_temp<core::array::Span::<core::integer::u64>>;
+libfunc keccak_syscall = keccak_syscall;
+libfunc branch_align = branch_align;
+libfunc enum_init<core::result::Result::<core::integer::u256, core::array::Array::<core::felt252>>, 0> = enum_init<core::result::Result::<core::integer::u256, core::array::Array::<core::felt252>>, 0>;
+libfunc store_temp<GasBuiltin> = store_temp<GasBuiltin>;
+libfunc store_temp<System> = store_temp<System>;
+libfunc store_temp<core::result::Result::<core::integer::u256, core::array::Array::<core::felt252>>> = store_temp<core::result::Result::<core::integer::u256, core::array::Array::<core::felt252>>>;
+libfunc enum_init<core::result::Result::<core::integer::u256, core::array::Array::<core::felt252>>, 1> = enum_init<core::result::Result::<core::integer::u256, core::array::Array::<core::felt252>>, 1>;
+
+snapshot_take<Array<u64>>([2]) -> ([3], [4]); // 0
+drop<Array<u64>>([3]) -> (); // 1
+struct_construct<core::array::Span::<core::integer::u64>>([4]) -> ([5]); // 2
+store_temp<core::array::Span::<core::integer::u64>>([5]) -> ([5]); // 3
+keccak_syscall([0], [1], [5]) { fallthrough([6], [7], [8]) 11([9], [10], [11]) }; // 4
+branch_align() -> (); // 5
+enum_init<core::result::Result::<core::integer::u256, core::array::Array::<core::felt252>>, 0>([8]) -> ([12]); // 6
+store_temp<GasBuiltin>([6]) -> ([6]); // 7
+store_temp<System>([7]) -> ([7]); // 8
+store_temp<core::result::Result::<core::integer::u256, core::array::Array::<core::felt252>>>([12]) -> ([12]); // 9
+return([6], [7], [12]); // 10
+branch_align() -> (); // 11
+enum_init<core::result::Result::<core::integer::u256, core::array::Array::<core::felt252>>, 1>([11]) -> ([13]); // 12
+store_temp<GasBuiltin>([9]) -> ([9]); // 13
+store_temp<System>([10]) -> ([10]); // 14
+store_temp<core::result::Result::<core::integer::u256, core::array::Array::<core::felt252>>>([13]) -> ([13]); // 15
+return([9], [10], [13]); // 16
+
+test::foo@0([0]: GasBuiltin, [1]: System, [2]: Array<u64>) -> (GasBuiltin, System, core::result::Result::<core::integer::u256, core::array::Array::<core::felt252>>);

--- a/Aegis/Tests/e2e_libfuncs/syscalls_aegis/library_call_syscall.sierra
+++ b/Aegis/Tests/e2e_libfuncs/syscalls_aegis/library_call_syscall.sierra
@@ -1,0 +1,32 @@
+type GasBuiltin = GasBuiltin [storable: true, drop: false, dup: false, zero_sized: false];
+type Array<felt252> = Array<felt252> [storable: true, drop: true, dup: false, zero_sized: false];
+type Snapshot<Array<felt252>> = Snapshot<Array<felt252>> [storable: true, drop: true, dup: true, zero_sized: false];
+type core::array::Span::<core::felt252> = Struct<ut@core::array::Span::<core::felt252>, Snapshot<Array<felt252>>> [storable: true, drop: true, dup: true, zero_sized: false];
+type core::result::Result::<core::array::Span::<core::felt252>, core::array::Array::<core::felt252>> = Enum<ut@core::result::Result::<core::array::Span::<core::felt252>, core::array::Array::<core::felt252>>, core::array::Span::<core::felt252>, Array<felt252>> [storable: true, drop: true, dup: false, zero_sized: false];
+type felt252 = felt252 [storable: true, drop: true, dup: true, zero_sized: false];
+type ClassHash = ClassHash [storable: true, drop: true, dup: true, zero_sized: false];
+type System = System [storable: true, drop: false, dup: false, zero_sized: false];
+
+libfunc library_call_syscall = library_call_syscall;
+libfunc branch_align = branch_align;
+libfunc enum_init<core::result::Result::<core::array::Span::<core::felt252>, core::array::Array::<core::felt252>>, 0> = enum_init<core::result::Result::<core::array::Span::<core::felt252>, core::array::Array::<core::felt252>>, 0>;
+libfunc store_temp<GasBuiltin> = store_temp<GasBuiltin>;
+libfunc store_temp<System> = store_temp<System>;
+libfunc store_temp<core::result::Result::<core::array::Span::<core::felt252>, core::array::Array::<core::felt252>>> = store_temp<core::result::Result::<core::array::Span::<core::felt252>, core::array::Array::<core::felt252>>>;
+libfunc enum_init<core::result::Result::<core::array::Span::<core::felt252>, core::array::Array::<core::felt252>>, 1> = enum_init<core::result::Result::<core::array::Span::<core::felt252>, core::array::Array::<core::felt252>>, 1>;
+
+library_call_syscall([0], [1], [2], [3], [4]) { fallthrough([5], [6], [7]) 7([8], [9], [10]) }; // 0
+branch_align() -> (); // 1
+enum_init<core::result::Result::<core::array::Span::<core::felt252>, core::array::Array::<core::felt252>>, 0>([7]) -> ([11]); // 2
+store_temp<GasBuiltin>([5]) -> ([5]); // 3
+store_temp<System>([6]) -> ([6]); // 4
+store_temp<core::result::Result::<core::array::Span::<core::felt252>, core::array::Array::<core::felt252>>>([11]) -> ([11]); // 5
+return([5], [6], [11]); // 6
+branch_align() -> (); // 7
+enum_init<core::result::Result::<core::array::Span::<core::felt252>, core::array::Array::<core::felt252>>, 1>([10]) -> ([12]); // 8
+store_temp<GasBuiltin>([8]) -> ([8]); // 9
+store_temp<System>([9]) -> ([9]); // 10
+store_temp<core::result::Result::<core::array::Span::<core::felt252>, core::array::Array::<core::felt252>>>([12]) -> ([12]); // 11
+return([8], [9], [12]); // 12
+
+test::foo@0([0]: GasBuiltin, [1]: System, [2]: ClassHash, [3]: felt252, [4]: core::array::Span::<core::felt252>) -> (GasBuiltin, System, core::result::Result::<core::array::Span::<core::felt252>, core::array::Array::<core::felt252>>);

--- a/Aegis/Tests/e2e_libfuncs/syscalls_aegis/send_message_to_l1_syscall.sierra
+++ b/Aegis/Tests/e2e_libfuncs/syscalls_aegis/send_message_to_l1_syscall.sierra
@@ -1,0 +1,34 @@
+type GasBuiltin = GasBuiltin [storable: true, drop: false, dup: false, zero_sized: false];
+type Unit = Struct<ut@Tuple> [storable: true, drop: true, dup: true, zero_sized: true];
+type Array<felt252> = Array<felt252> [storable: true, drop: true, dup: false, zero_sized: false];
+type core::result::Result::<(), core::array::Array::<core::felt252>> = Enum<ut@core::result::Result::<(), core::array::Array::<core::felt252>>, Unit, Array<felt252>> [storable: true, drop: true, dup: false, zero_sized: false];
+type Snapshot<Array<felt252>> = Snapshot<Array<felt252>> [storable: true, drop: true, dup: true, zero_sized: false];
+type core::array::Span::<core::felt252> = Struct<ut@core::array::Span::<core::felt252>, Snapshot<Array<felt252>>> [storable: true, drop: true, dup: true, zero_sized: false];
+type felt252 = felt252 [storable: true, drop: true, dup: true, zero_sized: false];
+type System = System [storable: true, drop: false, dup: false, zero_sized: false];
+
+libfunc send_message_to_l1_syscall = send_message_to_l1_syscall;
+libfunc branch_align = branch_align;
+libfunc struct_construct<Unit> = struct_construct<Unit>;
+libfunc enum_init<core::result::Result::<(), core::array::Array::<core::felt252>>, 0> = enum_init<core::result::Result::<(), core::array::Array::<core::felt252>>, 0>;
+libfunc store_temp<GasBuiltin> = store_temp<GasBuiltin>;
+libfunc store_temp<System> = store_temp<System>;
+libfunc store_temp<core::result::Result::<(), core::array::Array::<core::felt252>>> = store_temp<core::result::Result::<(), core::array::Array::<core::felt252>>>;
+libfunc enum_init<core::result::Result::<(), core::array::Array::<core::felt252>>, 1> = enum_init<core::result::Result::<(), core::array::Array::<core::felt252>>, 1>;
+
+send_message_to_l1_syscall([0], [1], [2], [3]) { fallthrough([4], [5]) 8([6], [7], [8]) }; // 0
+branch_align() -> (); // 1
+struct_construct<Unit>() -> ([9]); // 2
+enum_init<core::result::Result::<(), core::array::Array::<core::felt252>>, 0>([9]) -> ([10]); // 3
+store_temp<GasBuiltin>([4]) -> ([4]); // 4
+store_temp<System>([5]) -> ([5]); // 5
+store_temp<core::result::Result::<(), core::array::Array::<core::felt252>>>([10]) -> ([10]); // 6
+return([4], [5], [10]); // 7
+branch_align() -> (); // 8
+enum_init<core::result::Result::<(), core::array::Array::<core::felt252>>, 1>([8]) -> ([11]); // 9
+store_temp<GasBuiltin>([6]) -> ([6]); // 10
+store_temp<System>([7]) -> ([7]); // 11
+store_temp<core::result::Result::<(), core::array::Array::<core::felt252>>>([11]) -> ([11]); // 12
+return([6], [7], [11]); // 13
+
+test::foo@0([0]: GasBuiltin, [1]: System, [2]: felt252, [3]: core::array::Span::<core::felt252>) -> (GasBuiltin, System, core::result::Result::<(), core::array::Array::<core::felt252>>);

--- a/Aegis/Tests/e2e_libfuncs/syscalls_aegis/storage_read_syscall.sierra
+++ b/Aegis/Tests/e2e_libfuncs/syscalls_aegis/storage_read_syscall.sierra
@@ -1,0 +1,31 @@
+type GasBuiltin = GasBuiltin [storable: true, drop: false, dup: false, zero_sized: false];
+type felt252 = felt252 [storable: true, drop: true, dup: true, zero_sized: false];
+type Array<felt252> = Array<felt252> [storable: true, drop: true, dup: false, zero_sized: false];
+type core::result::Result::<core::felt252, core::array::Array::<core::felt252>> = Enum<ut@core::result::Result::<core::felt252, core::array::Array::<core::felt252>>, felt252, Array<felt252>> [storable: true, drop: true, dup: false, zero_sized: false];
+type StorageAddress = StorageAddress [storable: true, drop: true, dup: true, zero_sized: false];
+type u32 = u32 [storable: true, drop: true, dup: true, zero_sized: false];
+type System = System [storable: true, drop: false, dup: false, zero_sized: false];
+
+libfunc storage_read_syscall = storage_read_syscall;
+libfunc branch_align = branch_align;
+libfunc enum_init<core::result::Result::<core::felt252, core::array::Array::<core::felt252>>, 0> = enum_init<core::result::Result::<core::felt252, core::array::Array::<core::felt252>>, 0>;
+libfunc store_temp<GasBuiltin> = store_temp<GasBuiltin>;
+libfunc store_temp<System> = store_temp<System>;
+libfunc store_temp<core::result::Result::<core::felt252, core::array::Array::<core::felt252>>> = store_temp<core::result::Result::<core::felt252, core::array::Array::<core::felt252>>>;
+libfunc enum_init<core::result::Result::<core::felt252, core::array::Array::<core::felt252>>, 1> = enum_init<core::result::Result::<core::felt252, core::array::Array::<core::felt252>>, 1>;
+
+storage_read_syscall([0], [1], [2], [3]) { fallthrough([4], [5], [6]) 7([7], [8], [9]) }; // 0
+branch_align() -> (); // 1
+enum_init<core::result::Result::<core::felt252, core::array::Array::<core::felt252>>, 0>([6]) -> ([10]); // 2
+store_temp<GasBuiltin>([4]) -> ([4]); // 3
+store_temp<System>([5]) -> ([5]); // 4
+store_temp<core::result::Result::<core::felt252, core::array::Array::<core::felt252>>>([10]) -> ([10]); // 5
+return([4], [5], [10]); // 6
+branch_align() -> (); // 7
+enum_init<core::result::Result::<core::felt252, core::array::Array::<core::felt252>>, 1>([9]) -> ([11]); // 8
+store_temp<GasBuiltin>([7]) -> ([7]); // 9
+store_temp<System>([8]) -> ([8]); // 10
+store_temp<core::result::Result::<core::felt252, core::array::Array::<core::felt252>>>([11]) -> ([11]); // 11
+return([7], [8], [11]); // 12
+
+test::foo@0([0]: GasBuiltin, [1]: System, [2]: u32, [3]: StorageAddress) -> (GasBuiltin, System, core::result::Result::<core::felt252, core::array::Array::<core::felt252>>);

--- a/Aegis/Tests/e2e_libfuncs/syscalls_aegis/storage_write_syscall.sierra
+++ b/Aegis/Tests/e2e_libfuncs/syscalls_aegis/storage_write_syscall.sierra
@@ -1,0 +1,34 @@
+type GasBuiltin = GasBuiltin [storable: true, drop: false, dup: false, zero_sized: false];
+type Unit = Struct<ut@Tuple> [storable: true, drop: true, dup: true, zero_sized: true];
+type Array<felt252> = Array<felt252> [storable: true, drop: true, dup: false, zero_sized: false];
+type core::result::Result::<(), core::array::Array::<core::felt252>> = Enum<ut@core::result::Result::<(), core::array::Array::<core::felt252>>, Unit, Array<felt252>> [storable: true, drop: true, dup: false, zero_sized: false];
+type felt252 = felt252 [storable: true, drop: true, dup: true, zero_sized: false];
+type StorageAddress = StorageAddress [storable: true, drop: true, dup: true, zero_sized: false];
+type u32 = u32 [storable: true, drop: true, dup: true, zero_sized: false];
+type System = System [storable: true, drop: false, dup: false, zero_sized: false];
+
+libfunc storage_write_syscall = storage_write_syscall;
+libfunc branch_align = branch_align;
+libfunc struct_construct<Unit> = struct_construct<Unit>;
+libfunc enum_init<core::result::Result::<(), core::array::Array::<core::felt252>>, 0> = enum_init<core::result::Result::<(), core::array::Array::<core::felt252>>, 0>;
+libfunc store_temp<GasBuiltin> = store_temp<GasBuiltin>;
+libfunc store_temp<System> = store_temp<System>;
+libfunc store_temp<core::result::Result::<(), core::array::Array::<core::felt252>>> = store_temp<core::result::Result::<(), core::array::Array::<core::felt252>>>;
+libfunc enum_init<core::result::Result::<(), core::array::Array::<core::felt252>>, 1> = enum_init<core::result::Result::<(), core::array::Array::<core::felt252>>, 1>;
+
+storage_write_syscall([0], [1], [2], [3], [4]) { fallthrough([5], [6]) 8([7], [8], [9]) }; // 0
+branch_align() -> (); // 1
+struct_construct<Unit>() -> ([10]); // 2
+enum_init<core::result::Result::<(), core::array::Array::<core::felt252>>, 0>([10]) -> ([11]); // 3
+store_temp<GasBuiltin>([5]) -> ([5]); // 4
+store_temp<System>([6]) -> ([6]); // 5
+store_temp<core::result::Result::<(), core::array::Array::<core::felt252>>>([11]) -> ([11]); // 6
+return([5], [6], [11]); // 7
+branch_align() -> (); // 8
+enum_init<core::result::Result::<(), core::array::Array::<core::felt252>>, 1>([9]) -> ([12]); // 9
+store_temp<GasBuiltin>([7]) -> ([7]); // 10
+store_temp<System>([8]) -> ([8]); // 11
+store_temp<core::result::Result::<(), core::array::Array::<core::felt252>>>([12]) -> ([12]); // 12
+return([7], [8], [12]); // 13
+
+test::foo@0([0]: GasBuiltin, [1]: System, [2]: u32, [3]: StorageAddress, [4]: felt252) -> (GasBuiltin, System, core::result::Result::<(), core::array::Array::<core::felt252>>);

--- a/Aegis/Tests/e2e_libfuncs/u128_aegis/u128_byte_reverse.sierra
+++ b/Aegis/Tests/e2e_libfuncs/u128_aegis/u128_byte_reverse.sierra
@@ -1,0 +1,13 @@
+type Bitwise = Bitwise [storable: true, drop: false, dup: false, zero_sized: false];
+type u128 = u128 [storable: true, drop: true, dup: true, zero_sized: false];
+
+libfunc u128_byte_reverse = u128_byte_reverse;
+libfunc store_temp<Bitwise> = store_temp<Bitwise>;
+libfunc store_temp<u128> = store_temp<u128>;
+
+u128_byte_reverse([0], [1]) -> ([2], [3]); // 0
+store_temp<Bitwise>([2]) -> ([2]); // 1
+store_temp<u128>([3]) -> ([3]); // 2
+return([2], [3]); // 3
+
+test::foo@0([0]: Bitwise, [1]: u128) -> (Bitwise, u128);

--- a/Aegis/Tests/e2e_libfuncs/u128_aegis/u128_eq.sierra
+++ b/Aegis/Tests/e2e_libfuncs/u128_aegis/u128_eq.sierra
@@ -1,0 +1,30 @@
+type u128 = u128 [storable: true, drop: true, dup: true, zero_sized: false];
+type Unit = Struct<ut@Tuple> [storable: true, drop: true, dup: true, zero_sized: true];
+type core::bool = Enum<ut@core::bool, Unit, Unit> [storable: true, drop: true, dup: true, zero_sized: false];
+
+libfunc u128_const<11> = u128_const<11>;
+libfunc u128_const<12> = u128_const<12>;
+libfunc store_temp<u128> = store_temp<u128>;
+libfunc u128_eq = u128_eq;
+libfunc branch_align = branch_align;
+libfunc struct_construct<Unit> = struct_construct<Unit>;
+libfunc enum_init<core::bool, 0> = enum_init<core::bool, 0>;
+libfunc store_temp<core::bool> = store_temp<core::bool>;
+libfunc enum_init<core::bool, 1> = enum_init<core::bool, 1>;
+
+u128_const<11>() -> ([0]); // 0
+u128_const<12>() -> ([1]); // 1
+store_temp<u128>([0]) -> ([0]); // 2
+u128_eq([0], [1]) { fallthrough() 9() }; // 3
+branch_align() -> (); // 4
+struct_construct<Unit>() -> ([2]); // 5
+enum_init<core::bool, 0>([2]) -> ([3]); // 6
+store_temp<core::bool>([3]) -> ([3]); // 7
+return([3]); // 8
+branch_align() -> (); // 9
+struct_construct<Unit>() -> ([4]); // 10
+enum_init<core::bool, 1>([4]) -> ([5]); // 11
+store_temp<core::bool>([5]) -> ([5]); // 12
+return([5]); // 13
+
+test::foo@0() -> (core::bool);

--- a/Aegis/Tests/e2e_libfuncs/u128_aegis/u128_overflowing_add.sierra
+++ b/Aegis/Tests/e2e_libfuncs/u128_aegis/u128_overflowing_add.sierra
@@ -1,0 +1,24 @@
+type RangeCheck = RangeCheck [storable: true, drop: false, dup: false, zero_sized: false];
+type u128 = u128 [storable: true, drop: true, dup: true, zero_sized: false];
+type core::result::Result::<core::integer::u128, core::integer::u128> = Enum<ut@core::result::Result::<core::integer::u128, core::integer::u128>, u128, u128> [storable: true, drop: true, dup: true, zero_sized: false];
+
+libfunc u128_overflowing_add = u128_overflowing_add;
+libfunc branch_align = branch_align;
+libfunc enum_init<core::result::Result::<core::integer::u128, core::integer::u128>, 0> = enum_init<core::result::Result::<core::integer::u128, core::integer::u128>, 0>;
+libfunc store_temp<RangeCheck> = store_temp<RangeCheck>;
+libfunc store_temp<core::result::Result::<core::integer::u128, core::integer::u128>> = store_temp<core::result::Result::<core::integer::u128, core::integer::u128>>;
+libfunc enum_init<core::result::Result::<core::integer::u128, core::integer::u128>, 1> = enum_init<core::result::Result::<core::integer::u128, core::integer::u128>, 1>;
+
+u128_overflowing_add([0], [1], [2]) { fallthrough([3], [4]) 6([5], [6]) }; // 0
+branch_align() -> (); // 1
+enum_init<core::result::Result::<core::integer::u128, core::integer::u128>, 0>([4]) -> ([7]); // 2
+store_temp<RangeCheck>([3]) -> ([3]); // 3
+store_temp<core::result::Result::<core::integer::u128, core::integer::u128>>([7]) -> ([7]); // 4
+return([3], [7]); // 5
+branch_align() -> (); // 6
+enum_init<core::result::Result::<core::integer::u128, core::integer::u128>, 1>([6]) -> ([8]); // 7
+store_temp<RangeCheck>([5]) -> ([5]); // 8
+store_temp<core::result::Result::<core::integer::u128, core::integer::u128>>([8]) -> ([8]); // 9
+return([5], [8]); // 10
+
+test::foo@0([0]: RangeCheck, [1]: u128, [2]: u128) -> (RangeCheck, core::result::Result::<core::integer::u128, core::integer::u128>);

--- a/Aegis/Tests/e2e_libfuncs/u128_aegis/u128_overflowing_sub.sierra
+++ b/Aegis/Tests/e2e_libfuncs/u128_aegis/u128_overflowing_sub.sierra
@@ -1,0 +1,24 @@
+type RangeCheck = RangeCheck [storable: true, drop: false, dup: false, zero_sized: false];
+type u128 = u128 [storable: true, drop: true, dup: true, zero_sized: false];
+type core::result::Result::<core::integer::u128, core::integer::u128> = Enum<ut@core::result::Result::<core::integer::u128, core::integer::u128>, u128, u128> [storable: true, drop: true, dup: true, zero_sized: false];
+
+libfunc u128_overflowing_sub = u128_overflowing_sub;
+libfunc branch_align = branch_align;
+libfunc enum_init<core::result::Result::<core::integer::u128, core::integer::u128>, 0> = enum_init<core::result::Result::<core::integer::u128, core::integer::u128>, 0>;
+libfunc store_temp<RangeCheck> = store_temp<RangeCheck>;
+libfunc store_temp<core::result::Result::<core::integer::u128, core::integer::u128>> = store_temp<core::result::Result::<core::integer::u128, core::integer::u128>>;
+libfunc enum_init<core::result::Result::<core::integer::u128, core::integer::u128>, 1> = enum_init<core::result::Result::<core::integer::u128, core::integer::u128>, 1>;
+
+u128_overflowing_sub([0], [1], [2]) { fallthrough([3], [4]) 6([5], [6]) }; // 0
+branch_align() -> (); // 1
+enum_init<core::result::Result::<core::integer::u128, core::integer::u128>, 0>([4]) -> ([7]); // 2
+store_temp<RangeCheck>([3]) -> ([3]); // 3
+store_temp<core::result::Result::<core::integer::u128, core::integer::u128>>([7]) -> ([7]); // 4
+return([3], [7]); // 5
+branch_align() -> (); // 6
+enum_init<core::result::Result::<core::integer::u128, core::integer::u128>, 1>([6]) -> ([8]); // 7
+store_temp<RangeCheck>([5]) -> ([5]); // 8
+store_temp<core::result::Result::<core::integer::u128, core::integer::u128>>([8]) -> ([8]); // 9
+return([5], [8]); // 10
+
+test::foo@0([0]: RangeCheck, [1]: u128, [2]: u128) -> (RangeCheck, core::result::Result::<core::integer::u128, core::integer::u128>);

--- a/Aegis/Tests/e2e_libfuncs/u128_aegis/u128_safe_divmod.sierra
+++ b/Aegis/Tests/e2e_libfuncs/u128_aegis/u128_safe_divmod.sierra
@@ -1,0 +1,17 @@
+type RangeCheck = RangeCheck [storable: true, drop: false, dup: false, zero_sized: false];
+type u128 = u128 [storable: true, drop: true, dup: true, zero_sized: false];
+type Tuple<u128, u128> = Struct<ut@Tuple, u128, u128> [storable: true, drop: true, dup: true, zero_sized: false];
+type NonZero<u128> = NonZero<u128> [storable: true, drop: true, dup: true, zero_sized: false];
+
+libfunc u128_safe_divmod = u128_safe_divmod;
+libfunc struct_construct<Tuple<u128, u128>> = struct_construct<Tuple<u128, u128>>;
+libfunc store_temp<RangeCheck> = store_temp<RangeCheck>;
+libfunc store_temp<Tuple<u128, u128>> = store_temp<Tuple<u128, u128>>;
+
+u128_safe_divmod([0], [1], [2]) -> ([3], [4], [5]); // 0
+struct_construct<Tuple<u128, u128>>([4], [5]) -> ([6]); // 1
+store_temp<RangeCheck>([3]) -> ([3]); // 2
+store_temp<Tuple<u128, u128>>([6]) -> ([6]); // 3
+return([3], [6]); // 4
+
+test::foo@0([0]: RangeCheck, [1]: u128, [2]: NonZero<u128>) -> (RangeCheck, Tuple<u128, u128>);

--- a/Aegis/Tests/e2e_libfuncs/u128_aegis/u128_sqrt.sierra
+++ b/Aegis/Tests/e2e_libfuncs/u128_aegis/u128_sqrt.sierra
@@ -1,0 +1,14 @@
+type RangeCheck = RangeCheck [storable: true, drop: false, dup: false, zero_sized: false];
+type u64 = u64 [storable: true, drop: true, dup: true, zero_sized: false];
+type u128 = u128 [storable: true, drop: true, dup: true, zero_sized: false];
+
+libfunc u128_sqrt = u128_sqrt;
+libfunc store_temp<RangeCheck> = store_temp<RangeCheck>;
+libfunc store_temp<u64> = store_temp<u64>;
+
+u128_sqrt([0], [1]) -> ([2], [3]); // 0
+store_temp<RangeCheck>([2]) -> ([2]); // 1
+store_temp<u64>([3]) -> ([3]); // 2
+return([2], [3]); // 3
+
+test::foo@0([0]: RangeCheck, [1]: u128) -> (RangeCheck, u64);

--- a/Aegis/Tests/e2e_libfuncs/u128_aegis/u128s_from_felt252.sierra
+++ b/Aegis/Tests/e2e_libfuncs/u128_aegis/u128s_from_felt252.sierra
@@ -1,0 +1,28 @@
+type RangeCheck = RangeCheck [storable: true, drop: false, dup: false, zero_sized: false];
+type u128 = u128 [storable: true, drop: true, dup: true, zero_sized: false];
+type Tuple<u128, u128> = Struct<ut@Tuple, u128, u128> [storable: true, drop: true, dup: true, zero_sized: false];
+type core::integer::U128sFromFelt252Result = Enum<ut@core::integer::U128sFromFelt252Result, u128, Tuple<u128, u128>> [storable: true, drop: true, dup: true, zero_sized: false];
+type felt252 = felt252 [storable: true, drop: true, dup: true, zero_sized: false];
+
+libfunc u128s_from_felt252 = u128s_from_felt252;
+libfunc branch_align = branch_align;
+libfunc enum_init<core::integer::U128sFromFelt252Result, 0> = enum_init<core::integer::U128sFromFelt252Result, 0>;
+libfunc store_temp<RangeCheck> = store_temp<RangeCheck>;
+libfunc store_temp<core::integer::U128sFromFelt252Result> = store_temp<core::integer::U128sFromFelt252Result>;
+libfunc struct_construct<Tuple<u128, u128>> = struct_construct<Tuple<u128, u128>>;
+libfunc enum_init<core::integer::U128sFromFelt252Result, 1> = enum_init<core::integer::U128sFromFelt252Result, 1>;
+
+u128s_from_felt252([0], [1]) { fallthrough([2], [3]) 6([4], [5], [6]) }; // 0
+branch_align() -> (); // 1
+enum_init<core::integer::U128sFromFelt252Result, 0>([3]) -> ([7]); // 2
+store_temp<RangeCheck>([2]) -> ([2]); // 3
+store_temp<core::integer::U128sFromFelt252Result>([7]) -> ([7]); // 4
+return([2], [7]); // 5
+branch_align() -> (); // 6
+struct_construct<Tuple<u128, u128>>([5], [6]) -> ([8]); // 7
+enum_init<core::integer::U128sFromFelt252Result, 1>([8]) -> ([9]); // 8
+store_temp<RangeCheck>([4]) -> ([4]); // 9
+store_temp<core::integer::U128sFromFelt252Result>([9]) -> ([9]); // 10
+return([4], [9]); // 11
+
+test::foo@0([0]: RangeCheck, [1]: felt252) -> (RangeCheck, core::integer::U128sFromFelt252Result);

--- a/Aegis/Tests/e2e_libfuncs/u16_aegis/u16_eq.sierra
+++ b/Aegis/Tests/e2e_libfuncs/u16_aegis/u16_eq.sierra
@@ -1,0 +1,30 @@
+type u16 = u16 [storable: true, drop: true, dup: true, zero_sized: false];
+type Unit = Struct<ut@Tuple> [storable: true, drop: true, dup: true, zero_sized: true];
+type core::bool = Enum<ut@core::bool, Unit, Unit> [storable: true, drop: true, dup: true, zero_sized: false];
+
+libfunc u16_const<11> = u16_const<11>;
+libfunc u16_const<12> = u16_const<12>;
+libfunc store_temp<u16> = store_temp<u16>;
+libfunc u16_eq = u16_eq;
+libfunc branch_align = branch_align;
+libfunc struct_construct<Unit> = struct_construct<Unit>;
+libfunc enum_init<core::bool, 0> = enum_init<core::bool, 0>;
+libfunc store_temp<core::bool> = store_temp<core::bool>;
+libfunc enum_init<core::bool, 1> = enum_init<core::bool, 1>;
+
+u16_const<11>() -> ([0]); // 0
+u16_const<12>() -> ([1]); // 1
+store_temp<u16>([0]) -> ([0]); // 2
+u16_eq([0], [1]) { fallthrough() 9() }; // 3
+branch_align() -> (); // 4
+struct_construct<Unit>() -> ([2]); // 5
+enum_init<core::bool, 0>([2]) -> ([3]); // 6
+store_temp<core::bool>([3]) -> ([3]); // 7
+return([3]); // 8
+branch_align() -> (); // 9
+struct_construct<Unit>() -> ([4]); // 10
+enum_init<core::bool, 1>([4]) -> ([5]); // 11
+store_temp<core::bool>([5]) -> ([5]); // 12
+return([5]); // 13
+
+test::foo@0() -> (core::bool);

--- a/Aegis/Tests/e2e_libfuncs/u16_aegis/u16_is_zero.sierra
+++ b/Aegis/Tests/e2e_libfuncs/u16_aegis/u16_is_zero.sierra
@@ -1,0 +1,20 @@
+type u16 = u16 [storable: true, drop: true, dup: true, zero_sized: false];
+type NonZero<u16> = NonZero<u16> [storable: true, drop: true, dup: true, zero_sized: false];
+
+libfunc u16_is_zero = u16_is_zero;
+libfunc branch_align = branch_align;
+libfunc u16_const<1234> = u16_const<1234>;
+libfunc store_temp<u16> = store_temp<u16>;
+libfunc unwrap_non_zero<u16> = unwrap_non_zero<u16>;
+
+u16_is_zero([0]) { fallthrough() 5([1]) }; // 0
+branch_align() -> (); // 1
+u16_const<1234>() -> ([2]); // 2
+store_temp<u16>([2]) -> ([2]); // 3
+return([2]); // 4
+branch_align() -> (); // 5
+unwrap_non_zero<u16>([1]) -> ([3]); // 6
+store_temp<u16>([3]) -> ([3]); // 7
+return([3]); // 8
+
+test::foo@0([0]: u16) -> (u16);

--- a/Aegis/Tests/e2e_libfuncs/u16_aegis/u16_overflowing_add.sierra
+++ b/Aegis/Tests/e2e_libfuncs/u16_aegis/u16_overflowing_add.sierra
@@ -1,0 +1,24 @@
+type RangeCheck = RangeCheck [storable: true, drop: false, dup: false, zero_sized: false];
+type u16 = u16 [storable: true, drop: true, dup: true, zero_sized: false];
+type core::result::Result::<core::integer::u16, core::integer::u16> = Enum<ut@core::result::Result::<core::integer::u16, core::integer::u16>, u16, u16> [storable: true, drop: true, dup: true, zero_sized: false];
+
+libfunc u16_overflowing_add = u16_overflowing_add;
+libfunc branch_align = branch_align;
+libfunc enum_init<core::result::Result::<core::integer::u16, core::integer::u16>, 0> = enum_init<core::result::Result::<core::integer::u16, core::integer::u16>, 0>;
+libfunc store_temp<RangeCheck> = store_temp<RangeCheck>;
+libfunc store_temp<core::result::Result::<core::integer::u16, core::integer::u16>> = store_temp<core::result::Result::<core::integer::u16, core::integer::u16>>;
+libfunc enum_init<core::result::Result::<core::integer::u16, core::integer::u16>, 1> = enum_init<core::result::Result::<core::integer::u16, core::integer::u16>, 1>;
+
+u16_overflowing_add([0], [1], [2]) { fallthrough([3], [4]) 6([5], [6]) }; // 0
+branch_align() -> (); // 1
+enum_init<core::result::Result::<core::integer::u16, core::integer::u16>, 0>([4]) -> ([7]); // 2
+store_temp<RangeCheck>([3]) -> ([3]); // 3
+store_temp<core::result::Result::<core::integer::u16, core::integer::u16>>([7]) -> ([7]); // 4
+return([3], [7]); // 5
+branch_align() -> (); // 6
+enum_init<core::result::Result::<core::integer::u16, core::integer::u16>, 1>([6]) -> ([8]); // 7
+store_temp<RangeCheck>([5]) -> ([5]); // 8
+store_temp<core::result::Result::<core::integer::u16, core::integer::u16>>([8]) -> ([8]); // 9
+return([5], [8]); // 10
+
+test::foo@0([0]: RangeCheck, [1]: u16, [2]: u16) -> (RangeCheck, core::result::Result::<core::integer::u16, core::integer::u16>);

--- a/Aegis/Tests/e2e_libfuncs/u16_aegis/u16_overflowing_sub.sierra
+++ b/Aegis/Tests/e2e_libfuncs/u16_aegis/u16_overflowing_sub.sierra
@@ -1,0 +1,24 @@
+type RangeCheck = RangeCheck [storable: true, drop: false, dup: false, zero_sized: false];
+type u16 = u16 [storable: true, drop: true, dup: true, zero_sized: false];
+type core::result::Result::<core::integer::u16, core::integer::u16> = Enum<ut@core::result::Result::<core::integer::u16, core::integer::u16>, u16, u16> [storable: true, drop: true, dup: true, zero_sized: false];
+
+libfunc u16_overflowing_sub = u16_overflowing_sub;
+libfunc branch_align = branch_align;
+libfunc enum_init<core::result::Result::<core::integer::u16, core::integer::u16>, 0> = enum_init<core::result::Result::<core::integer::u16, core::integer::u16>, 0>;
+libfunc store_temp<RangeCheck> = store_temp<RangeCheck>;
+libfunc store_temp<core::result::Result::<core::integer::u16, core::integer::u16>> = store_temp<core::result::Result::<core::integer::u16, core::integer::u16>>;
+libfunc enum_init<core::result::Result::<core::integer::u16, core::integer::u16>, 1> = enum_init<core::result::Result::<core::integer::u16, core::integer::u16>, 1>;
+
+u16_overflowing_sub([0], [1], [2]) { fallthrough([3], [4]) 6([5], [6]) }; // 0
+branch_align() -> (); // 1
+enum_init<core::result::Result::<core::integer::u16, core::integer::u16>, 0>([4]) -> ([7]); // 2
+store_temp<RangeCheck>([3]) -> ([3]); // 3
+store_temp<core::result::Result::<core::integer::u16, core::integer::u16>>([7]) -> ([7]); // 4
+return([3], [7]); // 5
+branch_align() -> (); // 6
+enum_init<core::result::Result::<core::integer::u16, core::integer::u16>, 1>([6]) -> ([8]); // 7
+store_temp<RangeCheck>([5]) -> ([5]); // 8
+store_temp<core::result::Result::<core::integer::u16, core::integer::u16>>([8]) -> ([8]); // 9
+return([5], [8]); // 10
+
+test::foo@0([0]: RangeCheck, [1]: u16, [2]: u16) -> (RangeCheck, core::result::Result::<core::integer::u16, core::integer::u16>);

--- a/Aegis/Tests/e2e_libfuncs/u16_aegis/u16_safe_divmod.sierra
+++ b/Aegis/Tests/e2e_libfuncs/u16_aegis/u16_safe_divmod.sierra
@@ -1,0 +1,17 @@
+type RangeCheck = RangeCheck [storable: true, drop: false, dup: false, zero_sized: false];
+type u16 = u16 [storable: true, drop: true, dup: true, zero_sized: false];
+type Tuple<u16, u16> = Struct<ut@Tuple, u16, u16> [storable: true, drop: true, dup: true, zero_sized: false];
+type NonZero<u16> = NonZero<u16> [storable: true, drop: true, dup: true, zero_sized: false];
+
+libfunc u16_safe_divmod = u16_safe_divmod;
+libfunc struct_construct<Tuple<u16, u16>> = struct_construct<Tuple<u16, u16>>;
+libfunc store_temp<RangeCheck> = store_temp<RangeCheck>;
+libfunc store_temp<Tuple<u16, u16>> = store_temp<Tuple<u16, u16>>;
+
+u16_safe_divmod([0], [1], [2]) -> ([3], [4], [5]); // 0
+struct_construct<Tuple<u16, u16>>([4], [5]) -> ([6]); // 1
+store_temp<RangeCheck>([3]) -> ([3]); // 2
+store_temp<Tuple<u16, u16>>([6]) -> ([6]); // 3
+return([3], [6]); // 4
+
+test::foo@0([0]: RangeCheck, [1]: u16, [2]: NonZero<u16>) -> (RangeCheck, Tuple<u16, u16>);

--- a/Aegis/Tests/e2e_libfuncs/u16_aegis/u16_sqrt.sierra
+++ b/Aegis/Tests/e2e_libfuncs/u16_aegis/u16_sqrt.sierra
@@ -1,0 +1,14 @@
+type RangeCheck = RangeCheck [storable: true, drop: false, dup: false, zero_sized: false];
+type u8 = u8 [storable: true, drop: true, dup: true, zero_sized: false];
+type u16 = u16 [storable: true, drop: true, dup: true, zero_sized: false];
+
+libfunc u16_sqrt = u16_sqrt;
+libfunc store_temp<RangeCheck> = store_temp<RangeCheck>;
+libfunc store_temp<u8> = store_temp<u8>;
+
+u16_sqrt([0], [1]) -> ([2], [3]); // 0
+store_temp<RangeCheck>([2]) -> ([2]); // 1
+store_temp<u8>([3]) -> ([3]); // 2
+return([2], [3]); // 3
+
+test::foo@0([0]: RangeCheck, [1]: u16) -> (RangeCheck, u8);

--- a/Aegis/Tests/e2e_libfuncs/u16_aegis/u16_try_from_felt252.sierra
+++ b/Aegis/Tests/e2e_libfuncs/u16_aegis/u16_try_from_felt252.sierra
@@ -1,0 +1,28 @@
+type RangeCheck = RangeCheck [storable: true, drop: false, dup: false, zero_sized: false];
+type Unit = Struct<ut@Tuple> [storable: true, drop: true, dup: true, zero_sized: true];
+type u16 = u16 [storable: true, drop: true, dup: true, zero_sized: false];
+type core::option::Option::<core::integer::u16> = Enum<ut@core::option::Option::<core::integer::u16>, u16, Unit> [storable: true, drop: true, dup: true, zero_sized: false];
+type felt252 = felt252 [storable: true, drop: true, dup: true, zero_sized: false];
+
+libfunc u16_try_from_felt252 = u16_try_from_felt252;
+libfunc branch_align = branch_align;
+libfunc enum_init<core::option::Option::<core::integer::u16>, 0> = enum_init<core::option::Option::<core::integer::u16>, 0>;
+libfunc store_temp<RangeCheck> = store_temp<RangeCheck>;
+libfunc store_temp<core::option::Option::<core::integer::u16>> = store_temp<core::option::Option::<core::integer::u16>>;
+libfunc struct_construct<Unit> = struct_construct<Unit>;
+libfunc enum_init<core::option::Option::<core::integer::u16>, 1> = enum_init<core::option::Option::<core::integer::u16>, 1>;
+
+u16_try_from_felt252([0], [1]) { fallthrough([2], [3]) 6([4]) }; // 0
+branch_align() -> (); // 1
+enum_init<core::option::Option::<core::integer::u16>, 0>([3]) -> ([5]); // 2
+store_temp<RangeCheck>([2]) -> ([2]); // 3
+store_temp<core::option::Option::<core::integer::u16>>([5]) -> ([5]); // 4
+return([2], [5]); // 5
+branch_align() -> (); // 6
+struct_construct<Unit>() -> ([6]); // 7
+enum_init<core::option::Option::<core::integer::u16>, 1>([6]) -> ([7]); // 8
+store_temp<RangeCheck>([4]) -> ([4]); // 9
+store_temp<core::option::Option::<core::integer::u16>>([7]) -> ([7]); // 10
+return([4], [7]); // 11
+
+test::foo@0([0]: RangeCheck, [1]: felt252) -> (RangeCheck, core::option::Option::<core::integer::u16>);

--- a/Aegis/Tests/e2e_libfuncs/u16_aegis/u16_wide_mul.sierra
+++ b/Aegis/Tests/e2e_libfuncs/u16_aegis/u16_wide_mul.sierra
@@ -1,0 +1,11 @@
+type u16 = u16 [storable: true, drop: true, dup: true, zero_sized: false];
+type u32 = u32 [storable: true, drop: true, dup: true, zero_sized: false];
+
+libfunc u16_wide_mul = u16_wide_mul;
+libfunc store_temp<u32> = store_temp<u32>;
+
+u16_wide_mul([0], [1]) -> ([2]); // 0
+store_temp<u32>([2]) -> ([2]); // 1
+return([2]); // 2
+
+test::foo@0([0]: u16, [1]: u16) -> (u32);

--- a/Aegis/Tests/e2e_libfuncs/u256_aegis/u256_guarantee_inv_mod_n.sierra
+++ b/Aegis/Tests/e2e_libfuncs/u256_aegis/u256_guarantee_inv_mod_n.sierra
@@ -1,0 +1,41 @@
+type RangeCheck = RangeCheck [storable: true, drop: false, dup: false, zero_sized: false];
+type Unit = Struct<ut@Tuple> [storable: true, drop: true, dup: true, zero_sized: true];
+type u128 = u128 [storable: true, drop: true, dup: true, zero_sized: false];
+type core::integer::u256 = Struct<ut@core::integer::u256, u128, u128> [storable: true, drop: true, dup: true, zero_sized: false];
+type NonZero<core::integer::u256> = NonZero<core::integer::u256> [storable: true, drop: true, dup: true, zero_sized: false];
+type core::option::Option::<core::zeroable::NonZero::<core::integer::u256>> = Enum<ut@core::option::Option::<core::zeroable::NonZero::<core::integer::u256>>, NonZero<core::integer::u256>, Unit> [storable: true, drop: true, dup: true, zero_sized: false];
+type U128MulGuarantee = U128MulGuarantee [storable: true, drop: false, dup: false, zero_sized: false];
+
+libfunc u256_guarantee_inv_mod_n = u256_guarantee_inv_mod_n;
+libfunc branch_align = branch_align;
+libfunc u128_mul_guarantee_verify = u128_mul_guarantee_verify;
+libfunc enum_init<core::option::Option::<core::zeroable::NonZero::<core::integer::u256>>, 0> = enum_init<core::option::Option::<core::zeroable::NonZero::<core::integer::u256>>, 0>;
+libfunc store_temp<RangeCheck> = store_temp<RangeCheck>;
+libfunc store_temp<core::option::Option::<core::zeroable::NonZero::<core::integer::u256>>> = store_temp<core::option::Option::<core::zeroable::NonZero::<core::integer::u256>>>;
+libfunc struct_construct<Unit> = struct_construct<Unit>;
+libfunc enum_init<core::option::Option::<core::zeroable::NonZero::<core::integer::u256>>, 1> = enum_init<core::option::Option::<core::zeroable::NonZero::<core::integer::u256>>, 1>;
+
+u256_guarantee_inv_mod_n([0], [1], [2]) { fallthrough([3], [4], [5], [6], [7], [8], [9], [10], [11], [12]) 14([13], [14], [15]) }; // 0
+branch_align() -> (); // 1
+u128_mul_guarantee_verify([3], [12]) -> ([16]); // 2
+u128_mul_guarantee_verify([16], [11]) -> ([17]); // 3
+u128_mul_guarantee_verify([17], [10]) -> ([18]); // 4
+u128_mul_guarantee_verify([18], [9]) -> ([19]); // 5
+u128_mul_guarantee_verify([19], [8]) -> ([20]); // 6
+u128_mul_guarantee_verify([20], [7]) -> ([21]); // 7
+u128_mul_guarantee_verify([21], [6]) -> ([22]); // 8
+u128_mul_guarantee_verify([22], [5]) -> ([23]); // 9
+enum_init<core::option::Option::<core::zeroable::NonZero::<core::integer::u256>>, 0>([4]) -> ([24]); // 10
+store_temp<RangeCheck>([23]) -> ([23]); // 11
+store_temp<core::option::Option::<core::zeroable::NonZero::<core::integer::u256>>>([24]) -> ([24]); // 12
+return([23], [24]); // 13
+branch_align() -> (); // 14
+u128_mul_guarantee_verify([13], [15]) -> ([25]); // 15
+u128_mul_guarantee_verify([25], [14]) -> ([26]); // 16
+struct_construct<Unit>() -> ([27]); // 17
+enum_init<core::option::Option::<core::zeroable::NonZero::<core::integer::u256>>, 1>([27]) -> ([28]); // 18
+store_temp<RangeCheck>([26]) -> ([26]); // 19
+store_temp<core::option::Option::<core::zeroable::NonZero::<core::integer::u256>>>([28]) -> ([28]); // 20
+return([26], [28]); // 21
+
+test::foo@0([0]: RangeCheck, [1]: core::integer::u256, [2]: NonZero<core::integer::u256>) -> (RangeCheck, core::option::Option::<core::zeroable::NonZero::<core::integer::u256>>);

--- a/Aegis/Tests/e2e_libfuncs/u256_aegis/u256_is_zero.sierra
+++ b/Aegis/Tests/e2e_libfuncs/u256_aegis/u256_is_zero.sierra
@@ -1,0 +1,24 @@
+type u128 = u128 [storable: true, drop: true, dup: true, zero_sized: false];
+type core::integer::u256 = Struct<ut@core::integer::u256, u128, u128> [storable: true, drop: true, dup: true, zero_sized: false];
+type NonZero<core::integer::u256> = NonZero<core::integer::u256> [storable: true, drop: true, dup: true, zero_sized: false];
+
+libfunc u256_is_zero = u256_is_zero;
+libfunc branch_align = branch_align;
+libfunc u128_const<0> = u128_const<0>;
+libfunc struct_construct<core::integer::u256> = struct_construct<core::integer::u256>;
+libfunc store_temp<core::integer::u256> = store_temp<core::integer::u256>;
+libfunc unwrap_non_zero<core::integer::u256> = unwrap_non_zero<core::integer::u256>;
+
+u256_is_zero([0]) { fallthrough() 7([1]) }; // 0
+branch_align() -> (); // 1
+u128_const<0>() -> ([2]); // 2
+u128_const<0>() -> ([3]); // 3
+struct_construct<core::integer::u256>([2], [3]) -> ([4]); // 4
+store_temp<core::integer::u256>([4]) -> ([4]); // 5
+return([4]); // 6
+branch_align() -> (); // 7
+unwrap_non_zero<core::integer::u256>([1]) -> ([5]); // 8
+store_temp<core::integer::u256>([5]) -> ([5]); // 9
+return([5]); // 10
+
+test::foo@0([0]: core::integer::u256) -> (core::integer::u256);

--- a/Aegis/Tests/e2e_libfuncs/u256_aegis/u256_safe_divmod.sierra
+++ b/Aegis/Tests/e2e_libfuncs/u256_aegis/u256_safe_divmod.sierra
@@ -1,0 +1,21 @@
+type RangeCheck = RangeCheck [storable: true, drop: false, dup: false, zero_sized: false];
+type u128 = u128 [storable: true, drop: true, dup: true, zero_sized: false];
+type core::integer::u256 = Struct<ut@core::integer::u256, u128, u128> [storable: true, drop: true, dup: true, zero_sized: false];
+type Tuple<core::integer::u256, core::integer::u256> = Struct<ut@Tuple, core::integer::u256, core::integer::u256> [storable: true, drop: true, dup: true, zero_sized: false];
+type U128MulGuarantee = U128MulGuarantee [storable: true, drop: false, dup: false, zero_sized: false];
+type NonZero<core::integer::u256> = NonZero<core::integer::u256> [storable: true, drop: true, dup: true, zero_sized: false];
+
+libfunc u256_safe_divmod = u256_safe_divmod;
+libfunc u128_mul_guarantee_verify = u128_mul_guarantee_verify;
+libfunc struct_construct<Tuple<core::integer::u256, core::integer::u256>> = struct_construct<Tuple<core::integer::u256, core::integer::u256>>;
+libfunc store_temp<RangeCheck> = store_temp<RangeCheck>;
+libfunc store_temp<Tuple<core::integer::u256, core::integer::u256>> = store_temp<Tuple<core::integer::u256, core::integer::u256>>;
+
+u256_safe_divmod([0], [1], [2]) -> ([3], [4], [5], [6]); // 0
+u128_mul_guarantee_verify([3], [6]) -> ([7]); // 1
+struct_construct<Tuple<core::integer::u256, core::integer::u256>>([4], [5]) -> ([8]); // 2
+store_temp<RangeCheck>([7]) -> ([7]); // 3
+store_temp<Tuple<core::integer::u256, core::integer::u256>>([8]) -> ([8]); // 4
+return([7], [8]); // 5
+
+test::foo@0([0]: RangeCheck, [1]: core::integer::u256, [2]: NonZero<core::integer::u256>) -> (RangeCheck, Tuple<core::integer::u256, core::integer::u256>);

--- a/Aegis/Tests/e2e_libfuncs/u256_aegis/u256_sqrt.sierra
+++ b/Aegis/Tests/e2e_libfuncs/u256_aegis/u256_sqrt.sierra
@@ -1,0 +1,14 @@
+type RangeCheck = RangeCheck [storable: true, drop: false, dup: false, zero_sized: false];
+type u128 = u128 [storable: true, drop: true, dup: true, zero_sized: false];
+type core::integer::u256 = Struct<ut@core::integer::u256, u128, u128> [storable: true, drop: true, dup: true, zero_sized: false];
+
+libfunc u256_sqrt = u256_sqrt;
+libfunc store_temp<RangeCheck> = store_temp<RangeCheck>;
+libfunc store_temp<u128> = store_temp<u128>;
+
+u256_sqrt([0], [1]) -> ([2], [3]); // 0
+store_temp<RangeCheck>([2]) -> ([2]); // 1
+store_temp<u128>([3]) -> ([3]); // 2
+return([2], [3]); // 3
+
+test::foo@0([0]: RangeCheck, [1]: core::integer::u256) -> (RangeCheck, u128);

--- a/Aegis/Tests/e2e_libfuncs/u32_aegis/u32_eq.sierra
+++ b/Aegis/Tests/e2e_libfuncs/u32_aegis/u32_eq.sierra
@@ -1,0 +1,30 @@
+type u32 = u32 [storable: true, drop: true, dup: true, zero_sized: false];
+type Unit = Struct<ut@Tuple> [storable: true, drop: true, dup: true, zero_sized: true];
+type core::bool = Enum<ut@core::bool, Unit, Unit> [storable: true, drop: true, dup: true, zero_sized: false];
+
+libfunc u32_const<11> = u32_const<11>;
+libfunc u32_const<12> = u32_const<12>;
+libfunc store_temp<u32> = store_temp<u32>;
+libfunc u32_eq = u32_eq;
+libfunc branch_align = branch_align;
+libfunc struct_construct<Unit> = struct_construct<Unit>;
+libfunc enum_init<core::bool, 0> = enum_init<core::bool, 0>;
+libfunc store_temp<core::bool> = store_temp<core::bool>;
+libfunc enum_init<core::bool, 1> = enum_init<core::bool, 1>;
+
+u32_const<11>() -> ([0]); // 0
+u32_const<12>() -> ([1]); // 1
+store_temp<u32>([0]) -> ([0]); // 2
+u32_eq([0], [1]) { fallthrough() 9() }; // 3
+branch_align() -> (); // 4
+struct_construct<Unit>() -> ([2]); // 5
+enum_init<core::bool, 0>([2]) -> ([3]); // 6
+store_temp<core::bool>([3]) -> ([3]); // 7
+return([3]); // 8
+branch_align() -> (); // 9
+struct_construct<Unit>() -> ([4]); // 10
+enum_init<core::bool, 1>([4]) -> ([5]); // 11
+store_temp<core::bool>([5]) -> ([5]); // 12
+return([5]); // 13
+
+test::foo@0() -> (core::bool);

--- a/Aegis/Tests/e2e_libfuncs/u32_aegis/u32_is_zero.sierra
+++ b/Aegis/Tests/e2e_libfuncs/u32_aegis/u32_is_zero.sierra
@@ -1,0 +1,20 @@
+type u32 = u32 [storable: true, drop: true, dup: true, zero_sized: false];
+type NonZero<u32> = NonZero<u32> [storable: true, drop: true, dup: true, zero_sized: false];
+
+libfunc u32_is_zero = u32_is_zero;
+libfunc branch_align = branch_align;
+libfunc u32_const<1234> = u32_const<1234>;
+libfunc store_temp<u32> = store_temp<u32>;
+libfunc unwrap_non_zero<u32> = unwrap_non_zero<u32>;
+
+u32_is_zero([0]) { fallthrough() 5([1]) }; // 0
+branch_align() -> (); // 1
+u32_const<1234>() -> ([2]); // 2
+store_temp<u32>([2]) -> ([2]); // 3
+return([2]); // 4
+branch_align() -> (); // 5
+unwrap_non_zero<u32>([1]) -> ([3]); // 6
+store_temp<u32>([3]) -> ([3]); // 7
+return([3]); // 8
+
+test::foo@0([0]: u32) -> (u32);

--- a/Aegis/Tests/e2e_libfuncs/u32_aegis/u32_overflowing_add.sierra
+++ b/Aegis/Tests/e2e_libfuncs/u32_aegis/u32_overflowing_add.sierra
@@ -1,0 +1,24 @@
+type RangeCheck = RangeCheck [storable: true, drop: false, dup: false, zero_sized: false];
+type u32 = u32 [storable: true, drop: true, dup: true, zero_sized: false];
+type core::result::Result::<core::integer::u32, core::integer::u32> = Enum<ut@core::result::Result::<core::integer::u32, core::integer::u32>, u32, u32> [storable: true, drop: true, dup: true, zero_sized: false];
+
+libfunc u32_overflowing_add = u32_overflowing_add;
+libfunc branch_align = branch_align;
+libfunc enum_init<core::result::Result::<core::integer::u32, core::integer::u32>, 0> = enum_init<core::result::Result::<core::integer::u32, core::integer::u32>, 0>;
+libfunc store_temp<RangeCheck> = store_temp<RangeCheck>;
+libfunc store_temp<core::result::Result::<core::integer::u32, core::integer::u32>> = store_temp<core::result::Result::<core::integer::u32, core::integer::u32>>;
+libfunc enum_init<core::result::Result::<core::integer::u32, core::integer::u32>, 1> = enum_init<core::result::Result::<core::integer::u32, core::integer::u32>, 1>;
+
+u32_overflowing_add([0], [1], [2]) { fallthrough([3], [4]) 6([5], [6]) }; // 0
+branch_align() -> (); // 1
+enum_init<core::result::Result::<core::integer::u32, core::integer::u32>, 0>([4]) -> ([7]); // 2
+store_temp<RangeCheck>([3]) -> ([3]); // 3
+store_temp<core::result::Result::<core::integer::u32, core::integer::u32>>([7]) -> ([7]); // 4
+return([3], [7]); // 5
+branch_align() -> (); // 6
+enum_init<core::result::Result::<core::integer::u32, core::integer::u32>, 1>([6]) -> ([8]); // 7
+store_temp<RangeCheck>([5]) -> ([5]); // 8
+store_temp<core::result::Result::<core::integer::u32, core::integer::u32>>([8]) -> ([8]); // 9
+return([5], [8]); // 10
+
+test::foo@0([0]: RangeCheck, [1]: u32, [2]: u32) -> (RangeCheck, core::result::Result::<core::integer::u32, core::integer::u32>);

--- a/Aegis/Tests/e2e_libfuncs/u32_aegis/u32_overflowing_sub.sierra
+++ b/Aegis/Tests/e2e_libfuncs/u32_aegis/u32_overflowing_sub.sierra
@@ -1,0 +1,24 @@
+type RangeCheck = RangeCheck [storable: true, drop: false, dup: false, zero_sized: false];
+type u32 = u32 [storable: true, drop: true, dup: true, zero_sized: false];
+type core::result::Result::<core::integer::u32, core::integer::u32> = Enum<ut@core::result::Result::<core::integer::u32, core::integer::u32>, u32, u32> [storable: true, drop: true, dup: true, zero_sized: false];
+
+libfunc u32_overflowing_sub = u32_overflowing_sub;
+libfunc branch_align = branch_align;
+libfunc enum_init<core::result::Result::<core::integer::u32, core::integer::u32>, 0> = enum_init<core::result::Result::<core::integer::u32, core::integer::u32>, 0>;
+libfunc store_temp<RangeCheck> = store_temp<RangeCheck>;
+libfunc store_temp<core::result::Result::<core::integer::u32, core::integer::u32>> = store_temp<core::result::Result::<core::integer::u32, core::integer::u32>>;
+libfunc enum_init<core::result::Result::<core::integer::u32, core::integer::u32>, 1> = enum_init<core::result::Result::<core::integer::u32, core::integer::u32>, 1>;
+
+u32_overflowing_sub([0], [1], [2]) { fallthrough([3], [4]) 6([5], [6]) }; // 0
+branch_align() -> (); // 1
+enum_init<core::result::Result::<core::integer::u32, core::integer::u32>, 0>([4]) -> ([7]); // 2
+store_temp<RangeCheck>([3]) -> ([3]); // 3
+store_temp<core::result::Result::<core::integer::u32, core::integer::u32>>([7]) -> ([7]); // 4
+return([3], [7]); // 5
+branch_align() -> (); // 6
+enum_init<core::result::Result::<core::integer::u32, core::integer::u32>, 1>([6]) -> ([8]); // 7
+store_temp<RangeCheck>([5]) -> ([5]); // 8
+store_temp<core::result::Result::<core::integer::u32, core::integer::u32>>([8]) -> ([8]); // 9
+return([5], [8]); // 10
+
+test::foo@0([0]: RangeCheck, [1]: u32, [2]: u32) -> (RangeCheck, core::result::Result::<core::integer::u32, core::integer::u32>);

--- a/Aegis/Tests/e2e_libfuncs/u32_aegis/u32_safe_divmod.sierra
+++ b/Aegis/Tests/e2e_libfuncs/u32_aegis/u32_safe_divmod.sierra
@@ -1,0 +1,17 @@
+type RangeCheck = RangeCheck [storable: true, drop: false, dup: false, zero_sized: false];
+type u32 = u32 [storable: true, drop: true, dup: true, zero_sized: false];
+type Tuple<u32, u32> = Struct<ut@Tuple, u32, u32> [storable: true, drop: true, dup: true, zero_sized: false];
+type NonZero<u32> = NonZero<u32> [storable: true, drop: true, dup: true, zero_sized: false];
+
+libfunc u32_safe_divmod = u32_safe_divmod;
+libfunc struct_construct<Tuple<u32, u32>> = struct_construct<Tuple<u32, u32>>;
+libfunc store_temp<RangeCheck> = store_temp<RangeCheck>;
+libfunc store_temp<Tuple<u32, u32>> = store_temp<Tuple<u32, u32>>;
+
+u32_safe_divmod([0], [1], [2]) -> ([3], [4], [5]); // 0
+struct_construct<Tuple<u32, u32>>([4], [5]) -> ([6]); // 1
+store_temp<RangeCheck>([3]) -> ([3]); // 2
+store_temp<Tuple<u32, u32>>([6]) -> ([6]); // 3
+return([3], [6]); // 4
+
+test::foo@0([0]: RangeCheck, [1]: u32, [2]: NonZero<u32>) -> (RangeCheck, Tuple<u32, u32>);

--- a/Aegis/Tests/e2e_libfuncs/u32_aegis/u32_sqrt.sierra
+++ b/Aegis/Tests/e2e_libfuncs/u32_aegis/u32_sqrt.sierra
@@ -1,0 +1,14 @@
+type RangeCheck = RangeCheck [storable: true, drop: false, dup: false, zero_sized: false];
+type u16 = u16 [storable: true, drop: true, dup: true, zero_sized: false];
+type u32 = u32 [storable: true, drop: true, dup: true, zero_sized: false];
+
+libfunc u32_sqrt = u32_sqrt;
+libfunc store_temp<RangeCheck> = store_temp<RangeCheck>;
+libfunc store_temp<u16> = store_temp<u16>;
+
+u32_sqrt([0], [1]) -> ([2], [3]); // 0
+store_temp<RangeCheck>([2]) -> ([2]); // 1
+store_temp<u16>([3]) -> ([3]); // 2
+return([2], [3]); // 3
+
+test::foo@0([0]: RangeCheck, [1]: u32) -> (RangeCheck, u16);

--- a/Aegis/Tests/e2e_libfuncs/u32_aegis/u32_try_from_felt252.sierra
+++ b/Aegis/Tests/e2e_libfuncs/u32_aegis/u32_try_from_felt252.sierra
@@ -1,0 +1,28 @@
+type RangeCheck = RangeCheck [storable: true, drop: false, dup: false, zero_sized: false];
+type Unit = Struct<ut@Tuple> [storable: true, drop: true, dup: true, zero_sized: true];
+type u32 = u32 [storable: true, drop: true, dup: true, zero_sized: false];
+type core::option::Option::<core::integer::u32> = Enum<ut@core::option::Option::<core::integer::u32>, u32, Unit> [storable: true, drop: true, dup: true, zero_sized: false];
+type felt252 = felt252 [storable: true, drop: true, dup: true, zero_sized: false];
+
+libfunc u32_try_from_felt252 = u32_try_from_felt252;
+libfunc branch_align = branch_align;
+libfunc enum_init<core::option::Option::<core::integer::u32>, 0> = enum_init<core::option::Option::<core::integer::u32>, 0>;
+libfunc store_temp<RangeCheck> = store_temp<RangeCheck>;
+libfunc store_temp<core::option::Option::<core::integer::u32>> = store_temp<core::option::Option::<core::integer::u32>>;
+libfunc struct_construct<Unit> = struct_construct<Unit>;
+libfunc enum_init<core::option::Option::<core::integer::u32>, 1> = enum_init<core::option::Option::<core::integer::u32>, 1>;
+
+u32_try_from_felt252([0], [1]) { fallthrough([2], [3]) 6([4]) }; // 0
+branch_align() -> (); // 1
+enum_init<core::option::Option::<core::integer::u32>, 0>([3]) -> ([5]); // 2
+store_temp<RangeCheck>([2]) -> ([2]); // 3
+store_temp<core::option::Option::<core::integer::u32>>([5]) -> ([5]); // 4
+return([2], [5]); // 5
+branch_align() -> (); // 6
+struct_construct<Unit>() -> ([6]); // 7
+enum_init<core::option::Option::<core::integer::u32>, 1>([6]) -> ([7]); // 8
+store_temp<RangeCheck>([4]) -> ([4]); // 9
+store_temp<core::option::Option::<core::integer::u32>>([7]) -> ([7]); // 10
+return([4], [7]); // 11
+
+test::foo@0([0]: RangeCheck, [1]: felt252) -> (RangeCheck, core::option::Option::<core::integer::u32>);

--- a/Aegis/Tests/e2e_libfuncs/u32_aegis/u32_wide_mul.sierra
+++ b/Aegis/Tests/e2e_libfuncs/u32_aegis/u32_wide_mul.sierra
@@ -1,0 +1,11 @@
+type u32 = u32 [storable: true, drop: true, dup: true, zero_sized: false];
+type u64 = u64 [storable: true, drop: true, dup: true, zero_sized: false];
+
+libfunc u32_wide_mul = u32_wide_mul;
+libfunc store_temp<u64> = store_temp<u64>;
+
+u32_wide_mul([0], [1]) -> ([2]); // 0
+store_temp<u64>([2]) -> ([2]); // 1
+return([2]); // 2
+
+test::foo@0([0]: u32, [1]: u32) -> (u64);

--- a/Aegis/Tests/e2e_libfuncs/u512_aegis/u512_safe_divmod_by_u256.sierra
+++ b/Aegis/Tests/e2e_libfuncs/u512_aegis/u512_safe_divmod_by_u256.sierra
@@ -1,0 +1,26 @@
+type RangeCheck = RangeCheck [storable: true, drop: false, dup: false, zero_sized: false];
+type u128 = u128 [storable: true, drop: true, dup: true, zero_sized: false];
+type core::integer::u512 = Struct<ut@core::integer::u512, u128, u128, u128, u128> [storable: true, drop: true, dup: true, zero_sized: false];
+type core::integer::u256 = Struct<ut@core::integer::u256, u128, u128> [storable: true, drop: true, dup: true, zero_sized: false];
+type Tuple<core::integer::u512, core::integer::u256> = Struct<ut@Tuple, core::integer::u512, core::integer::u256> [storable: true, drop: true, dup: true, zero_sized: false];
+type U128MulGuarantee = U128MulGuarantee [storable: true, drop: false, dup: false, zero_sized: false];
+type NonZero<core::integer::u256> = NonZero<core::integer::u256> [storable: true, drop: true, dup: true, zero_sized: false];
+
+libfunc u512_safe_divmod_by_u256 = u512_safe_divmod_by_u256;
+libfunc u128_mul_guarantee_verify = u128_mul_guarantee_verify;
+libfunc struct_construct<Tuple<core::integer::u512, core::integer::u256>> = struct_construct<Tuple<core::integer::u512, core::integer::u256>>;
+libfunc store_temp<RangeCheck> = store_temp<RangeCheck>;
+libfunc store_temp<Tuple<core::integer::u512, core::integer::u256>> = store_temp<Tuple<core::integer::u512, core::integer::u256>>;
+
+u512_safe_divmod_by_u256([0], [1], [2]) -> ([3], [4], [5], [6], [7], [8], [9], [10]); // 0
+u128_mul_guarantee_verify([3], [10]) -> ([11]); // 1
+u128_mul_guarantee_verify([11], [9]) -> ([12]); // 2
+u128_mul_guarantee_verify([12], [8]) -> ([13]); // 3
+u128_mul_guarantee_verify([13], [7]) -> ([14]); // 4
+u128_mul_guarantee_verify([14], [6]) -> ([15]); // 5
+struct_construct<Tuple<core::integer::u512, core::integer::u256>>([4], [5]) -> ([16]); // 6
+store_temp<RangeCheck>([15]) -> ([15]); // 7
+store_temp<Tuple<core::integer::u512, core::integer::u256>>([16]) -> ([16]); // 8
+return([15], [16]); // 9
+
+test::foo@0([0]: RangeCheck, [1]: core::integer::u512, [2]: NonZero<core::integer::u256>) -> (RangeCheck, Tuple<core::integer::u512, core::integer::u256>);

--- a/Aegis/Tests/e2e_libfuncs/u64_aegis/u64_eq.sierra
+++ b/Aegis/Tests/e2e_libfuncs/u64_aegis/u64_eq.sierra
@@ -1,0 +1,30 @@
+type u64 = u64 [storable: true, drop: true, dup: true, zero_sized: false];
+type Unit = Struct<ut@Tuple> [storable: true, drop: true, dup: true, zero_sized: true];
+type core::bool = Enum<ut@core::bool, Unit, Unit> [storable: true, drop: true, dup: true, zero_sized: false];
+
+libfunc u64_const<11> = u64_const<11>;
+libfunc u64_const<12> = u64_const<12>;
+libfunc store_temp<u64> = store_temp<u64>;
+libfunc u64_eq = u64_eq;
+libfunc branch_align = branch_align;
+libfunc struct_construct<Unit> = struct_construct<Unit>;
+libfunc enum_init<core::bool, 0> = enum_init<core::bool, 0>;
+libfunc store_temp<core::bool> = store_temp<core::bool>;
+libfunc enum_init<core::bool, 1> = enum_init<core::bool, 1>;
+
+u64_const<11>() -> ([0]); // 0
+u64_const<12>() -> ([1]); // 1
+store_temp<u64>([0]) -> ([0]); // 2
+u64_eq([0], [1]) { fallthrough() 9() }; // 3
+branch_align() -> (); // 4
+struct_construct<Unit>() -> ([2]); // 5
+enum_init<core::bool, 0>([2]) -> ([3]); // 6
+store_temp<core::bool>([3]) -> ([3]); // 7
+return([3]); // 8
+branch_align() -> (); // 9
+struct_construct<Unit>() -> ([4]); // 10
+enum_init<core::bool, 1>([4]) -> ([5]); // 11
+store_temp<core::bool>([5]) -> ([5]); // 12
+return([5]); // 13
+
+test::foo@0() -> (core::bool);

--- a/Aegis/Tests/e2e_libfuncs/u64_aegis/u64_is_zero.sierra
+++ b/Aegis/Tests/e2e_libfuncs/u64_aegis/u64_is_zero.sierra
@@ -1,0 +1,20 @@
+type u64 = u64 [storable: true, drop: true, dup: true, zero_sized: false];
+type NonZero<u64> = NonZero<u64> [storable: true, drop: true, dup: true, zero_sized: false];
+
+libfunc u64_is_zero = u64_is_zero;
+libfunc branch_align = branch_align;
+libfunc u64_const<1234> = u64_const<1234>;
+libfunc store_temp<u64> = store_temp<u64>;
+libfunc unwrap_non_zero<u64> = unwrap_non_zero<u64>;
+
+u64_is_zero([0]) { fallthrough() 5([1]) }; // 0
+branch_align() -> (); // 1
+u64_const<1234>() -> ([2]); // 2
+store_temp<u64>([2]) -> ([2]); // 3
+return([2]); // 4
+branch_align() -> (); // 5
+unwrap_non_zero<u64>([1]) -> ([3]); // 6
+store_temp<u64>([3]) -> ([3]); // 7
+return([3]); // 8
+
+test::foo@0([0]: u64) -> (u64);

--- a/Aegis/Tests/e2e_libfuncs/u64_aegis/u64_overflowing_add.sierra
+++ b/Aegis/Tests/e2e_libfuncs/u64_aegis/u64_overflowing_add.sierra
@@ -1,0 +1,24 @@
+type RangeCheck = RangeCheck [storable: true, drop: false, dup: false, zero_sized: false];
+type u64 = u64 [storable: true, drop: true, dup: true, zero_sized: false];
+type core::result::Result::<core::integer::u64, core::integer::u64> = Enum<ut@core::result::Result::<core::integer::u64, core::integer::u64>, u64, u64> [storable: true, drop: true, dup: true, zero_sized: false];
+
+libfunc u64_overflowing_add = u64_overflowing_add;
+libfunc branch_align = branch_align;
+libfunc enum_init<core::result::Result::<core::integer::u64, core::integer::u64>, 0> = enum_init<core::result::Result::<core::integer::u64, core::integer::u64>, 0>;
+libfunc store_temp<RangeCheck> = store_temp<RangeCheck>;
+libfunc store_temp<core::result::Result::<core::integer::u64, core::integer::u64>> = store_temp<core::result::Result::<core::integer::u64, core::integer::u64>>;
+libfunc enum_init<core::result::Result::<core::integer::u64, core::integer::u64>, 1> = enum_init<core::result::Result::<core::integer::u64, core::integer::u64>, 1>;
+
+u64_overflowing_add([0], [1], [2]) { fallthrough([3], [4]) 6([5], [6]) }; // 0
+branch_align() -> (); // 1
+enum_init<core::result::Result::<core::integer::u64, core::integer::u64>, 0>([4]) -> ([7]); // 2
+store_temp<RangeCheck>([3]) -> ([3]); // 3
+store_temp<core::result::Result::<core::integer::u64, core::integer::u64>>([7]) -> ([7]); // 4
+return([3], [7]); // 5
+branch_align() -> (); // 6
+enum_init<core::result::Result::<core::integer::u64, core::integer::u64>, 1>([6]) -> ([8]); // 7
+store_temp<RangeCheck>([5]) -> ([5]); // 8
+store_temp<core::result::Result::<core::integer::u64, core::integer::u64>>([8]) -> ([8]); // 9
+return([5], [8]); // 10
+
+test::foo@0([0]: RangeCheck, [1]: u64, [2]: u64) -> (RangeCheck, core::result::Result::<core::integer::u64, core::integer::u64>);

--- a/Aegis/Tests/e2e_libfuncs/u64_aegis/u64_overflowing_sub.sierra
+++ b/Aegis/Tests/e2e_libfuncs/u64_aegis/u64_overflowing_sub.sierra
@@ -1,0 +1,24 @@
+type RangeCheck = RangeCheck [storable: true, drop: false, dup: false, zero_sized: false];
+type u64 = u64 [storable: true, drop: true, dup: true, zero_sized: false];
+type core::result::Result::<core::integer::u64, core::integer::u64> = Enum<ut@core::result::Result::<core::integer::u64, core::integer::u64>, u64, u64> [storable: true, drop: true, dup: true, zero_sized: false];
+
+libfunc u64_overflowing_sub = u64_overflowing_sub;
+libfunc branch_align = branch_align;
+libfunc enum_init<core::result::Result::<core::integer::u64, core::integer::u64>, 0> = enum_init<core::result::Result::<core::integer::u64, core::integer::u64>, 0>;
+libfunc store_temp<RangeCheck> = store_temp<RangeCheck>;
+libfunc store_temp<core::result::Result::<core::integer::u64, core::integer::u64>> = store_temp<core::result::Result::<core::integer::u64, core::integer::u64>>;
+libfunc enum_init<core::result::Result::<core::integer::u64, core::integer::u64>, 1> = enum_init<core::result::Result::<core::integer::u64, core::integer::u64>, 1>;
+
+u64_overflowing_sub([0], [1], [2]) { fallthrough([3], [4]) 6([5], [6]) }; // 0
+branch_align() -> (); // 1
+enum_init<core::result::Result::<core::integer::u64, core::integer::u64>, 0>([4]) -> ([7]); // 2
+store_temp<RangeCheck>([3]) -> ([3]); // 3
+store_temp<core::result::Result::<core::integer::u64, core::integer::u64>>([7]) -> ([7]); // 4
+return([3], [7]); // 5
+branch_align() -> (); // 6
+enum_init<core::result::Result::<core::integer::u64, core::integer::u64>, 1>([6]) -> ([8]); // 7
+store_temp<RangeCheck>([5]) -> ([5]); // 8
+store_temp<core::result::Result::<core::integer::u64, core::integer::u64>>([8]) -> ([8]); // 9
+return([5], [8]); // 10
+
+test::foo@0([0]: RangeCheck, [1]: u64, [2]: u64) -> (RangeCheck, core::result::Result::<core::integer::u64, core::integer::u64>);

--- a/Aegis/Tests/e2e_libfuncs/u64_aegis/u64_safe_divmod.sierra
+++ b/Aegis/Tests/e2e_libfuncs/u64_aegis/u64_safe_divmod.sierra
@@ -1,0 +1,17 @@
+type RangeCheck = RangeCheck [storable: true, drop: false, dup: false, zero_sized: false];
+type u64 = u64 [storable: true, drop: true, dup: true, zero_sized: false];
+type Tuple<u64, u64> = Struct<ut@Tuple, u64, u64> [storable: true, drop: true, dup: true, zero_sized: false];
+type NonZero<u64> = NonZero<u64> [storable: true, drop: true, dup: true, zero_sized: false];
+
+libfunc u64_safe_divmod = u64_safe_divmod;
+libfunc struct_construct<Tuple<u64, u64>> = struct_construct<Tuple<u64, u64>>;
+libfunc store_temp<RangeCheck> = store_temp<RangeCheck>;
+libfunc store_temp<Tuple<u64, u64>> = store_temp<Tuple<u64, u64>>;
+
+u64_safe_divmod([0], [1], [2]) -> ([3], [4], [5]); // 0
+struct_construct<Tuple<u64, u64>>([4], [5]) -> ([6]); // 1
+store_temp<RangeCheck>([3]) -> ([3]); // 2
+store_temp<Tuple<u64, u64>>([6]) -> ([6]); // 3
+return([3], [6]); // 4
+
+test::foo@0([0]: RangeCheck, [1]: u64, [2]: NonZero<u64>) -> (RangeCheck, Tuple<u64, u64>);

--- a/Aegis/Tests/e2e_libfuncs/u64_aegis/u64_sqrt.sierra
+++ b/Aegis/Tests/e2e_libfuncs/u64_aegis/u64_sqrt.sierra
@@ -1,0 +1,14 @@
+type RangeCheck = RangeCheck [storable: true, drop: false, dup: false, zero_sized: false];
+type u32 = u32 [storable: true, drop: true, dup: true, zero_sized: false];
+type u64 = u64 [storable: true, drop: true, dup: true, zero_sized: false];
+
+libfunc u64_sqrt = u64_sqrt;
+libfunc store_temp<RangeCheck> = store_temp<RangeCheck>;
+libfunc store_temp<u32> = store_temp<u32>;
+
+u64_sqrt([0], [1]) -> ([2], [3]); // 0
+store_temp<RangeCheck>([2]) -> ([2]); // 1
+store_temp<u32>([3]) -> ([3]); // 2
+return([2], [3]); // 3
+
+test::foo@0([0]: RangeCheck, [1]: u64) -> (RangeCheck, u32);

--- a/Aegis/Tests/e2e_libfuncs/u64_aegis/u64_try_from_felt252.sierra
+++ b/Aegis/Tests/e2e_libfuncs/u64_aegis/u64_try_from_felt252.sierra
@@ -1,0 +1,28 @@
+type RangeCheck = RangeCheck [storable: true, drop: false, dup: false, zero_sized: false];
+type Unit = Struct<ut@Tuple> [storable: true, drop: true, dup: true, zero_sized: true];
+type u64 = u64 [storable: true, drop: true, dup: true, zero_sized: false];
+type core::option::Option::<core::integer::u64> = Enum<ut@core::option::Option::<core::integer::u64>, u64, Unit> [storable: true, drop: true, dup: true, zero_sized: false];
+type felt252 = felt252 [storable: true, drop: true, dup: true, zero_sized: false];
+
+libfunc u64_try_from_felt252 = u64_try_from_felt252;
+libfunc branch_align = branch_align;
+libfunc enum_init<core::option::Option::<core::integer::u64>, 0> = enum_init<core::option::Option::<core::integer::u64>, 0>;
+libfunc store_temp<RangeCheck> = store_temp<RangeCheck>;
+libfunc store_temp<core::option::Option::<core::integer::u64>> = store_temp<core::option::Option::<core::integer::u64>>;
+libfunc struct_construct<Unit> = struct_construct<Unit>;
+libfunc enum_init<core::option::Option::<core::integer::u64>, 1> = enum_init<core::option::Option::<core::integer::u64>, 1>;
+
+u64_try_from_felt252([0], [1]) { fallthrough([2], [3]) 6([4]) }; // 0
+branch_align() -> (); // 1
+enum_init<core::option::Option::<core::integer::u64>, 0>([3]) -> ([5]); // 2
+store_temp<RangeCheck>([2]) -> ([2]); // 3
+store_temp<core::option::Option::<core::integer::u64>>([5]) -> ([5]); // 4
+return([2], [5]); // 5
+branch_align() -> (); // 6
+struct_construct<Unit>() -> ([6]); // 7
+enum_init<core::option::Option::<core::integer::u64>, 1>([6]) -> ([7]); // 8
+store_temp<RangeCheck>([4]) -> ([4]); // 9
+store_temp<core::option::Option::<core::integer::u64>>([7]) -> ([7]); // 10
+return([4], [7]); // 11
+
+test::foo@0([0]: RangeCheck, [1]: felt252) -> (RangeCheck, core::option::Option::<core::integer::u64>);

--- a/Aegis/Tests/e2e_libfuncs/u64_aegis/u64_wide_mul.sierra
+++ b/Aegis/Tests/e2e_libfuncs/u64_aegis/u64_wide_mul.sierra
@@ -1,0 +1,11 @@
+type u64 = u64 [storable: true, drop: true, dup: true, zero_sized: false];
+type u128 = u128 [storable: true, drop: true, dup: true, zero_sized: false];
+
+libfunc u64_wide_mul = u64_wide_mul;
+libfunc store_temp<u128> = store_temp<u128>;
+
+u64_wide_mul([0], [1]) -> ([2]); // 0
+store_temp<u128>([2]) -> ([2]); // 1
+return([2]); // 2
+
+test::foo@0([0]: u64, [1]: u64) -> (u128);

--- a/Aegis/Tests/e2e_libfuncs/u8_aegis/u8_eq.sierra
+++ b/Aegis/Tests/e2e_libfuncs/u8_aegis/u8_eq.sierra
@@ -1,0 +1,30 @@
+type u8 = u8 [storable: true, drop: true, dup: true, zero_sized: false];
+type Unit = Struct<ut@Tuple> [storable: true, drop: true, dup: true, zero_sized: true];
+type core::bool = Enum<ut@core::bool, Unit, Unit> [storable: true, drop: true, dup: true, zero_sized: false];
+
+libfunc u8_const<11> = u8_const<11>;
+libfunc u8_const<12> = u8_const<12>;
+libfunc store_temp<u8> = store_temp<u8>;
+libfunc u8_eq = u8_eq;
+libfunc branch_align = branch_align;
+libfunc struct_construct<Unit> = struct_construct<Unit>;
+libfunc enum_init<core::bool, 0> = enum_init<core::bool, 0>;
+libfunc store_temp<core::bool> = store_temp<core::bool>;
+libfunc enum_init<core::bool, 1> = enum_init<core::bool, 1>;
+
+u8_const<11>() -> ([0]); // 0
+u8_const<12>() -> ([1]); // 1
+store_temp<u8>([0]) -> ([0]); // 2
+u8_eq([0], [1]) { fallthrough() 9() }; // 3
+branch_align() -> (); // 4
+struct_construct<Unit>() -> ([2]); // 5
+enum_init<core::bool, 0>([2]) -> ([3]); // 6
+store_temp<core::bool>([3]) -> ([3]); // 7
+return([3]); // 8
+branch_align() -> (); // 9
+struct_construct<Unit>() -> ([4]); // 10
+enum_init<core::bool, 1>([4]) -> ([5]); // 11
+store_temp<core::bool>([5]) -> ([5]); // 12
+return([5]); // 13
+
+test::foo@0() -> (core::bool);

--- a/Aegis/Tests/e2e_libfuncs/u8_aegis/u8_is_zero.sierra
+++ b/Aegis/Tests/e2e_libfuncs/u8_aegis/u8_is_zero.sierra
@@ -1,0 +1,20 @@
+type u8 = u8 [storable: true, drop: true, dup: true, zero_sized: false];
+type NonZero<u8> = NonZero<u8> [storable: true, drop: true, dup: true, zero_sized: false];
+
+libfunc u8_is_zero = u8_is_zero;
+libfunc branch_align = branch_align;
+libfunc u8_const<123> = u8_const<123>;
+libfunc store_temp<u8> = store_temp<u8>;
+libfunc unwrap_non_zero<u8> = unwrap_non_zero<u8>;
+
+u8_is_zero([0]) { fallthrough() 5([1]) }; // 0
+branch_align() -> (); // 1
+u8_const<123>() -> ([2]); // 2
+store_temp<u8>([2]) -> ([2]); // 3
+return([2]); // 4
+branch_align() -> (); // 5
+unwrap_non_zero<u8>([1]) -> ([3]); // 6
+store_temp<u8>([3]) -> ([3]); // 7
+return([3]); // 8
+
+test::foo@0([0]: u8) -> (u8);

--- a/Aegis/Tests/e2e_libfuncs/u8_aegis/u8_overflowing_add.sierra
+++ b/Aegis/Tests/e2e_libfuncs/u8_aegis/u8_overflowing_add.sierra
@@ -1,0 +1,24 @@
+type RangeCheck = RangeCheck [storable: true, drop: false, dup: false, zero_sized: false];
+type u8 = u8 [storable: true, drop: true, dup: true, zero_sized: false];
+type core::result::Result::<core::integer::u8, core::integer::u8> = Enum<ut@core::result::Result::<core::integer::u8, core::integer::u8>, u8, u8> [storable: true, drop: true, dup: true, zero_sized: false];
+
+libfunc u8_overflowing_add = u8_overflowing_add;
+libfunc branch_align = branch_align;
+libfunc enum_init<core::result::Result::<core::integer::u8, core::integer::u8>, 0> = enum_init<core::result::Result::<core::integer::u8, core::integer::u8>, 0>;
+libfunc store_temp<RangeCheck> = store_temp<RangeCheck>;
+libfunc store_temp<core::result::Result::<core::integer::u8, core::integer::u8>> = store_temp<core::result::Result::<core::integer::u8, core::integer::u8>>;
+libfunc enum_init<core::result::Result::<core::integer::u8, core::integer::u8>, 1> = enum_init<core::result::Result::<core::integer::u8, core::integer::u8>, 1>;
+
+u8_overflowing_add([0], [1], [2]) { fallthrough([3], [4]) 6([5], [6]) }; // 0
+branch_align() -> (); // 1
+enum_init<core::result::Result::<core::integer::u8, core::integer::u8>, 0>([4]) -> ([7]); // 2
+store_temp<RangeCheck>([3]) -> ([3]); // 3
+store_temp<core::result::Result::<core::integer::u8, core::integer::u8>>([7]) -> ([7]); // 4
+return([3], [7]); // 5
+branch_align() -> (); // 6
+enum_init<core::result::Result::<core::integer::u8, core::integer::u8>, 1>([6]) -> ([8]); // 7
+store_temp<RangeCheck>([5]) -> ([5]); // 8
+store_temp<core::result::Result::<core::integer::u8, core::integer::u8>>([8]) -> ([8]); // 9
+return([5], [8]); // 10
+
+test::foo@0([0]: RangeCheck, [1]: u8, [2]: u8) -> (RangeCheck, core::result::Result::<core::integer::u8, core::integer::u8>);

--- a/Aegis/Tests/e2e_libfuncs/u8_aegis/u8_overflowing_sub.sierra
+++ b/Aegis/Tests/e2e_libfuncs/u8_aegis/u8_overflowing_sub.sierra
@@ -1,0 +1,24 @@
+type RangeCheck = RangeCheck [storable: true, drop: false, dup: false, zero_sized: false];
+type u8 = u8 [storable: true, drop: true, dup: true, zero_sized: false];
+type core::result::Result::<core::integer::u8, core::integer::u8> = Enum<ut@core::result::Result::<core::integer::u8, core::integer::u8>, u8, u8> [storable: true, drop: true, dup: true, zero_sized: false];
+
+libfunc u8_overflowing_sub = u8_overflowing_sub;
+libfunc branch_align = branch_align;
+libfunc enum_init<core::result::Result::<core::integer::u8, core::integer::u8>, 0> = enum_init<core::result::Result::<core::integer::u8, core::integer::u8>, 0>;
+libfunc store_temp<RangeCheck> = store_temp<RangeCheck>;
+libfunc store_temp<core::result::Result::<core::integer::u8, core::integer::u8>> = store_temp<core::result::Result::<core::integer::u8, core::integer::u8>>;
+libfunc enum_init<core::result::Result::<core::integer::u8, core::integer::u8>, 1> = enum_init<core::result::Result::<core::integer::u8, core::integer::u8>, 1>;
+
+u8_overflowing_sub([0], [1], [2]) { fallthrough([3], [4]) 6([5], [6]) }; // 0
+branch_align() -> (); // 1
+enum_init<core::result::Result::<core::integer::u8, core::integer::u8>, 0>([4]) -> ([7]); // 2
+store_temp<RangeCheck>([3]) -> ([3]); // 3
+store_temp<core::result::Result::<core::integer::u8, core::integer::u8>>([7]) -> ([7]); // 4
+return([3], [7]); // 5
+branch_align() -> (); // 6
+enum_init<core::result::Result::<core::integer::u8, core::integer::u8>, 1>([6]) -> ([8]); // 7
+store_temp<RangeCheck>([5]) -> ([5]); // 8
+store_temp<core::result::Result::<core::integer::u8, core::integer::u8>>([8]) -> ([8]); // 9
+return([5], [8]); // 10
+
+test::foo@0([0]: RangeCheck, [1]: u8, [2]: u8) -> (RangeCheck, core::result::Result::<core::integer::u8, core::integer::u8>);

--- a/Aegis/Tests/e2e_libfuncs/u8_aegis/u8_safe_divmod.sierra
+++ b/Aegis/Tests/e2e_libfuncs/u8_aegis/u8_safe_divmod.sierra
@@ -1,0 +1,17 @@
+type RangeCheck = RangeCheck [storable: true, drop: false, dup: false, zero_sized: false];
+type u8 = u8 [storable: true, drop: true, dup: true, zero_sized: false];
+type Tuple<u8, u8> = Struct<ut@Tuple, u8, u8> [storable: true, drop: true, dup: true, zero_sized: false];
+type NonZero<u8> = NonZero<u8> [storable: true, drop: true, dup: true, zero_sized: false];
+
+libfunc u8_safe_divmod = u8_safe_divmod;
+libfunc struct_construct<Tuple<u8, u8>> = struct_construct<Tuple<u8, u8>>;
+libfunc store_temp<RangeCheck> = store_temp<RangeCheck>;
+libfunc store_temp<Tuple<u8, u8>> = store_temp<Tuple<u8, u8>>;
+
+u8_safe_divmod([0], [1], [2]) -> ([3], [4], [5]); // 0
+struct_construct<Tuple<u8, u8>>([4], [5]) -> ([6]); // 1
+store_temp<RangeCheck>([3]) -> ([3]); // 2
+store_temp<Tuple<u8, u8>>([6]) -> ([6]); // 3
+return([3], [6]); // 4
+
+test::foo@0([0]: RangeCheck, [1]: u8, [2]: NonZero<u8>) -> (RangeCheck, Tuple<u8, u8>);

--- a/Aegis/Tests/e2e_libfuncs/u8_aegis/u8_sqrt.sierra
+++ b/Aegis/Tests/e2e_libfuncs/u8_aegis/u8_sqrt.sierra
@@ -1,0 +1,13 @@
+type RangeCheck = RangeCheck [storable: true, drop: false, dup: false, zero_sized: false];
+type u8 = u8 [storable: true, drop: true, dup: true, zero_sized: false];
+
+libfunc u8_sqrt = u8_sqrt;
+libfunc store_temp<RangeCheck> = store_temp<RangeCheck>;
+libfunc store_temp<u8> = store_temp<u8>;
+
+u8_sqrt([0], [1]) -> ([2], [3]); // 0
+store_temp<RangeCheck>([2]) -> ([2]); // 1
+store_temp<u8>([3]) -> ([3]); // 2
+return([2], [3]); // 3
+
+test::foo@0([0]: RangeCheck, [1]: u8) -> (RangeCheck, u8);

--- a/Aegis/Tests/e2e_libfuncs/u8_aegis/u8_try_from_felt252.sierra
+++ b/Aegis/Tests/e2e_libfuncs/u8_aegis/u8_try_from_felt252.sierra
@@ -1,0 +1,28 @@
+type RangeCheck = RangeCheck [storable: true, drop: false, dup: false, zero_sized: false];
+type Unit = Struct<ut@Tuple> [storable: true, drop: true, dup: true, zero_sized: true];
+type u8 = u8 [storable: true, drop: true, dup: true, zero_sized: false];
+type core::option::Option::<core::integer::u8> = Enum<ut@core::option::Option::<core::integer::u8>, u8, Unit> [storable: true, drop: true, dup: true, zero_sized: false];
+type felt252 = felt252 [storable: true, drop: true, dup: true, zero_sized: false];
+
+libfunc u8_try_from_felt252 = u8_try_from_felt252;
+libfunc branch_align = branch_align;
+libfunc enum_init<core::option::Option::<core::integer::u8>, 0> = enum_init<core::option::Option::<core::integer::u8>, 0>;
+libfunc store_temp<RangeCheck> = store_temp<RangeCheck>;
+libfunc store_temp<core::option::Option::<core::integer::u8>> = store_temp<core::option::Option::<core::integer::u8>>;
+libfunc struct_construct<Unit> = struct_construct<Unit>;
+libfunc enum_init<core::option::Option::<core::integer::u8>, 1> = enum_init<core::option::Option::<core::integer::u8>, 1>;
+
+u8_try_from_felt252([0], [1]) { fallthrough([2], [3]) 6([4]) }; // 0
+branch_align() -> (); // 1
+enum_init<core::option::Option::<core::integer::u8>, 0>([3]) -> ([5]); // 2
+store_temp<RangeCheck>([2]) -> ([2]); // 3
+store_temp<core::option::Option::<core::integer::u8>>([5]) -> ([5]); // 4
+return([2], [5]); // 5
+branch_align() -> (); // 6
+struct_construct<Unit>() -> ([6]); // 7
+enum_init<core::option::Option::<core::integer::u8>, 1>([6]) -> ([7]); // 8
+store_temp<RangeCheck>([4]) -> ([4]); // 9
+store_temp<core::option::Option::<core::integer::u8>>([7]) -> ([7]); // 10
+return([4], [7]); // 11
+
+test::foo@0([0]: RangeCheck, [1]: felt252) -> (RangeCheck, core::option::Option::<core::integer::u8>);

--- a/Aegis/Tests/e2e_libfuncs/u8_aegis/u8_wide_mul.sierra
+++ b/Aegis/Tests/e2e_libfuncs/u8_aegis/u8_wide_mul.sierra
@@ -1,0 +1,11 @@
+type u8 = u8 [storable: true, drop: true, dup: true, zero_sized: false];
+type u16 = u16 [storable: true, drop: true, dup: true, zero_sized: false];
+
+libfunc u8_wide_mul = u8_wide_mul;
+libfunc store_temp<u16> = store_temp<u16>;
+
+u8_wide_mul([0], [1]) -> ([2]); // 0
+store_temp<u16>([2]) -> ([2]); // 1
+return([2]); // 2
+
+test::foo@0([0]: u8, [1]: u8) -> (u16);

--- a/contrib/README.md
+++ b/contrib/README.md
@@ -1,0 +1,16 @@
+# Various scripts useful for contributors or developers
+
+This is a "catch-all" directory to hold every script which are roughly relevant to Aegis, but not necessarily fits any structure right now.
+It follows the classical `contrib/` directory you may find in other projects.
+
+## Extraction of E2EE libfuncs
+
+Cairo has a treasure of many Sierra code they use to run E2E testing on their libfuncs in https://github.com/starkware-libs/cairo/tree/main/tests/e2e_test_data/libfuncs.
+As noted in https://github.com/lindy-labs/aegis/issues/11, it makes sense to extract all of their Sierra and load it in Aegis
+for further refinements (spec & proof).
+
+To update those extracted files, you can use:
+
+- `extract_all_e2e_tests.sh` to run in the current working directory of a checkout of Cairo's compiler `libfuncs` directory to generate all `*_aegis` directories containing
+split out specification of _each_ function for _each_ family of libfuncs.
+- `extract_aegis_tests.py` is the core script which does some very basic string parsing to discover test data and generate it. Note that the parsing is brittle and expect StarkWare to follow their own seemingly consistent (actually, no…) format, some files will fail and that's expected, getting 100 % coverage is a work in progress in parser recovery… :-).

--- a/contrib/extract_aegis_tests.py
+++ b/contrib/extract_aegis_tests.py
@@ -1,0 +1,93 @@
+#!/usr/bin/env python3
+import sys
+from dataclasses import dataclass
+from collections import defaultdict
+from pathlib import Path
+
+TEST_MARKER = "//! > =========================================================================="
+
+@dataclass
+class TestFunData:
+    name: str
+    test_runner_name: str
+    cairo: str
+    casm: str
+    function_costs: str
+    sierra_code: str
+    test_comments: str | None
+
+@dataclass
+class TestData:
+    funs: list[TestFunData]
+
+def parse_comment(comment: str) -> str:
+    """
+    >>> parse_comment("//! > cairo")
+    cairo
+    >>> parse_comment("//! > test_runner_name")
+    test_runner_name
+    """
+    return comment.split('>')[1].strip()
+
+def build_fun_data(indexes: dict[str, dict[str, int]], lines: list[str]) -> TestFunData:
+    attrs = {}
+
+    attrs['test_comments'] = None
+
+    for key, range_ in indexes.items():
+        if 'libfunc' in key:
+            attrs['name'] = key[:key.find('libfunc')].strip()
+        else:
+            start, stop = range_['start'], range_.get('end')
+            if stop is None:
+                attrs[key] = '\n'.join(lines[start:]).strip()
+            else:
+                # stop is excluded here.
+                attrs[key] = '\n'.join(lines[start:stop]).strip()
+
+    return TestFunData(**attrs)
+
+def parse_test(lines: list[str]) -> TestFunData:
+    indexes = defaultdict(dict)
+    last_key = None
+    for index, line in enumerate(lines):
+        if line.startswith("//!"):
+            key = parse_comment(line)
+            indexes[key]['start'] = index + 1
+            if last_key is not None:
+                # end will be excluded by range syntax anyway.
+                indexes[last_key]['end'] = index
+
+            last_key = key
+
+    return build_fun_data(indexes, lines)
+
+def parse_test_file(target: str) -> TestData:
+    contents = None
+    with open(target, 'r') as f:
+        contents = ''.join(f.readlines())
+
+    if contents is None:
+        raise RuntimeError('Failed to read test file')
+
+    tests = [test.split('\n') for test in contents.split(TEST_MARKER)]
+    funs = []
+    for test in tests:
+        try:
+            funs.append(parse_test(test))
+        except Exception as e:
+            print(f'Skipped invalid test: {test}', e)
+
+    return TestData(funs=funs)
+
+def main():
+    target = sys.argv[1]
+    out_folder = Path(sys.argv[2])
+    test_data = parse_test_file(target)
+    out_folder.mkdir(exist_ok=True)
+    for fun in test_data.funs:
+        with open((out_folder / fun.name).with_suffix('.sierra'), 'w') as f:
+            f.write(fun.sierra_code)
+
+if __name__ == '__main__':
+    main()

--- a/contrib/extract_all_e2e_tests.sh
+++ b/contrib/extract_all_e2e_tests.sh
@@ -1,0 +1,4 @@
+#!/usr/bin/env bash
+for defn_test in {,**/}*; do
+    ./extract_aegis_tests.py $defn_test "${defn_test}_aegis"
+done


### PR DESCRIPTION
Those are bunch of scripts to auto-extract E2E libfunc tests from Cairo repo
into separate file which can be loaded further in Aegis for refinements.

First step towards #11, remains:

- Lean glue code to load them via globbing (?)
- Lean glue code to generate empty spec / proofs without failing too hard (?)
- Putting them in CI (?)
- Automating the extraction from released Cairo to our repo by opening an PR
- Improving the extraction coverage (seems to cover a lot… but not everything!)

Here's an example of the tree.
```
tests/e2e_test_data/libfuncs on  main via  v3.11.7 
❯ ls *_aegis
array_aegis:
array_append.e2e_aegis_test  array_len.e2e_aegis_test  array_pop_front.e2e_aegis_test          array_slice.e2e_aegis_test              array_snapshot_pop_front.e2e_aegis_test
array_get.e2e_aegis_test     array_new.e2e_aegis_test  array_pop_front_consume.e2e_aegis_test  array_snapshot_pop_back.e2e_aegis_test  span_from_tuple.e2e_aegis_test

bitwise_aegis:
bitwise.e2e_aegis_test  u8_bitwise.e2e_aegis_test  u16_bitwise.e2e_aegis_test  u32_bitwise.e2e_aegis_test  u64_bitwise.e2e_aegis_test

bool_aegis:
bool_and.e2e_aegis_test  bool_not.e2e_aegis_test  bool_or.e2e_aegis_test  bool_xor.e2e_aegis_test

box_aegis:
box_forward_snapshot.e2e_aegis_test  into_box.e2e_aegis_test  unbox.e2e_aegis_test

builtin_costs_aegis:
get_builtin_costs.e2e_aegis_test

bytes31_aegis:
bytes31_const.e2e_aegis_test  bytes31_to_felt252.e2e_aegis_test  bytes31_try_from_felt252.e2e_aegis_test

casts_aegis:

coupon_aegis:

ec_aegis:
ec_neg.e2e_aegis_test              ec_point_is_zero.e2e_aegis_test     ec_point_unwrap.e2e_aegis_test  ec_state_add.e2e_aegis_test      ec_state_init.e2e_aegis_test
ec_point_from_x_nz.e2e_aegis_test  ec_point_try_new_nz.e2e_aegis_test  ec_point_zero.e2e_aegis_test    ec_state_add_mul.e2e_aegis_test  ec_state_try_finalize_nz.e2e_aegis_test

enum_aegis:

enum_snapshot_aegis:

extract_aegis_tests.py_aegis:

extract_all_e2e_tests.sh_aegis:

felt252_aegis:

felt252_dict_aegis:
felt252_dict_new.e2e_aegis_test  felt252_dict_squash.e2e_aegis_test

felt252_downcast_aegis:

gas_aegis:
redeposit_gas.e2e_aegis_test

i128_aegis:
i128_diff.e2e_aegis_test  i128_is_zero.e2e_aegis_test               i128_overflowing_sub_impl.e2e_aegis_test  i128_try_from_felt252.e2e_aegis_test
i128_eq.e2e_aegis_test    i128_overflowing_add_impl.e2e_aegis_test  i128_to_felt252.e2e_aegis_test            

i16_aegis:
i16_diff.e2e_aegis_test  i16_is_zero.e2e_aegis_test               i16_overflowing_sub_impl.e2e_aegis_test  i16_try_from_felt252.e2e_aegis_test
i16_eq.e2e_aegis_test    i16_overflowing_add_impl.e2e_aegis_test  i16_to_felt252.e2e_aegis_test            i16_wide_mul.e2e_aegis_test

i32_aegis:
i32_diff.e2e_aegis_test  i32_is_zero.e2e_aegis_test               i32_overflowing_sub_impl.e2e_aegis_test  i32_try_from_felt252.e2e_aegis_test
i32_eq.e2e_aegis_test    i32_overflowing_add_impl.e2e_aegis_test  i32_to_felt252.e2e_aegis_test            i32_wide_mul.e2e_aegis_test

i64_aegis:
i64_diff.e2e_aegis_test  i64_is_zero.e2e_aegis_test               i64_overflowing_sub_impl.e2e_aegis_test  i64_try_from_felt252.e2e_aegis_test
i64_eq.e2e_aegis_test    i64_overflowing_add_impl.e2e_aegis_test  i64_to_felt252.e2e_aegis_test            i64_wide_mul.e2e_aegis_test

i8_aegis:
i8_diff.e2e_aegis_test  i8_is_zero.e2e_aegis_test               i8_overflowing_sub_impl.e2e_aegis_test  i8_try_from_felt252.e2e_aegis_test
i8_eq.e2e_aegis_test    i8_overflowing_add_impl.e2e_aegis_test  i8_to_felt252.e2e_aegis_test            i8_wide_mul.e2e_aegis_test

nullable_aegis:
match_nullable.e2e_aegis_test  nullable.e2e_aegis_test                   nullable_from_box.e2e_aegis_test
null.e2e_aegis_test            nullable_forward_snapshot.e2e_aegis_test  'nullable snapshot matching.e2e_aegis_test'

poseidon_aegis:
hades_permutation.e2e_aegis_test

snapshot_aegis:

u128_aegis:
u128_byte_reverse.e2e_aegis_test  u128_overflowing_add.e2e_aegis_test  u128_safe_divmod.e2e_aegis_test  u128s_from_felt252.e2e_aegis_test
u128_eq.e2e_aegis_test            u128_overflowing_sub.e2e_aegis_test  u128_sqrt.e2e_aegis_test         

u16_aegis:
u16_eq.e2e_aegis_test       u16_overflowing_add.e2e_aegis_test  u16_safe_divmod.e2e_aegis_test  u16_try_from_felt252.e2e_aegis_test
u16_is_zero.e2e_aegis_test  u16_overflowing_sub.e2e_aegis_test  u16_sqrt.e2e_aegis_test         u16_wide_mul.e2e_aegis_test

u256_aegis:
u256_guarantee_inv_mod_n.e2e_aegis_test  u256_is_zero.e2e_aegis_test  u256_safe_divmod.e2e_aegis_test  u256_sqrt.e2e_aegis_test

u32_aegis:
u32_eq.e2e_aegis_test       u32_overflowing_add.e2e_aegis_test  u32_safe_divmod.e2e_aegis_test  u32_try_from_felt252.e2e_aegis_test
u32_is_zero.e2e_aegis_test  u32_overflowing_sub.e2e_aegis_test  u32_sqrt.e2e_aegis_test         u32_wide_mul.e2e_aegis_test

u512_aegis:
u512_safe_divmod_by_u256.e2e_aegis_test

u64_aegis:
u64_eq.e2e_aegis_test       u64_overflowing_add.e2e_aegis_test  u64_safe_divmod.e2e_aegis_test  u64_try_from_felt252.e2e_aegis_test
u64_is_zero.e2e_aegis_test  u64_overflowing_sub.e2e_aegis_test  u64_sqrt.e2e_aegis_test         u64_wide_mul.e2e_aegis_test

u8_aegis:
u8_eq.e2e_aegis_test       u8_overflowing_add.e2e_aegis_test  u8_safe_divmod.e2e_aegis_test  u8_try_from_felt252.e2e_aegis_test
u8_is_zero.e2e_aegis_test  u8_overflowing_sub.e2e_aegis_test  u8_sqrt.e2e_aegis_test         u8_wide_mul.e2e_aegis_test
```