### PR TITLE
Update README.md: `double` should double, not square

### DIFF
--- a/README.md
+++ b/README.md
@@ -13,7 +13,7 @@ aegis_load_file "../foo.sierra"
 
 -- Provide the specification of the function double
 aegis_spec "foo::foo::double" :=
-  fun _ a ρ => ρ = a * a
+  fun _ a ρ => ρ = a + a
 
 -- Prove the correctness of the specification
 aegis_prove "foo::foo::double" :=


### PR DESCRIPTION
A small nit in the introductory example that threw me off for a second :)

I believe the double.sierra test case needs updating as well. Alternatively, rename the example to `square`.