### PR TITLE
fix(ci): bump to NixOS 24.11 as a base channel

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -12,7 +12,7 @@ jobs:
       - name: Get the only thing that usually is reliable in CI
         uses: cachix/install-nix-action@v20
         with:
-          nix_path: nixpkgs=channel:nixos-23.11
+          nix_path: nixpkgs=channel:nixos-24.11
       - name: Download mathlib4 cache
         run: nix-shell -p elan --run "lake exe cache get"
       - name: Build the framework


### PR DESCRIPTION
This should hopefully fix the crashes with Clang.