### PR TITLE
Update a subset of the libfunc e2e test data to Cairo v2.11.4 data

### DIFF
--- a/Aegis/Tests/e2e_libfuncs/array_aegis/array_append.sierra
+++ b/Aegis/Tests/e2e_libfuncs/array_aegis/array_append.sierra
@@ -3,13 +3,12 @@ type Unit = Struct<ut@Tuple> [storable: true, drop: true, dup: true, zero_sized:
 type felt252 = felt252 [storable: true, drop: true, dup: true, zero_sized: false];
 
 libfunc array_append<felt252> = array_append<felt252>;
-libfunc struct_construct<Unit> = struct_construct<Unit>;
 libfunc store_temp<Array<felt252>> = store_temp<Array<felt252>>;
 
-array_append<felt252>([0], [1]) -> ([3]); // 0
-array_append<felt252>([3], [2]) -> ([4]); // 1
-struct_construct<Unit>() -> ([5]); // 2
-store_temp<Array<felt252>>([4]) -> ([4]); // 3
-return([4], [5]); // 4
+F0:
+array_append<felt252>([0], [1]) -> ([3]);
+array_append<felt252>([3], [2]) -> ([4]);
+store_temp<Array<felt252>>([4]) -> ([4]);
+return([4]);
 
-test::foo@0([0]: Array<felt252>, [1]: felt252, [2]: felt252) -> (Array<felt252>, Unit);
+test::foo@F0([0]: Array<felt252>, [1]: felt252, [2]: felt252) -> (Array<felt252>);

--- a/Aegis/Tests/e2e_libfuncs/array_aegis/array_get.sierra
+++ b/Aegis/Tests/e2e_libfuncs/array_aegis/array_get.sierra
@@ -4,8 +4,8 @@ type Box<Snapshot<Array<felt252>>> = Box<Snapshot<Array<felt252>>> [storable: tr
 type core::option::Option::<core::box::Box::<@core::array::Array::<core::felt252>>> = Enum<ut@core::option::Option::<core::box::Box::<@core::array::Array::<core::felt252>>>, Box<Snapshot<Array<felt252>>>, Unit> [storable: true, drop: true, dup: true, zero_sized: false];
 type Array<felt252> = Array<felt252> [storable: true, drop: true, dup: false, zero_sized: false];
 type Snapshot<Array<felt252>> = Snapshot<Array<felt252>> [storable: true, drop: true, dup: true, zero_sized: false];
-type u32 = u32 [storable: true, drop: true, dup: true, zero_sized: false];
 type felt252 = felt252 [storable: true, drop: true, dup: true, zero_sized: false];
+type u32 = u32 [storable: true, drop: true, dup: true, zero_sized: false];
 type Array<Array<felt252>> = Array<Array<felt252>> [storable: true, drop: true, dup: false, zero_sized: false];
 type Snapshot<Array<Array<felt252>>> = Snapshot<Array<Array<felt252>>> [storable: true, drop: true, dup: true, zero_sized: false];
 
@@ -17,17 +17,19 @@ libfunc store_temp<core::option::Option::<core::box::Box::<@core::array::Array::
 libfunc struct_construct<Unit> = struct_construct<Unit>;
 libfunc enum_init<core::option::Option::<core::box::Box::<@core::array::Array::<core::felt252>>>, 1> = enum_init<core::option::Option::<core::box::Box::<@core::array::Array::<core::felt252>>>, 1>;
 
-array_get<Array<felt252>>([0], [1], [2]) { fallthrough([3], [4]) 6([5]) }; // 0
-branch_align() -> (); // 1
-enum_init<core::option::Option::<core::box::Box::<@core::array::Array::<core::felt252>>>, 0>([4]) -> ([6]); // 2
-store_temp<RangeCheck>([3]) -> ([3]); // 3
-store_temp<core::option::Option::<core::box::Box::<@core::array::Array::<core::felt252>>>>([6]) -> ([6]); // 4
-return([3], [6]); // 5
-branch_align() -> (); // 6
-struct_construct<Unit>() -> ([7]); // 7
-enum_init<core::option::Option::<core::box::Box::<@core::array::Array::<core::felt252>>>, 1>([7]) -> ([8]); // 8
-store_temp<RangeCheck>([5]) -> ([5]); // 9
-store_temp<core::option::Option::<core::box::Box::<@core::array::Array::<core::felt252>>>>([8]) -> ([8]); // 10
-return([5], [8]); // 11
+F0:
+array_get<Array<felt252>>([0], [1], [2]) { fallthrough([3], [4]) F0_B0([5]) };
+branch_align() -> ();
+enum_init<core::option::Option::<core::box::Box::<@core::array::Array::<core::felt252>>>, 0>([4]) -> ([6]);
+store_temp<RangeCheck>([3]) -> ([3]);
+store_temp<core::option::Option::<core::box::Box::<@core::array::Array::<core::felt252>>>>([6]) -> ([6]);
+return([3], [6]);
+F0_B0:
+branch_align() -> ();
+struct_construct<Unit>() -> ([7]);
+enum_init<core::option::Option::<core::box::Box::<@core::array::Array::<core::felt252>>>, 1>([7]) -> ([8]);
+store_temp<RangeCheck>([5]) -> ([5]);
+store_temp<core::option::Option::<core::box::Box::<@core::array::Array::<core::felt252>>>>([8]) -> ([8]);
+return([5], [8]);
 
-test::foo@0([0]: RangeCheck, [1]: Snapshot<Array<Array<felt252>>>, [2]: u32) -> (RangeCheck, core::option::Option::<core::box::Box::<@core::array::Array::<core::felt252>>>);
+test::foo@F0([0]: RangeCheck, [1]: Snapshot<Array<Array<felt252>>>, [2]: u32) -> (RangeCheck, core::option::Option::<core::box::Box::<@core::array::Array::<core::felt252>>>);

--- a/Aegis/Tests/e2e_libfuncs/array_aegis/array_len.sierra
+++ b/Aegis/Tests/e2e_libfuncs/array_aegis/array_len.sierra
@@ -1,7 +1,7 @@
 type Array<core::integer::u256> = Array<core::integer::u256> [storable: true, drop: true, dup: false, zero_sized: false];
-type u32 = u32 [storable: true, drop: true, dup: true, zero_sized: false];
 type u128 = u128 [storable: true, drop: true, dup: true, zero_sized: false];
 type core::integer::u256 = Struct<ut@core::integer::u256, u128, u128> [storable: true, drop: true, dup: true, zero_sized: false];
+type u32 = u32 [storable: true, drop: true, dup: true, zero_sized: false];
 type Snapshot<Array<core::integer::u256>> = Snapshot<Array<core::integer::u256>> [storable: true, drop: true, dup: true, zero_sized: false];
 
 libfunc snapshot_take<Array<core::integer::u256>> = snapshot_take<Array<core::integer::u256>>;
@@ -9,10 +9,11 @@ libfunc array_len<core::integer::u256> = array_len<core::integer::u256>;
 libfunc store_temp<Array<core::integer::u256>> = store_temp<Array<core::integer::u256>>;
 libfunc store_temp<u32> = store_temp<u32>;
 
-snapshot_take<Array<core::integer::u256>>([0]) -> ([1], [2]); // 0
-array_len<core::integer::u256>([2]) -> ([3]); // 1
-store_temp<Array<core::integer::u256>>([1]) -> ([1]); // 2
-store_temp<u32>([3]) -> ([3]); // 3
-return([1], [3]); // 4
+F0:
+snapshot_take<Array<core::integer::u256>>([0]) -> ([1], [2]);
+array_len<core::integer::u256>([2]) -> ([3]);
+store_temp<Array<core::integer::u256>>([1]) -> ([1]);
+store_temp<u32>([3]) -> ([3]);
+return([1], [3]);
 
-test::foo@0([0]: Array<core::integer::u256>) -> (Array<core::integer::u256>, u32);
+test::foo@F0([0]: Array<core::integer::u256>) -> (Array<core::integer::u256>, u32);

--- a/Aegis/Tests/e2e_libfuncs/array_aegis/array_new.sierra
+++ b/Aegis/Tests/e2e_libfuncs/array_aegis/array_new.sierra
@@ -4,8 +4,9 @@ type felt252 = felt252 [storable: true, drop: true, dup: true, zero_sized: false
 libfunc array_new<felt252> = array_new<felt252>;
 libfunc store_temp<Array<felt252>> = store_temp<Array<felt252>>;
 
-array_new<felt252>() -> ([0]); // 0
-store_temp<Array<felt252>>([0]) -> ([0]); // 1
-return([0]); // 2
+F0:
+array_new<felt252>() -> ([0]);
+store_temp<Array<felt252>>([0]) -> ([0]);
+return([0]);
 
-test::foo@0() -> (Array<felt252>);
+test::foo@F0() -> (Array<felt252>);

--- a/Aegis/Tests/e2e_libfuncs/array_aegis/array_pop_front.sierra
+++ b/Aegis/Tests/e2e_libfuncs/array_aegis/array_pop_front.sierra
@@ -1,8 +1,8 @@
 type Array<felt252> = Array<felt252> [storable: true, drop: true, dup: false, zero_sized: false];
 type Unit = Struct<ut@Tuple> [storable: true, drop: true, dup: true, zero_sized: true];
-type felt252 = felt252 [storable: true, drop: true, dup: true, zero_sized: false];
 type Box<felt252> = Box<felt252> [storable: true, drop: true, dup: true, zero_sized: false];
 type core::option::Option::<core::box::Box::<core::felt252>> = Enum<ut@core::option::Option::<core::box::Box::<core::felt252>>, Box<felt252>, Unit> [storable: true, drop: true, dup: true, zero_sized: false];
+type felt252 = felt252 [storable: true, drop: true, dup: true, zero_sized: false];
 
 libfunc array_pop_front<felt252> = array_pop_front<felt252>;
 libfunc branch_align = branch_align;
@@ -12,17 +12,19 @@ libfunc store_temp<core::option::Option::<core::box::Box::<core::felt252>>> = st
 libfunc struct_construct<Unit> = struct_construct<Unit>;
 libfunc enum_init<core::option::Option::<core::box::Box::<core::felt252>>, 1> = enum_init<core::option::Option::<core::box::Box::<core::felt252>>, 1>;
 
-array_pop_front<felt252>([0]) { fallthrough([1], [2]) 6([3]) }; // 0
-branch_align() -> (); // 1
-enum_init<core::option::Option::<core::box::Box::<core::felt252>>, 0>([2]) -> ([4]); // 2
-store_temp<Array<felt252>>([1]) -> ([1]); // 3
-store_temp<core::option::Option::<core::box::Box::<core::felt252>>>([4]) -> ([4]); // 4
-return([1], [4]); // 5
-branch_align() -> (); // 6
-struct_construct<Unit>() -> ([5]); // 7
-enum_init<core::option::Option::<core::box::Box::<core::felt252>>, 1>([5]) -> ([6]); // 8
-store_temp<Array<felt252>>([3]) -> ([3]); // 9
-store_temp<core::option::Option::<core::box::Box::<core::felt252>>>([6]) -> ([6]); // 10
-return([3], [6]); // 11
+F0:
+array_pop_front<felt252>([0]) { fallthrough([1], [2]) F0_B0([3]) };
+branch_align() -> ();
+enum_init<core::option::Option::<core::box::Box::<core::felt252>>, 0>([2]) -> ([4]);
+store_temp<Array<felt252>>([1]) -> ([1]);
+store_temp<core::option::Option::<core::box::Box::<core::felt252>>>([4]) -> ([4]);
+return([1], [4]);
+F0_B0:
+branch_align() -> ();
+struct_construct<Unit>() -> ([5]);
+enum_init<core::option::Option::<core::box::Box::<core::felt252>>, 1>([5]) -> ([6]);
+store_temp<Array<felt252>>([3]) -> ([3]);
+store_temp<core::option::Option::<core::box::Box::<core::felt252>>>([6]) -> ([6]);
+return([3], [6]);
 
-test::foo@0([0]: Array<felt252>) -> (Array<felt252>, core::option::Option::<core::box::Box::<core::felt252>>);
+test::foo@F0([0]: Array<felt252>) -> (Array<felt252>, core::option::Option::<core::box::Box::<core::felt252>>);

--- a/Aegis/Tests/e2e_libfuncs/array_aegis/array_pop_front_consume.sierra
+++ b/Aegis/Tests/e2e_libfuncs/array_aegis/array_pop_front_consume.sierra
@@ -1,9 +1,9 @@
 type Array<felt252> = Array<felt252> [storable: true, drop: true, dup: false, zero_sized: false];
 type Unit = Struct<ut@Tuple> [storable: true, drop: true, dup: true, zero_sized: true];
-type felt252 = felt252 [storable: true, drop: true, dup: true, zero_sized: false];
 type Box<felt252> = Box<felt252> [storable: true, drop: true, dup: true, zero_sized: false];
 type Tuple<Array<felt252>, Box<felt252>> = Struct<ut@Tuple, Array<felt252>, Box<felt252>> [storable: true, drop: true, dup: false, zero_sized: false];
 type core::option::Option::<(core::array::Array::<core::felt252>, core::box::Box::<core::felt252>)> = Enum<ut@core::option::Option::<(core::array::Array::<core::felt252>, core::box::Box::<core::felt252>)>, Tuple<Array<felt252>, Box<felt252>>, Unit> [storable: true, drop: true, dup: false, zero_sized: false];
+type felt252 = felt252 [storable: true, drop: true, dup: true, zero_sized: false];
 
 libfunc array_pop_front_consume<felt252> = array_pop_front_consume<felt252>;
 libfunc branch_align = branch_align;
@@ -13,16 +13,18 @@ libfunc store_temp<core::option::Option::<(core::array::Array::<core::felt252>, 
 libfunc struct_construct<Unit> = struct_construct<Unit>;
 libfunc enum_init<core::option::Option::<(core::array::Array::<core::felt252>, core::box::Box::<core::felt252>)>, 1> = enum_init<core::option::Option::<(core::array::Array::<core::felt252>, core::box::Box::<core::felt252>)>, 1>;
 
-array_pop_front_consume<felt252>([0]) { fallthrough([1], [2]) 6() }; // 0
-branch_align() -> (); // 1
-struct_construct<Tuple<Array<felt252>, Box<felt252>>>([1], [2]) -> ([3]); // 2
-enum_init<core::option::Option::<(core::array::Array::<core::felt252>, core::box::Box::<core::felt252>)>, 0>([3]) -> ([4]); // 3
-store_temp<core::option::Option::<(core::array::Array::<core::felt252>, core::box::Box::<core::felt252>)>>([4]) -> ([4]); // 4
-return([4]); // 5
-branch_align() -> (); // 6
-struct_construct<Unit>() -> ([5]); // 7
-enum_init<core::option::Option::<(core::array::Array::<core::felt252>, core::box::Box::<core::felt252>)>, 1>([5]) -> ([6]); // 8
-store_temp<core::option::Option::<(core::array::Array::<core::felt252>, core::box::Box::<core::felt252>)>>([6]) -> ([6]); // 9
-return([6]); // 10
+F0:
+array_pop_front_consume<felt252>([0]) { fallthrough([1], [2]) F0_B0() };
+branch_align() -> ();
+struct_construct<Tuple<Array<felt252>, Box<felt252>>>([1], [2]) -> ([3]);
+enum_init<core::option::Option::<(core::array::Array::<core::felt252>, core::box::Box::<core::felt252>)>, 0>([3]) -> ([4]);
+store_temp<core::option::Option::<(core::array::Array::<core::felt252>, core::box::Box::<core::felt252>)>>([4]) -> ([4]);
+return([4]);
+F0_B0:
+branch_align() -> ();
+struct_construct<Unit>() -> ([5]);
+enum_init<core::option::Option::<(core::array::Array::<core::felt252>, core::box::Box::<core::felt252>)>, 1>([5]) -> ([6]);
+store_temp<core::option::Option::<(core::array::Array::<core::felt252>, core::box::Box::<core::felt252>)>>([6]) -> ([6]);
+return([6]);
 
-test::foo@0([0]: Array<felt252>) -> (core::option::Option::<(core::array::Array::<core::felt252>, core::box::Box::<core::felt252>)>);
+test::foo@F0([0]: Array<felt252>) -> (core::option::Option::<(core::array::Array::<core::felt252>, core::box::Box::<core::felt252>)>);

--- a/Aegis/Tests/e2e_libfuncs/array_aegis/array_slice.sierra
+++ b/Aegis/Tests/e2e_libfuncs/array_aegis/array_slice.sierra
@@ -3,8 +3,8 @@ type Unit = Struct<ut@Tuple> [storable: true, drop: true, dup: true, zero_sized:
 type Array<Array<felt252>> = Array<Array<felt252>> [storable: true, drop: true, dup: false, zero_sized: false];
 type Snapshot<Array<Array<felt252>>> = Snapshot<Array<Array<felt252>>> [storable: true, drop: true, dup: true, zero_sized: false];
 type core::option::Option::<@core::array::Array::<core::array::Array::<core::felt252>>> = Enum<ut@core::option::Option::<@core::array::Array::<core::array::Array::<core::felt252>>>, Snapshot<Array<Array<felt252>>>, Unit> [storable: true, drop: true, dup: true, zero_sized: false];
-type u32 = u32 [storable: true, drop: true, dup: true, zero_sized: false];
 type Array<felt252> = Array<felt252> [storable: true, drop: true, dup: false, zero_sized: false];
+type u32 = u32 [storable: true, drop: true, dup: true, zero_sized: false];
 type felt252 = felt252 [storable: true, drop: true, dup: true, zero_sized: false];
 
 libfunc array_slice<Array<felt252>> = array_slice<Array<felt252>>;
@@ -15,17 +15,19 @@ libfunc store_temp<core::option::Option::<@core::array::Array::<core::array::Arr
 libfunc struct_construct<Unit> = struct_construct<Unit>;
 libfunc enum_init<core::option::Option::<@core::array::Array::<core::array::Array::<core::felt252>>>, 1> = enum_init<core::option::Option::<@core::array::Array::<core::array::Array::<core::felt252>>>, 1>;
 
-array_slice<Array<felt252>>([0], [1], [2], [3]) { fallthrough([4], [5]) 6([6]) }; // 0
-branch_align() -> (); // 1
-enum_init<core::option::Option::<@core::array::Array::<core::array::Array::<core::felt252>>>, 0>([5]) -> ([7]); // 2
-store_temp<RangeCheck>([4]) -> ([4]); // 3
-store_temp<core::option::Option::<@core::array::Array::<core::array::Array::<core::felt252>>>>([7]) -> ([7]); // 4
-return([4], [7]); // 5
-branch_align() -> (); // 6
-struct_construct<Unit>() -> ([8]); // 7
-enum_init<core::option::Option::<@core::array::Array::<core::array::Array::<core::felt252>>>, 1>([8]) -> ([9]); // 8
-store_temp<RangeCheck>([6]) -> ([6]); // 9
-store_temp<core::option::Option::<@core::array::Array::<core::array::Array::<core::felt252>>>>([9]) -> ([9]); // 10
-return([6], [9]); // 11
+F0:
+array_slice<Array<felt252>>([0], [1], [2], [3]) { fallthrough([4], [5]) F0_B0([6]) };
+branch_align() -> ();
+enum_init<core::option::Option::<@core::array::Array::<core::array::Array::<core::felt252>>>, 0>([5]) -> ([7]);
+store_temp<RangeCheck>([4]) -> ([4]);
+store_temp<core::option::Option::<@core::array::Array::<core::array::Array::<core::felt252>>>>([7]) -> ([7]);
+return([4], [7]);
+F0_B0:
+branch_align() -> ();
+struct_construct<Unit>() -> ([8]);
+enum_init<core::option::Option::<@core::array::Array::<core::array::Array::<core::felt252>>>, 1>([8]) -> ([9]);
+store_temp<RangeCheck>([6]) -> ([6]);
+store_temp<core::option::Option::<@core::array::Array::<core::array::Array::<core::felt252>>>>([9]) -> ([9]);
+return([6], [9]);
 
-test::foo@0([0]: RangeCheck, [1]: Snapshot<Array<Array<felt252>>>, [2]: u32, [3]: u32) -> (RangeCheck, core::option::Option::<@core::array::Array::<core::array::Array::<core::felt252>>>);
+test::foo@F0([0]: RangeCheck, [1]: Snapshot<Array<Array<felt252>>>, [2]: u32, [3]: u32) -> (RangeCheck, core::option::Option::<@core::array::Array::<core::array::Array::<core::felt252>>>);

--- a/Aegis/Tests/e2e_libfuncs/array_aegis/array_snapshot_multi_pop_back.sierra
+++ b/Aegis/Tests/e2e_libfuncs/array_aegis/array_snapshot_multi_pop_back.sierra
@@ -1,0 +1,36 @@
+type RangeCheck = RangeCheck [storable: true, drop: false, dup: false, zero_sized: false];
+type Unit = Struct<ut@Tuple> [storable: true, drop: true, dup: true, zero_sized: true];
+type Box<Tuple<felt252, felt252>> = Box<Tuple<felt252, felt252>> [storable: true, drop: true, dup: true, zero_sized: false];
+type core::option::Option::<@core::box::Box::<[core::felt252; 2]>> = Enum<ut@core::option::Option::<@core::box::Box::<[core::felt252; 2]>>, Box<Tuple<felt252, felt252>>, Unit> [storable: true, drop: true, dup: true, zero_sized: false];
+type felt252 = felt252 [storable: true, drop: true, dup: true, zero_sized: false];
+type Tuple<felt252, felt252> = Struct<ut@Tuple, felt252, felt252> [storable: true, drop: true, dup: true, zero_sized: false];
+type Array<felt252> = Array<felt252> [storable: true, drop: true, dup: false, zero_sized: false];
+type Snapshot<Array<felt252>> = Snapshot<Array<felt252>> [storable: true, drop: true, dup: true, zero_sized: false];
+
+libfunc array_snapshot_multi_pop_back<Tuple<felt252, felt252>> = array_snapshot_multi_pop_back<Tuple<felt252, felt252>>;
+libfunc branch_align = branch_align;
+libfunc enum_init<core::option::Option::<@core::box::Box::<[core::felt252; 2]>>, 0> = enum_init<core::option::Option::<@core::box::Box::<[core::felt252; 2]>>, 0>;
+libfunc store_temp<RangeCheck> = store_temp<RangeCheck>;
+libfunc store_temp<Snapshot<Array<felt252>>> = store_temp<Snapshot<Array<felt252>>>;
+libfunc store_temp<core::option::Option::<@core::box::Box::<[core::felt252; 2]>>> = store_temp<core::option::Option::<@core::box::Box::<[core::felt252; 2]>>>;
+libfunc struct_construct<Unit> = struct_construct<Unit>;
+libfunc enum_init<core::option::Option::<@core::box::Box::<[core::felt252; 2]>>, 1> = enum_init<core::option::Option::<@core::box::Box::<[core::felt252; 2]>>, 1>;
+
+F0:
+array_snapshot_multi_pop_back<Tuple<felt252, felt252>>([0], [1]) { fallthrough([2], [3], [4]) F0_B0([5], [6]) };
+branch_align() -> ();
+enum_init<core::option::Option::<@core::box::Box::<[core::felt252; 2]>>, 0>([4]) -> ([7]);
+store_temp<RangeCheck>([2]) -> ([2]);
+store_temp<Snapshot<Array<felt252>>>([3]) -> ([3]);
+store_temp<core::option::Option::<@core::box::Box::<[core::felt252; 2]>>>([7]) -> ([7]);
+return([2], [3], [7]);
+F0_B0:
+branch_align() -> ();
+struct_construct<Unit>() -> ([8]);
+enum_init<core::option::Option::<@core::box::Box::<[core::felt252; 2]>>, 1>([8]) -> ([9]);
+store_temp<RangeCheck>([5]) -> ([5]);
+store_temp<Snapshot<Array<felt252>>>([6]) -> ([6]);
+store_temp<core::option::Option::<@core::box::Box::<[core::felt252; 2]>>>([9]) -> ([9]);
+return([5], [6], [9]);
+
+test::foo@F0([0]: RangeCheck, [1]: Snapshot<Array<felt252>>) -> (RangeCheck, Snapshot<Array<felt252>>, core::option::Option::<@core::box::Box::<[core::felt252; 2]>>);

--- a/Aegis/Tests/e2e_libfuncs/array_aegis/array_snapshot_multi_pop_front.sierra
+++ b/Aegis/Tests/e2e_libfuncs/array_aegis/array_snapshot_multi_pop_front.sierra
@@ -1,0 +1,36 @@
+type RangeCheck = RangeCheck [storable: true, drop: false, dup: false, zero_sized: false];
+type Unit = Struct<ut@Tuple> [storable: true, drop: true, dup: true, zero_sized: true];
+type Box<Tuple<felt252, felt252>> = Box<Tuple<felt252, felt252>> [storable: true, drop: true, dup: true, zero_sized: false];
+type core::option::Option::<@core::box::Box::<[core::felt252; 2]>> = Enum<ut@core::option::Option::<@core::box::Box::<[core::felt252; 2]>>, Box<Tuple<felt252, felt252>>, Unit> [storable: true, drop: true, dup: true, zero_sized: false];
+type felt252 = felt252 [storable: true, drop: true, dup: true, zero_sized: false];
+type Tuple<felt252, felt252> = Struct<ut@Tuple, felt252, felt252> [storable: true, drop: true, dup: true, zero_sized: false];
+type Array<felt252> = Array<felt252> [storable: true, drop: true, dup: false, zero_sized: false];
+type Snapshot<Array<felt252>> = Snapshot<Array<felt252>> [storable: true, drop: true, dup: true, zero_sized: false];
+
+libfunc array_snapshot_multi_pop_front<Tuple<felt252, felt252>> = array_snapshot_multi_pop_front<Tuple<felt252, felt252>>;
+libfunc branch_align = branch_align;
+libfunc enum_init<core::option::Option::<@core::box::Box::<[core::felt252; 2]>>, 0> = enum_init<core::option::Option::<@core::box::Box::<[core::felt252; 2]>>, 0>;
+libfunc store_temp<RangeCheck> = store_temp<RangeCheck>;
+libfunc store_temp<Snapshot<Array<felt252>>> = store_temp<Snapshot<Array<felt252>>>;
+libfunc store_temp<core::option::Option::<@core::box::Box::<[core::felt252; 2]>>> = store_temp<core::option::Option::<@core::box::Box::<[core::felt252; 2]>>>;
+libfunc struct_construct<Unit> = struct_construct<Unit>;
+libfunc enum_init<core::option::Option::<@core::box::Box::<[core::felt252; 2]>>, 1> = enum_init<core::option::Option::<@core::box::Box::<[core::felt252; 2]>>, 1>;
+
+F0:
+array_snapshot_multi_pop_front<Tuple<felt252, felt252>>([0], [1]) { fallthrough([2], [3], [4]) F0_B0([5], [6]) };
+branch_align() -> ();
+enum_init<core::option::Option::<@core::box::Box::<[core::felt252; 2]>>, 0>([4]) -> ([7]);
+store_temp<RangeCheck>([2]) -> ([2]);
+store_temp<Snapshot<Array<felt252>>>([3]) -> ([3]);
+store_temp<core::option::Option::<@core::box::Box::<[core::felt252; 2]>>>([7]) -> ([7]);
+return([2], [3], [7]);
+F0_B0:
+branch_align() -> ();
+struct_construct<Unit>() -> ([8]);
+enum_init<core::option::Option::<@core::box::Box::<[core::felt252; 2]>>, 1>([8]) -> ([9]);
+store_temp<RangeCheck>([5]) -> ([5]);
+store_temp<Snapshot<Array<felt252>>>([6]) -> ([6]);
+store_temp<core::option::Option::<@core::box::Box::<[core::felt252; 2]>>>([9]) -> ([9]);
+return([5], [6], [9]);
+
+test::foo@F0([0]: RangeCheck, [1]: Snapshot<Array<felt252>>) -> (RangeCheck, Snapshot<Array<felt252>>, core::option::Option::<@core::box::Box::<[core::felt252; 2]>>);

--- a/Aegis/Tests/e2e_libfuncs/array_aegis/array_snapshot_pop_back.sierra
+++ b/Aegis/Tests/e2e_libfuncs/array_aegis/array_snapshot_pop_back.sierra
@@ -1,9 +1,9 @@
 type Array<felt252> = Array<felt252> [storable: true, drop: true, dup: false, zero_sized: false];
 type Snapshot<Array<felt252>> = Snapshot<Array<felt252>> [storable: true, drop: true, dup: true, zero_sized: false];
 type Unit = Struct<ut@Tuple> [storable: true, drop: true, dup: true, zero_sized: true];
-type felt252 = felt252 [storable: true, drop: true, dup: true, zero_sized: false];
 type Box<felt252> = Box<felt252> [storable: true, drop: true, dup: true, zero_sized: false];
 type core::option::Option::<core::box::Box::<@core::felt252>> = Enum<ut@core::option::Option::<core::box::Box::<@core::felt252>>, Box<felt252>, Unit> [storable: true, drop: true, dup: true, zero_sized: false];
+type felt252 = felt252 [storable: true, drop: true, dup: true, zero_sized: false];
 
 libfunc array_snapshot_pop_back<felt252> = array_snapshot_pop_back<felt252>;
 libfunc branch_align = branch_align;
@@ -13,17 +13,19 @@ libfunc store_temp<core::option::Option::<core::box::Box::<@core::felt252>>> = s
 libfunc struct_construct<Unit> = struct_construct<Unit>;
 libfunc enum_init<core::option::Option::<core::box::Box::<@core::felt252>>, 1> = enum_init<core::option::Option::<core::box::Box::<@core::felt252>>, 1>;
 
-array_snapshot_pop_back<felt252>([0]) { fallthrough([1], [2]) 6([3]) }; // 0
-branch_align() -> (); // 1
-enum_init<core::option::Option::<core::box::Box::<@core::felt252>>, 0>([2]) -> ([4]); // 2
-store_temp<Snapshot<Array<felt252>>>([1]) -> ([1]); // 3
-store_temp<core::option::Option::<core::box::Box::<@core::felt252>>>([4]) -> ([4]); // 4
-return([1], [4]); // 5
-branch_align() -> (); // 6
-struct_construct<Unit>() -> ([5]); // 7
-enum_init<core::option::Option::<core::box::Box::<@core::felt252>>, 1>([5]) -> ([6]); // 8
-store_temp<Snapshot<Array<felt252>>>([3]) -> ([3]); // 9
-store_temp<core::option::Option::<core::box::Box::<@core::felt252>>>([6]) -> ([6]); // 10
-return([3], [6]); // 11
+F0:
+array_snapshot_pop_back<felt252>([0]) { fallthrough([1], [2]) F0_B0([3]) };
+branch_align() -> ();
+enum_init<core::option::Option::<core::box::Box::<@core::felt252>>, 0>([2]) -> ([4]);
+store_temp<Snapshot<Array<felt252>>>([1]) -> ([1]);
+store_temp<core::option::Option::<core::box::Box::<@core::felt252>>>([4]) -> ([4]);
+return([1], [4]);
+F0_B0:
+branch_align() -> ();
+struct_construct<Unit>() -> ([5]);
+enum_init<core::option::Option::<core::box::Box::<@core::felt252>>, 1>([5]) -> ([6]);
+store_temp<Snapshot<Array<felt252>>>([3]) -> ([3]);
+store_temp<core::option::Option::<core::box::Box::<@core::felt252>>>([6]) -> ([6]);
+return([3], [6]);
 
-test::foo@0([0]: Snapshot<Array<felt252>>) -> (Snapshot<Array<felt252>>, core::option::Option::<core::box::Box::<@core::felt252>>);
+test::foo@F0([0]: Snapshot<Array<felt252>>) -> (Snapshot<Array<felt252>>, core::option::Option::<core::box::Box::<@core::felt252>>);

--- a/Aegis/Tests/e2e_libfuncs/array_aegis/array_snapshot_pop_front.sierra
+++ b/Aegis/Tests/e2e_libfuncs/array_aegis/array_snapshot_pop_front.sierra
@@ -1,9 +1,9 @@
 type Array<felt252> = Array<felt252> [storable: true, drop: true, dup: false, zero_sized: false];
 type Snapshot<Array<felt252>> = Snapshot<Array<felt252>> [storable: true, drop: true, dup: true, zero_sized: false];
 type Unit = Struct<ut@Tuple> [storable: true, drop: true, dup: true, zero_sized: true];
-type felt252 = felt252 [storable: true, drop: true, dup: true, zero_sized: false];
 type Box<felt252> = Box<felt252> [storable: true, drop: true, dup: true, zero_sized: false];
 type core::option::Option::<core::box::Box::<@core::felt252>> = Enum<ut@core::option::Option::<core::box::Box::<@core::felt252>>, Box<felt252>, Unit> [storable: true, drop: true, dup: true, zero_sized: false];
+type felt252 = felt252 [storable: true, drop: true, dup: true, zero_sized: false];
 
 libfunc array_snapshot_pop_front<felt252> = array_snapshot_pop_front<felt252>;
 libfunc branch_align = branch_align;
@@ -13,17 +13,19 @@ libfunc store_temp<core::option::Option::<core::box::Box::<@core::felt252>>> = s
 libfunc struct_construct<Unit> = struct_construct<Unit>;
 libfunc enum_init<core::option::Option::<core::box::Box::<@core::felt252>>, 1> = enum_init<core::option::Option::<core::box::Box::<@core::felt252>>, 1>;
 
-array_snapshot_pop_front<felt252>([0]) { fallthrough([1], [2]) 6([3]) }; // 0
-branch_align() -> (); // 1
-enum_init<core::option::Option::<core::box::Box::<@core::felt252>>, 0>([2]) -> ([4]); // 2
-store_temp<Snapshot<Array<felt252>>>([1]) -> ([1]); // 3
-store_temp<core::option::Option::<core::box::Box::<@core::felt252>>>([4]) -> ([4]); // 4
-return([1], [4]); // 5
-branch_align() -> (); // 6
-struct_construct<Unit>() -> ([5]); // 7
-enum_init<core::option::Option::<core::box::Box::<@core::felt252>>, 1>([5]) -> ([6]); // 8
-store_temp<Snapshot<Array<felt252>>>([3]) -> ([3]); // 9
-store_temp<core::option::Option::<core::box::Box::<@core::felt252>>>([6]) -> ([6]); // 10
-return([3], [6]); // 11
+F0:
+array_snapshot_pop_front<felt252>([0]) { fallthrough([1], [2]) F0_B0([3]) };
+branch_align() -> ();
+enum_init<core::option::Option::<core::box::Box::<@core::felt252>>, 0>([2]) -> ([4]);
+store_temp<Snapshot<Array<felt252>>>([1]) -> ([1]);
+store_temp<core::option::Option::<core::box::Box::<@core::felt252>>>([4]) -> ([4]);
+return([1], [4]);
+F0_B0:
+branch_align() -> ();
+struct_construct<Unit>() -> ([5]);
+enum_init<core::option::Option::<core::box::Box::<@core::felt252>>, 1>([5]) -> ([6]);
+store_temp<Snapshot<Array<felt252>>>([3]) -> ([3]);
+store_temp<core::option::Option::<core::box::Box::<@core::felt252>>>([6]) -> ([6]);
+return([3], [6]);
 
-test::foo@0([0]: Snapshot<Array<felt252>>) -> (Snapshot<Array<felt252>>, core::option::Option::<core::box::Box::<@core::felt252>>);
+test::foo@F0([0]: Snapshot<Array<felt252>>) -> (Snapshot<Array<felt252>>, core::option::Option::<core::box::Box::<@core::felt252>>);

--- a/Aegis/Tests/e2e_libfuncs/array_aegis/span_from_tuple.sierra
+++ b/Aegis/Tests/e2e_libfuncs/array_aegis/span_from_tuple.sierra
@@ -1,14 +1,15 @@
 type Box<Tuple<felt252, felt252, felt252>> = Box<Tuple<felt252, felt252, felt252>> [storable: true, drop: true, dup: true, zero_sized: false];
-type Array<felt252> = Array<felt252> [storable: true, drop: true, dup: false, zero_sized: false];
-type Snapshot<Array<felt252>> = Snapshot<Array<felt252>> [storable: true, drop: true, dup: true, zero_sized: false];
 type felt252 = felt252 [storable: true, drop: true, dup: true, zero_sized: false];
 type Tuple<felt252, felt252, felt252> = Struct<ut@Tuple, felt252, felt252, felt252> [storable: true, drop: true, dup: true, zero_sized: false];
+type Array<felt252> = Array<felt252> [storable: true, drop: true, dup: false, zero_sized: false];
+type Snapshot<Array<felt252>> = Snapshot<Array<felt252>> [storable: true, drop: true, dup: true, zero_sized: false];
 
 libfunc span_from_tuple<Tuple<felt252, felt252, felt252>> = span_from_tuple<Tuple<felt252, felt252, felt252>>;
 libfunc store_temp<Snapshot<Array<felt252>>> = store_temp<Snapshot<Array<felt252>>>;
 
-span_from_tuple<Tuple<felt252, felt252, felt252>>([0]) -> ([1]); // 0
-store_temp<Snapshot<Array<felt252>>>([1]) -> ([1]); // 1
-return([1]); // 2
+F0:
+span_from_tuple<Tuple<felt252, felt252, felt252>>([0]) -> ([1]);
+store_temp<Snapshot<Array<felt252>>>([1]) -> ([1]);
+return([1]);
 
-test::foo@0([0]: Box<Tuple<felt252, felt252, felt252>>) -> (Snapshot<Array<felt252>>);
+test::foo@F0([0]: Box<Tuple<felt252, felt252, felt252>>) -> (Snapshot<Array<felt252>>);

--- a/Aegis/Tests/e2e_libfuncs/array_aegis/tuple_from_span.sierra
+++ b/Aegis/Tests/e2e_libfuncs/array_aegis/tuple_from_span.sierra
@@ -1,0 +1,29 @@
+type Array<felt252> = Array<felt252> [storable: true, drop: true, dup: false, zero_sized: false];
+type Snapshot<Array<felt252>> = Snapshot<Array<felt252>> [storable: true, drop: true, dup: true, zero_sized: false];
+type Unit = Struct<ut@Tuple> [storable: true, drop: true, dup: true, zero_sized: true];
+type felt252 = felt252 [storable: true, drop: true, dup: true, zero_sized: false];
+type Box<Tuple<felt252, felt252, felt252>> = Box<Tuple<felt252, felt252, felt252>> [storable: true, drop: true, dup: true, zero_sized: false];
+type core::option::Option::<@core::box::Box::<(core::felt252, core::felt252, core::felt252)>> = Enum<ut@core::option::Option::<@core::box::Box::<(core::felt252, core::felt252, core::felt252)>>, Box<Tuple<felt252, felt252, felt252>>, Unit> [storable: true, drop: true, dup: true, zero_sized: false];
+type Tuple<felt252, felt252, felt252> = Struct<ut@Tuple, felt252, felt252, felt252> [storable: true, drop: true, dup: true, zero_sized: false];
+
+libfunc tuple_from_span<Tuple<felt252, felt252, felt252>> = tuple_from_span<Tuple<felt252, felt252, felt252>>;
+libfunc branch_align = branch_align;
+libfunc enum_init<core::option::Option::<@core::box::Box::<(core::felt252, core::felt252, core::felt252)>>, 0> = enum_init<core::option::Option::<@core::box::Box::<(core::felt252, core::felt252, core::felt252)>>, 0>;
+libfunc store_temp<core::option::Option::<@core::box::Box::<(core::felt252, core::felt252, core::felt252)>>> = store_temp<core::option::Option::<@core::box::Box::<(core::felt252, core::felt252, core::felt252)>>>;
+libfunc struct_construct<Unit> = struct_construct<Unit>;
+libfunc enum_init<core::option::Option::<@core::box::Box::<(core::felt252, core::felt252, core::felt252)>>, 1> = enum_init<core::option::Option::<@core::box::Box::<(core::felt252, core::felt252, core::felt252)>>, 1>;
+
+F0:
+tuple_from_span<Tuple<felt252, felt252, felt252>>([0]) { fallthrough([1]) F0_B0() };
+branch_align() -> ();
+enum_init<core::option::Option::<@core::box::Box::<(core::felt252, core::felt252, core::felt252)>>, 0>([1]) -> ([2]);
+store_temp<core::option::Option::<@core::box::Box::<(core::felt252, core::felt252, core::felt252)>>>([2]) -> ([2]);
+return([2]);
+F0_B0:
+branch_align() -> ();
+struct_construct<Unit>() -> ([3]);
+enum_init<core::option::Option::<@core::box::Box::<(core::felt252, core::felt252, core::felt252)>>, 1>([3]) -> ([4]);
+store_temp<core::option::Option::<@core::box::Box::<(core::felt252, core::felt252, core::felt252)>>>([4]) -> ([4]);
+return([4]);
+
+test::foo@F0([0]: Snapshot<Array<felt252>>) -> (core::option::Option::<@core::box::Box::<(core::felt252, core::felt252, core::felt252)>>);

--- a/Aegis/Tests/e2e_libfuncs/bitwise_aegis/bitwise.sierra
+++ b/Aegis/Tests/e2e_libfuncs/bitwise_aegis/bitwise.sierra
@@ -7,10 +7,11 @@ libfunc struct_construct<Tuple<u128, u128, u128>> = struct_construct<Tuple<u128,
 libfunc store_temp<Bitwise> = store_temp<Bitwise>;
 libfunc store_temp<Tuple<u128, u128, u128>> = store_temp<Tuple<u128, u128, u128>>;
 
-bitwise([0], [1], [2]) -> ([3], [4], [5], [6]); // 0
-struct_construct<Tuple<u128, u128, u128>>([4], [5], [6]) -> ([7]); // 1
-store_temp<Bitwise>([3]) -> ([3]); // 2
-store_temp<Tuple<u128, u128, u128>>([7]) -> ([7]); // 3
-return([3], [7]); // 4
+F0:
+bitwise([0], [1], [2]) -> ([3], [4], [5], [6]);
+struct_construct<Tuple<u128, u128, u128>>([4], [5], [6]) -> ([7]);
+store_temp<Bitwise>([3]) -> ([3]);
+store_temp<Tuple<u128, u128, u128>>([7]) -> ([7]);
+return([3], [7]);
 
-test::foo@0([0]: Bitwise, [1]: u128, [2]: u128) -> (Bitwise, Tuple<u128, u128, u128>);
+test::foo@F0([0]: Bitwise, [1]: u128, [2]: u128) -> (Bitwise, Tuple<u128, u128, u128>);

--- a/Aegis/Tests/e2e_libfuncs/bitwise_aegis/u16_bitwise.sierra
+++ b/Aegis/Tests/e2e_libfuncs/bitwise_aegis/u16_bitwise.sierra
@@ -7,10 +7,11 @@ libfunc struct_construct<Tuple<u16, u16, u16>> = struct_construct<Tuple<u16, u16
 libfunc store_temp<Bitwise> = store_temp<Bitwise>;
 libfunc store_temp<Tuple<u16, u16, u16>> = store_temp<Tuple<u16, u16, u16>>;
 
-u16_bitwise([0], [1], [2]) -> ([3], [4], [5], [6]); // 0
-struct_construct<Tuple<u16, u16, u16>>([4], [5], [6]) -> ([7]); // 1
-store_temp<Bitwise>([3]) -> ([3]); // 2
-store_temp<Tuple<u16, u16, u16>>([7]) -> ([7]); // 3
-return([3], [7]); // 4
+F0:
+u16_bitwise([0], [1], [2]) -> ([3], [4], [5], [6]);
+struct_construct<Tuple<u16, u16, u16>>([4], [5], [6]) -> ([7]);
+store_temp<Bitwise>([3]) -> ([3]);
+store_temp<Tuple<u16, u16, u16>>([7]) -> ([7]);
+return([3], [7]);
 
-test::foo@0([0]: Bitwise, [1]: u16, [2]: u16) -> (Bitwise, Tuple<u16, u16, u16>);
+test::foo@F0([0]: Bitwise, [1]: u16, [2]: u16) -> (Bitwise, Tuple<u16, u16, u16>);

--- a/Aegis/Tests/e2e_libfuncs/bitwise_aegis/u32_bitwise.sierra
+++ b/Aegis/Tests/e2e_libfuncs/bitwise_aegis/u32_bitwise.sierra
@@ -7,10 +7,11 @@ libfunc struct_construct<Tuple<u32, u32, u32>> = struct_construct<Tuple<u32, u32
 libfunc store_temp<Bitwise> = store_temp<Bitwise>;
 libfunc store_temp<Tuple<u32, u32, u32>> = store_temp<Tuple<u32, u32, u32>>;
 
-u32_bitwise([0], [1], [2]) -> ([3], [4], [5], [6]); // 0
-struct_construct<Tuple<u32, u32, u32>>([4], [5], [6]) -> ([7]); // 1
-store_temp<Bitwise>([3]) -> ([3]); // 2
-store_temp<Tuple<u32, u32, u32>>([7]) -> ([7]); // 3
-return([3], [7]); // 4
+F0:
+u32_bitwise([0], [1], [2]) -> ([3], [4], [5], [6]);
+struct_construct<Tuple<u32, u32, u32>>([4], [5], [6]) -> ([7]);
+store_temp<Bitwise>([3]) -> ([3]);
+store_temp<Tuple<u32, u32, u32>>([7]) -> ([7]);
+return([3], [7]);
 
-test::foo@0([0]: Bitwise, [1]: u32, [2]: u32) -> (Bitwise, Tuple<u32, u32, u32>);
+test::foo@F0([0]: Bitwise, [1]: u32, [2]: u32) -> (Bitwise, Tuple<u32, u32, u32>);

--- a/Aegis/Tests/e2e_libfuncs/bitwise_aegis/u64_bitwise.sierra
+++ b/Aegis/Tests/e2e_libfuncs/bitwise_aegis/u64_bitwise.sierra
@@ -7,10 +7,11 @@ libfunc struct_construct<Tuple<u64, u64, u64>> = struct_construct<Tuple<u64, u64
 libfunc store_temp<Bitwise> = store_temp<Bitwise>;
 libfunc store_temp<Tuple<u64, u64, u64>> = store_temp<Tuple<u64, u64, u64>>;
 
-u64_bitwise([0], [1], [2]) -> ([3], [4], [5], [6]); // 0
-struct_construct<Tuple<u64, u64, u64>>([4], [5], [6]) -> ([7]); // 1
-store_temp<Bitwise>([3]) -> ([3]); // 2
-store_temp<Tuple<u64, u64, u64>>([7]) -> ([7]); // 3
-return([3], [7]); // 4
+F0:
+u64_bitwise([0], [1], [2]) -> ([3], [4], [5], [6]);
+struct_construct<Tuple<u64, u64, u64>>([4], [5], [6]) -> ([7]);
+store_temp<Bitwise>([3]) -> ([3]);
+store_temp<Tuple<u64, u64, u64>>([7]) -> ([7]);
+return([3], [7]);
 
-test::foo@0([0]: Bitwise, [1]: u64, [2]: u64) -> (Bitwise, Tuple<u64, u64, u64>);
+test::foo@F0([0]: Bitwise, [1]: u64, [2]: u64) -> (Bitwise, Tuple<u64, u64, u64>);

--- a/Aegis/Tests/e2e_libfuncs/bitwise_aegis/u8_bitwise.sierra
+++ b/Aegis/Tests/e2e_libfuncs/bitwise_aegis/u8_bitwise.sierra
@@ -7,10 +7,11 @@ libfunc struct_construct<Tuple<u8, u8, u8>> = struct_construct<Tuple<u8, u8, u8>
 libfunc store_temp<Bitwise> = store_temp<Bitwise>;
 libfunc store_temp<Tuple<u8, u8, u8>> = store_temp<Tuple<u8, u8, u8>>;
 
-u8_bitwise([0], [1], [2]) -> ([3], [4], [5], [6]); // 0
-struct_construct<Tuple<u8, u8, u8>>([4], [5], [6]) -> ([7]); // 1
-store_temp<Bitwise>([3]) -> ([3]); // 2
-store_temp<Tuple<u8, u8, u8>>([7]) -> ([7]); // 3
-return([3], [7]); // 4
+F0:
+u8_bitwise([0], [1], [2]) -> ([3], [4], [5], [6]);
+struct_construct<Tuple<u8, u8, u8>>([4], [5], [6]) -> ([7]);
+store_temp<Bitwise>([3]) -> ([3]);
+store_temp<Tuple<u8, u8, u8>>([7]) -> ([7]);
+return([3], [7]);
 
-test::foo@0([0]: Bitwise, [1]: u8, [2]: u8) -> (Bitwise, Tuple<u8, u8, u8>);
+test::foo@F0([0]: Bitwise, [1]: u8, [2]: u8) -> (Bitwise, Tuple<u8, u8, u8>);

--- a/Aegis/Tests/e2e_libfuncs/blake_aegis/blake2s_finalize.sierra
+++ b/Aegis/Tests/e2e_libfuncs/blake_aegis/blake2s_finalize.sierra
@@ -1,0 +1,13 @@
+type Box<Tuple<u32, u32, u32, u32, u32, u32, u32, u32>> = Box<Tuple<u32, u32, u32, u32, u32, u32, u32, u32>> [storable: true, drop: true, dup: true, zero_sized: false];
+type Box<Tuple<u32, u32, u32, u32, u32, u32, u32, u32, u32, u32, u32, u32, u32, u32, u32, u32>> = Box<Tuple<u32, u32, u32, u32, u32, u32, u32, u32, u32, u32, u32, u32, u32, u32, u32, u32>> [storable: true, drop: true, dup: true, zero_sized: false];
+type u32 = u32 [storable: true, drop: true, dup: true, zero_sized: false];
+type Tuple<u32, u32, u32, u32, u32, u32, u32, u32> = Struct<ut@Tuple, u32, u32, u32, u32, u32, u32, u32, u32> [storable: true, drop: true, dup: true, zero_sized: false];
+type Tuple<u32, u32, u32, u32, u32, u32, u32, u32, u32, u32, u32, u32, u32, u32, u32, u32> = Struct<ut@Tuple, u32, u32, u32, u32, u32, u32, u32, u32, u32, u32, u32, u32, u32, u32, u32, u32> [storable: true, drop: true, dup: true, zero_sized: false];
+
+libfunc blake2s_finalize = blake2s_finalize;
+
+F0:
+blake2s_finalize([0], [1], [2]) -> ([3]);
+return([3]);
+
+test::foo@F0([0]: Box<Tuple<u32, u32, u32, u32, u32, u32, u32, u32>>, [1]: u32, [2]: Box<Tuple<u32, u32, u32, u32, u32, u32, u32, u32, u32, u32, u32, u32, u32, u32, u32, u32>>) -> (Box<Tuple<u32, u32, u32, u32, u32, u32, u32, u32>>);

--- a/Aegis/Tests/e2e_libfuncs/blake_aegis/blake_compress.sierra
+++ b/Aegis/Tests/e2e_libfuncs/blake_aegis/blake_compress.sierra
@@ -1,0 +1,13 @@
+type Box<Tuple<u32, u32, u32, u32, u32, u32, u32, u32>> = Box<Tuple<u32, u32, u32, u32, u32, u32, u32, u32>> [storable: true, drop: true, dup: true, zero_sized: false];
+type Box<Tuple<u32, u32, u32, u32, u32, u32, u32, u32, u32, u32, u32, u32, u32, u32, u32, u32>> = Box<Tuple<u32, u32, u32, u32, u32, u32, u32, u32, u32, u32, u32, u32, u32, u32, u32, u32>> [storable: true, drop: true, dup: true, zero_sized: false];
+type u32 = u32 [storable: true, drop: true, dup: true, zero_sized: false];
+type Tuple<u32, u32, u32, u32, u32, u32, u32, u32> = Struct<ut@Tuple, u32, u32, u32, u32, u32, u32, u32, u32> [storable: true, drop: true, dup: true, zero_sized: false];
+type Tuple<u32, u32, u32, u32, u32, u32, u32, u32, u32, u32, u32, u32, u32, u32, u32, u32> = Struct<ut@Tuple, u32, u32, u32, u32, u32, u32, u32, u32, u32, u32, u32, u32, u32, u32, u32, u32> [storable: true, drop: true, dup: true, zero_sized: false];
+
+libfunc blake2s_compress = blake2s_compress;
+
+F0:
+blake2s_compress([0], [1], [2]) -> ([3]);
+return([3]);
+
+test::foo@F0([0]: Box<Tuple<u32, u32, u32, u32, u32, u32, u32, u32>>, [1]: u32, [2]: Box<Tuple<u32, u32, u32, u32, u32, u32, u32, u32, u32, u32, u32, u32, u32, u32, u32, u32>>) -> (Box<Tuple<u32, u32, u32, u32, u32, u32, u32, u32>>);

--- a/Aegis/Tests/e2e_libfuncs/bool_aegis/bool_and.sierra
+++ b/Aegis/Tests/e2e_libfuncs/bool_aegis/bool_and.sierra
@@ -4,8 +4,9 @@ type core::bool = Enum<ut@core::bool, Unit, Unit> [storable: true, drop: true, d
 libfunc bool_and_impl = bool_and_impl;
 libfunc store_temp<core::bool> = store_temp<core::bool>;
 
-bool_and_impl([0], [1]) -> ([2]); // 0
-store_temp<core::bool>([2]) -> ([2]); // 1
-return([2]); // 2
+F0:
+bool_and_impl([0], [1]) -> ([2]);
+store_temp<core::bool>([2]) -> ([2]);
+return([2]);
 
-test::foo@0([0]: core::bool, [1]: core::bool) -> (core::bool);
+test::foo@F0([0]: core::bool, [1]: core::bool) -> (core::bool);

--- a/Aegis/Tests/e2e_libfuncs/bool_aegis/bool_not.sierra
+++ b/Aegis/Tests/e2e_libfuncs/bool_aegis/bool_not.sierra
@@ -4,8 +4,9 @@ type core::bool = Enum<ut@core::bool, Unit, Unit> [storable: true, drop: true, d
 libfunc bool_not_impl = bool_not_impl;
 libfunc store_temp<core::bool> = store_temp<core::bool>;
 
-bool_not_impl([0]) -> ([1]); // 0
-store_temp<core::bool>([1]) -> ([1]); // 1
-return([1]); // 2
+F0:
+bool_not_impl([0]) -> ([1]);
+store_temp<core::bool>([1]) -> ([1]);
+return([1]);
 
-test::foo@0([0]: core::bool) -> (core::bool);
+test::foo@F0([0]: core::bool) -> (core::bool);

--- a/Aegis/Tests/e2e_libfuncs/bool_aegis/bool_or.sierra
+++ b/Aegis/Tests/e2e_libfuncs/bool_aegis/bool_or.sierra
@@ -4,8 +4,9 @@ type core::bool = Enum<ut@core::bool, Unit, Unit> [storable: true, drop: true, d
 libfunc bool_or_impl = bool_or_impl;
 libfunc store_temp<core::bool> = store_temp<core::bool>;
 
-bool_or_impl([0], [1]) -> ([2]); // 0
-store_temp<core::bool>([2]) -> ([2]); // 1
-return([2]); // 2
+F0:
+bool_or_impl([0], [1]) -> ([2]);
+store_temp<core::bool>([2]) -> ([2]);
+return([2]);
 
-test::foo@0([0]: core::bool, [1]: core::bool) -> (core::bool);
+test::foo@F0([0]: core::bool, [1]: core::bool) -> (core::bool);

--- a/Aegis/Tests/e2e_libfuncs/bool_aegis/bool_xor.sierra
+++ b/Aegis/Tests/e2e_libfuncs/bool_aegis/bool_xor.sierra
@@ -4,8 +4,9 @@ type core::bool = Enum<ut@core::bool, Unit, Unit> [storable: true, drop: true, d
 libfunc bool_xor_impl = bool_xor_impl;
 libfunc store_temp<core::bool> = store_temp<core::bool>;
 
-bool_xor_impl([0], [1]) -> ([2]); // 0
-store_temp<core::bool>([2]) -> ([2]); // 1
-return([2]); // 2
+F0:
+bool_xor_impl([0], [1]) -> ([2]);
+store_temp<core::bool>([2]) -> ([2]);
+return([2]);
 
-test::foo@0([0]: core::bool, [1]: core::bool) -> (core::bool);
+test::foo@F0([0]: core::bool, [1]: core::bool) -> (core::bool);

--- a/Aegis/Tests/e2e_libfuncs/bounded_int_aegis/bounded_int_add with const.sierra
+++ b/Aegis/Tests/e2e_libfuncs/bounded_int_aegis/bounded_int_add with const.sierra
@@ -1,0 +1,15 @@
+type i8 = i8 [storable: true, drop: true, dup: true, zero_sized: false];
+type BoundedInt<-256, 254> = BoundedInt<-256, 254> [storable: true, drop: true, dup: true, zero_sized: false];
+type Const<i8, 50> = Const<i8, 50> [storable: false, drop: false, dup: false, zero_sized: false];
+
+libfunc const_as_immediate<Const<i8, 50>> = const_as_immediate<Const<i8, 50>>;
+libfunc bounded_int_add<i8, i8> = bounded_int_add<i8, i8>;
+libfunc store_temp<BoundedInt<-256, 254>> = store_temp<BoundedInt<-256, 254>>;
+
+F0:
+const_as_immediate<Const<i8, 50>>() -> ([1]);
+bounded_int_add<i8, i8>([0], [1]) -> ([2]);
+store_temp<BoundedInt<-256, 254>>([2]) -> ([2]);
+return([2]);
+
+test::foo@F0([0]: i8) -> (BoundedInt<-256, 254>);

--- a/Aegis/Tests/e2e_libfuncs/bounded_int_aegis/bounded_int_add.sierra
+++ b/Aegis/Tests/e2e_libfuncs/bounded_int_aegis/bounded_int_add.sierra
@@ -1,0 +1,12 @@
+type i8 = i8 [storable: true, drop: true, dup: true, zero_sized: false];
+type BoundedInt<-256, 254> = BoundedInt<-256, 254> [storable: true, drop: true, dup: true, zero_sized: false];
+
+libfunc bounded_int_add<i8, i8> = bounded_int_add<i8, i8>;
+libfunc store_temp<BoundedInt<-256, 254>> = store_temp<BoundedInt<-256, 254>>;
+
+F0:
+bounded_int_add<i8, i8>([0], [1]) -> ([2]);
+store_temp<BoundedInt<-256, 254>>([2]) -> ([2]);
+return([2]);
+
+test::foo@F0([0]: i8, [1]: i8) -> (BoundedInt<-256, 254>);

--- a/Aegis/Tests/e2e_libfuncs/bounded_int_aegis/bounded_int_constrain.sierra
+++ b/Aegis/Tests/e2e_libfuncs/bounded_int_aegis/bounded_int_constrain.sierra
@@ -1,0 +1,31 @@
+type RangeCheck = RangeCheck [storable: true, drop: false, dup: false, zero_sized: false];
+type BoundedInt<0, 127> = BoundedInt<0, 127> [storable: true, drop: true, dup: true, zero_sized: false];
+type NonZero<BoundedInt<0, 127>> = NonZero<BoundedInt<0, 127>> [storable: true, drop: true, dup: true, zero_sized: false];
+type BoundedInt<128, 255> = BoundedInt<128, 255> [storable: true, drop: true, dup: true, zero_sized: false];
+type NonZero<BoundedInt<128, 255>> = NonZero<BoundedInt<128, 255>> [storable: true, drop: true, dup: true, zero_sized: false];
+type core::result::Result::<core::zeroable::NonZero::<test::BoundedInt::<0, 127>>, core::zeroable::NonZero::<test::BoundedInt::<128, 255>>> = Enum<ut@core::result::Result::<core::zeroable::NonZero::<test::BoundedInt::<0, 127>>, core::zeroable::NonZero::<test::BoundedInt::<128, 255>>>, NonZero<BoundedInt<0, 127>>, NonZero<BoundedInt<128, 255>>> [storable: true, drop: true, dup: true, zero_sized: false];
+type u8 = u8 [storable: true, drop: true, dup: true, zero_sized: false];
+type NonZero<u8> = NonZero<u8> [storable: true, drop: true, dup: true, zero_sized: false];
+
+libfunc bounded_int_constrain<NonZero<u8>, 128> = bounded_int_constrain<NonZero<u8>, 128>;
+libfunc branch_align = branch_align;
+libfunc enum_init<core::result::Result::<core::zeroable::NonZero::<test::BoundedInt::<0, 127>>, core::zeroable::NonZero::<test::BoundedInt::<128, 255>>>, 0> = enum_init<core::result::Result::<core::zeroable::NonZero::<test::BoundedInt::<0, 127>>, core::zeroable::NonZero::<test::BoundedInt::<128, 255>>>, 0>;
+libfunc store_temp<RangeCheck> = store_temp<RangeCheck>;
+libfunc store_temp<core::result::Result::<core::zeroable::NonZero::<test::BoundedInt::<0, 127>>, core::zeroable::NonZero::<test::BoundedInt::<128, 255>>>> = store_temp<core::result::Result::<core::zeroable::NonZero::<test::BoundedInt::<0, 127>>, core::zeroable::NonZero::<test::BoundedInt::<128, 255>>>>;
+libfunc enum_init<core::result::Result::<core::zeroable::NonZero::<test::BoundedInt::<0, 127>>, core::zeroable::NonZero::<test::BoundedInt::<128, 255>>>, 1> = enum_init<core::result::Result::<core::zeroable::NonZero::<test::BoundedInt::<0, 127>>, core::zeroable::NonZero::<test::BoundedInt::<128, 255>>>, 1>;
+
+F0:
+bounded_int_constrain<NonZero<u8>, 128>([0], [1]) { fallthrough([2], [3]) F0_B0([4], [5]) };
+branch_align() -> ();
+enum_init<core::result::Result::<core::zeroable::NonZero::<test::BoundedInt::<0, 127>>, core::zeroable::NonZero::<test::BoundedInt::<128, 255>>>, 0>([3]) -> ([6]);
+store_temp<RangeCheck>([2]) -> ([2]);
+store_temp<core::result::Result::<core::zeroable::NonZero::<test::BoundedInt::<0, 127>>, core::zeroable::NonZero::<test::BoundedInt::<128, 255>>>>([6]) -> ([6]);
+return([2], [6]);
+F0_B0:
+branch_align() -> ();
+enum_init<core::result::Result::<core::zeroable::NonZero::<test::BoundedInt::<0, 127>>, core::zeroable::NonZero::<test::BoundedInt::<128, 255>>>, 1>([5]) -> ([7]);
+store_temp<RangeCheck>([4]) -> ([4]);
+store_temp<core::result::Result::<core::zeroable::NonZero::<test::BoundedInt::<0, 127>>, core::zeroable::NonZero::<test::BoundedInt::<128, 255>>>>([7]) -> ([7]);
+return([4], [7]);
+
+test::foo@F0([0]: RangeCheck, [1]: NonZero<u8>) -> (RangeCheck, core::result::Result::<core::zeroable::NonZero::<test::BoundedInt::<0, 127>>, core::zeroable::NonZero::<test::BoundedInt::<128, 255>>>);

--- a/Aegis/Tests/e2e_libfuncs/bounded_int_aegis/bounded_int_div_rem.sierra
+++ b/Aegis/Tests/e2e_libfuncs/bounded_int_aegis/bounded_int_div_rem.sierra
@@ -1,0 +1,21 @@
+type RangeCheck = RangeCheck [storable: true, drop: false, dup: false, zero_sized: false];
+type BoundedInt<0, 15> = BoundedInt<0, 15> [storable: true, drop: true, dup: true, zero_sized: false];
+type BoundedInt<0, 21267647932558653966460912964485513215> = BoundedInt<0, 21267647932558653966460912964485513215> [storable: true, drop: true, dup: true, zero_sized: false];
+type Tuple<BoundedInt<0, 15>, BoundedInt<0, 21267647932558653966460912964485513215>> = Struct<ut@Tuple, BoundedInt<0, 15>, BoundedInt<0, 21267647932558653966460912964485513215>> [storable: true, drop: true, dup: true, zero_sized: false];
+type BoundedInt<21267647932558653966460912964485513216, 21267647932558653966460912964485513216> = BoundedInt<21267647932558653966460912964485513216, 21267647932558653966460912964485513216> [storable: true, drop: true, dup: true, zero_sized: false];
+type NonZero<BoundedInt<21267647932558653966460912964485513216, 21267647932558653966460912964485513216>> = NonZero<BoundedInt<21267647932558653966460912964485513216, 21267647932558653966460912964485513216>> [storable: true, drop: true, dup: true, zero_sized: false];
+type u128 = u128 [storable: true, drop: true, dup: true, zero_sized: false];
+
+libfunc bounded_int_div_rem<u128, BoundedInt<21267647932558653966460912964485513216, 21267647932558653966460912964485513216>> = bounded_int_div_rem<u128, BoundedInt<21267647932558653966460912964485513216, 21267647932558653966460912964485513216>>;
+libfunc struct_construct<Tuple<BoundedInt<0, 15>, BoundedInt<0, 21267647932558653966460912964485513215>>> = struct_construct<Tuple<BoundedInt<0, 15>, BoundedInt<0, 21267647932558653966460912964485513215>>>;
+libfunc store_temp<RangeCheck> = store_temp<RangeCheck>;
+libfunc store_temp<Tuple<BoundedInt<0, 15>, BoundedInt<0, 21267647932558653966460912964485513215>>> = store_temp<Tuple<BoundedInt<0, 15>, BoundedInt<0, 21267647932558653966460912964485513215>>>;
+
+F0:
+bounded_int_div_rem<u128, BoundedInt<21267647932558653966460912964485513216, 21267647932558653966460912964485513216>>([0], [1], [2]) -> ([3], [4], [5]);
+struct_construct<Tuple<BoundedInt<0, 15>, BoundedInt<0, 21267647932558653966460912964485513215>>>([4], [5]) -> ([6]);
+store_temp<RangeCheck>([3]) -> ([3]);
+store_temp<Tuple<BoundedInt<0, 15>, BoundedInt<0, 21267647932558653966460912964485513215>>>([6]) -> ([6]);
+return([3], [6]);
+
+test::foo@F0([0]: RangeCheck, [1]: u128, [2]: NonZero<BoundedInt<21267647932558653966460912964485513216, 21267647932558653966460912964485513216>>) -> (RangeCheck, Tuple<BoundedInt<0, 15>, BoundedInt<0, 21267647932558653966460912964485513215>>);

--- a/Aegis/Tests/e2e_libfuncs/bounded_int_aegis/bounded_int_is_zero.sierra
+++ b/Aegis/Tests/e2e_libfuncs/bounded_int_aegis/bounded_int_is_zero.sierra
@@ -1,0 +1,26 @@
+type BoundedInt<0, 680564733841876926926749214863536422911> = BoundedInt<0, 680564733841876926926749214863536422911> [storable: true, drop: true, dup: true, zero_sized: false];
+type Unit = Struct<ut@Tuple> [storable: true, drop: true, dup: true, zero_sized: true];
+type NonZero<BoundedInt<0, 680564733841876926926749214863536422911>> = NonZero<BoundedInt<0, 680564733841876926926749214863536422911>> [storable: true, drop: true, dup: true, zero_sized: false];
+type core::zeroable::IsZeroResult::<test::BoundedInt::<0, 680564733841876926926749214863536422911>> = Enum<ut@core::zeroable::IsZeroResult::<test::BoundedInt::<0, 680564733841876926926749214863536422911>>, Unit, NonZero<BoundedInt<0, 680564733841876926926749214863536422911>>> [storable: true, drop: true, dup: true, zero_sized: false];
+
+libfunc bounded_int_is_zero<BoundedInt<0, 680564733841876926926749214863536422911>> = bounded_int_is_zero<BoundedInt<0, 680564733841876926926749214863536422911>>;
+libfunc branch_align = branch_align;
+libfunc struct_construct<Unit> = struct_construct<Unit>;
+libfunc enum_init<core::zeroable::IsZeroResult::<test::BoundedInt::<0, 680564733841876926926749214863536422911>>, 0> = enum_init<core::zeroable::IsZeroResult::<test::BoundedInt::<0, 680564733841876926926749214863536422911>>, 0>;
+libfunc store_temp<core::zeroable::IsZeroResult::<test::BoundedInt::<0, 680564733841876926926749214863536422911>>> = store_temp<core::zeroable::IsZeroResult::<test::BoundedInt::<0, 680564733841876926926749214863536422911>>>;
+libfunc enum_init<core::zeroable::IsZeroResult::<test::BoundedInt::<0, 680564733841876926926749214863536422911>>, 1> = enum_init<core::zeroable::IsZeroResult::<test::BoundedInt::<0, 680564733841876926926749214863536422911>>, 1>;
+
+F0:
+bounded_int_is_zero<BoundedInt<0, 680564733841876926926749214863536422911>>([0]) { fallthrough() F0_B0([1]) };
+branch_align() -> ();
+struct_construct<Unit>() -> ([2]);
+enum_init<core::zeroable::IsZeroResult::<test::BoundedInt::<0, 680564733841876926926749214863536422911>>, 0>([2]) -> ([3]);
+store_temp<core::zeroable::IsZeroResult::<test::BoundedInt::<0, 680564733841876926926749214863536422911>>>([3]) -> ([3]);
+return([3]);
+F0_B0:
+branch_align() -> ();
+enum_init<core::zeroable::IsZeroResult::<test::BoundedInt::<0, 680564733841876926926749214863536422911>>, 1>([1]) -> ([4]);
+store_temp<core::zeroable::IsZeroResult::<test::BoundedInt::<0, 680564733841876926926749214863536422911>>>([4]) -> ([4]);
+return([4]);
+
+test::foo@F0([0]: BoundedInt<0, 680564733841876926926749214863536422911>) -> (core::zeroable::IsZeroResult::<test::BoundedInt::<0, 680564733841876926926749214863536422911>>);

--- a/Aegis/Tests/e2e_libfuncs/bounded_int_aegis/bounded_int_mul.sierra
+++ b/Aegis/Tests/e2e_libfuncs/bounded_int_aegis/bounded_int_mul.sierra
@@ -1,0 +1,14 @@
+type i8 = i8 [storable: true, drop: true, dup: true, zero_sized: false];
+type NonZero<i8> = NonZero<i8> [storable: true, drop: true, dup: true, zero_sized: false];
+type BoundedInt<-16256, 16384> = BoundedInt<-16256, 16384> [storable: true, drop: true, dup: true, zero_sized: false];
+type NonZero<BoundedInt<-16256, 16384>> = NonZero<BoundedInt<-16256, 16384>> [storable: true, drop: true, dup: true, zero_sized: false];
+
+libfunc bounded_int_mul<NonZero<i8>, NonZero<i8>> = bounded_int_mul<NonZero<i8>, NonZero<i8>>;
+libfunc store_temp<NonZero<BoundedInt<-16256, 16384>>> = store_temp<NonZero<BoundedInt<-16256, 16384>>>;
+
+F0:
+bounded_int_mul<NonZero<i8>, NonZero<i8>>([0], [1]) -> ([2]);
+store_temp<NonZero<BoundedInt<-16256, 16384>>>([2]) -> ([2]);
+return([2]);
+
+test::foo@F0([0]: NonZero<i8>, [1]: NonZero<i8>) -> (NonZero<BoundedInt<-16256, 16384>>);

--- a/Aegis/Tests/e2e_libfuncs/bounded_int_aegis/bounded_int_sub.sierra
+++ b/Aegis/Tests/e2e_libfuncs/bounded_int_aegis/bounded_int_sub.sierra
@@ -1,0 +1,12 @@
+type i8 = i8 [storable: true, drop: true, dup: true, zero_sized: false];
+type BoundedInt<-255, 255> = BoundedInt<-255, 255> [storable: true, drop: true, dup: true, zero_sized: false];
+
+libfunc bounded_int_sub<i8, i8> = bounded_int_sub<i8, i8>;
+libfunc store_temp<BoundedInt<-255, 255>> = store_temp<BoundedInt<-255, 255>>;
+
+F0:
+bounded_int_sub<i8, i8>([0], [1]) -> ([2]);
+store_temp<BoundedInt<-255, 255>>([2]) -> ([2]);
+return([2]);
+
+test::foo@F0([0]: i8, [1]: i8) -> (BoundedInt<-255, 255>);

--- a/Aegis/Tests/e2e_libfuncs/bounded_int_aegis/bounded_int_trim_max.sierra
+++ b/Aegis/Tests/e2e_libfuncs/bounded_int_aegis/bounded_int_trim_max.sierra
@@ -1,0 +1,26 @@
+type u8 = u8 [storable: true, drop: true, dup: true, zero_sized: false];
+type Unit = Struct<ut@Tuple> [storable: true, drop: true, dup: true, zero_sized: true];
+type BoundedInt<0, 254> = BoundedInt<0, 254> [storable: true, drop: true, dup: true, zero_sized: false];
+type core::internal::OptionRev::<test::BoundedInt::<0, 254>> = Enum<ut@core::internal::OptionRev::<test::BoundedInt::<0, 254>>, Unit, BoundedInt<0, 254>> [storable: true, drop: true, dup: true, zero_sized: false];
+
+libfunc bounded_int_trim_max<u8> = bounded_int_trim_max<u8>;
+libfunc branch_align = branch_align;
+libfunc struct_construct<Unit> = struct_construct<Unit>;
+libfunc enum_init<core::internal::OptionRev::<test::BoundedInt::<0, 254>>, 0> = enum_init<core::internal::OptionRev::<test::BoundedInt::<0, 254>>, 0>;
+libfunc store_temp<core::internal::OptionRev::<test::BoundedInt::<0, 254>>> = store_temp<core::internal::OptionRev::<test::BoundedInt::<0, 254>>>;
+libfunc enum_init<core::internal::OptionRev::<test::BoundedInt::<0, 254>>, 1> = enum_init<core::internal::OptionRev::<test::BoundedInt::<0, 254>>, 1>;
+
+F0:
+bounded_int_trim_max<u8>([0]) { fallthrough() F0_B0([1]) };
+branch_align() -> ();
+struct_construct<Unit>() -> ([2]);
+enum_init<core::internal::OptionRev::<test::BoundedInt::<0, 254>>, 0>([2]) -> ([3]);
+store_temp<core::internal::OptionRev::<test::BoundedInt::<0, 254>>>([3]) -> ([3]);
+return([3]);
+F0_B0:
+branch_align() -> ();
+enum_init<core::internal::OptionRev::<test::BoundedInt::<0, 254>>, 1>([1]) -> ([4]);
+store_temp<core::internal::OptionRev::<test::BoundedInt::<0, 254>>>([4]) -> ([4]);
+return([4]);
+
+test::foo@F0([0]: u8) -> (core::internal::OptionRev::<test::BoundedInt::<0, 254>>);

--- a/Aegis/Tests/e2e_libfuncs/bounded_int_aegis/bounded_int_trim_min.sierra
+++ b/Aegis/Tests/e2e_libfuncs/bounded_int_aegis/bounded_int_trim_min.sierra
@@ -1,0 +1,26 @@
+type i8 = i8 [storable: true, drop: true, dup: true, zero_sized: false];
+type Unit = Struct<ut@Tuple> [storable: true, drop: true, dup: true, zero_sized: true];
+type BoundedInt<-127, 127> = BoundedInt<-127, 127> [storable: true, drop: true, dup: true, zero_sized: false];
+type core::internal::OptionRev::<test::BoundedInt::<-127, 127>> = Enum<ut@core::internal::OptionRev::<test::BoundedInt::<-127, 127>>, Unit, BoundedInt<-127, 127>> [storable: true, drop: true, dup: true, zero_sized: false];
+
+libfunc bounded_int_trim_min<i8> = bounded_int_trim_min<i8>;
+libfunc branch_align = branch_align;
+libfunc struct_construct<Unit> = struct_construct<Unit>;
+libfunc enum_init<core::internal::OptionRev::<test::BoundedInt::<-127, 127>>, 0> = enum_init<core::internal::OptionRev::<test::BoundedInt::<-127, 127>>, 0>;
+libfunc store_temp<core::internal::OptionRev::<test::BoundedInt::<-127, 127>>> = store_temp<core::internal::OptionRev::<test::BoundedInt::<-127, 127>>>;
+libfunc enum_init<core::internal::OptionRev::<test::BoundedInt::<-127, 127>>, 1> = enum_init<core::internal::OptionRev::<test::BoundedInt::<-127, 127>>, 1>;
+
+F0:
+bounded_int_trim_min<i8>([0]) { fallthrough() F0_B0([1]) };
+branch_align() -> ();
+struct_construct<Unit>() -> ([2]);
+enum_init<core::internal::OptionRev::<test::BoundedInt::<-127, 127>>, 0>([2]) -> ([3]);
+store_temp<core::internal::OptionRev::<test::BoundedInt::<-127, 127>>>([3]) -> ([3]);
+return([3]);
+F0_B0:
+branch_align() -> ();
+enum_init<core::internal::OptionRev::<test::BoundedInt::<-127, 127>>, 1>([1]) -> ([4]);
+store_temp<core::internal::OptionRev::<test::BoundedInt::<-127, 127>>>([4]) -> ([4]);
+return([4]);
+
+test::foo@F0([0]: i8) -> (core::internal::OptionRev::<test::BoundedInt::<-127, 127>>);

--- a/Aegis/Tests/e2e_libfuncs/bounded_int_aegis/bounded_int_wrap_non_zero.sierra
+++ b/Aegis/Tests/e2e_libfuncs/bounded_int_aegis/bounded_int_wrap_non_zero.sierra
@@ -1,0 +1,12 @@
+type BoundedInt<-680564733841876926926749214863536422911, -1> = BoundedInt<-680564733841876926926749214863536422911, -1> [storable: true, drop: true, dup: true, zero_sized: false];
+type NonZero<BoundedInt<-680564733841876926926749214863536422911, -1>> = NonZero<BoundedInt<-680564733841876926926749214863536422911, -1>> [storable: true, drop: true, dup: true, zero_sized: false];
+
+libfunc bounded_int_wrap_non_zero<BoundedInt<-680564733841876926926749214863536422911, -1>> = bounded_int_wrap_non_zero<BoundedInt<-680564733841876926926749214863536422911, -1>>;
+libfunc store_temp<NonZero<BoundedInt<-680564733841876926926749214863536422911, -1>>> = store_temp<NonZero<BoundedInt<-680564733841876926926749214863536422911, -1>>>;
+
+F0:
+bounded_int_wrap_non_zero<BoundedInt<-680564733841876926926749214863536422911, -1>>([0]) -> ([1]);
+store_temp<NonZero<BoundedInt<-680564733841876926926749214863536422911, -1>>>([1]) -> ([1]);
+return([1]);
+
+test::foo@F0([0]: BoundedInt<-680564733841876926926749214863536422911, -1>) -> (NonZero<BoundedInt<-680564733841876926926749214863536422911, -1>>);

--- a/Aegis/Tests/e2e_libfuncs/box_aegis/box_forward_snapshot.sierra
+++ b/Aegis/Tests/e2e_libfuncs/box_aegis/box_forward_snapshot.sierra
@@ -1,15 +1,16 @@
 type Box<Array<felt252>> = Box<Array<felt252>> [storable: true, drop: true, dup: false, zero_sized: false];
 type Snapshot<Box<Array<felt252>>> = Snapshot<Box<Array<felt252>>> [storable: true, drop: true, dup: true, zero_sized: false];
-type Box<Snapshot<Array<felt252>>> = Box<Snapshot<Array<felt252>>> [storable: true, drop: true, dup: true, zero_sized: false];
 type Array<felt252> = Array<felt252> [storable: true, drop: true, dup: false, zero_sized: false];
-type Snapshot<Array<felt252>> = Snapshot<Array<felt252>> [storable: true, drop: true, dup: true, zero_sized: false];
+type Box<Snapshot<Array<felt252>>> = Box<Snapshot<Array<felt252>>> [storable: true, drop: true, dup: true, zero_sized: false];
 type felt252 = felt252 [storable: true, drop: true, dup: true, zero_sized: false];
+type Snapshot<Array<felt252>> = Snapshot<Array<felt252>> [storable: true, drop: true, dup: true, zero_sized: false];
 
 libfunc box_forward_snapshot<Array<felt252>> = box_forward_snapshot<Array<felt252>>;
 libfunc store_temp<Box<Snapshot<Array<felt252>>>> = store_temp<Box<Snapshot<Array<felt252>>>>;
 
-box_forward_snapshot<Array<felt252>>([0]) -> ([1]); // 0
-store_temp<Box<Snapshot<Array<felt252>>>>([1]) -> ([1]); // 1
-return([1]); // 2
+F0:
+box_forward_snapshot<Array<felt252>>([0]) -> ([1]);
+store_temp<Box<Snapshot<Array<felt252>>>>([1]) -> ([1]);
+return([1]);
 
-test::foo@0([0]: Snapshot<Box<Array<felt252>>>) -> (Box<Snapshot<Array<felt252>>>);
+test::foo@F0([0]: Snapshot<Box<Array<felt252>>>) -> (Box<Snapshot<Array<felt252>>>);

--- a/Aegis/Tests/e2e_libfuncs/box_aegis/into_box.sierra
+++ b/Aegis/Tests/e2e_libfuncs/box_aegis/into_box.sierra
@@ -1,11 +1,10 @@
 type test::Empty = Struct<ut@test::Empty> [storable: true, drop: true, dup: true, zero_sized: true];
 type Box<test::Empty> = Box<test::Empty> [storable: true, drop: true, dup: true, zero_sized: false];
 
-libfunc struct_construct<test::Empty> = struct_construct<test::Empty>;
 libfunc into_box<test::Empty> = into_box<test::Empty>;
 
-struct_construct<test::Empty>() -> ([0]); // 0
-into_box<test::Empty>([0]) -> ([1]); // 1
-return([1]); // 2
+F0:
+into_box<test::Empty>([0]) -> ([1]);
+return([1]);
 
-test::foo@0() -> (Box<test::Empty>);
+test::foo@F0([0]: test::Empty) -> (Box<test::Empty>);

--- a/Aegis/Tests/e2e_libfuncs/box_aegis/unbox.sierra
+++ b/Aegis/Tests/e2e_libfuncs/box_aegis/unbox.sierra
@@ -3,7 +3,8 @@ type test::Empty = Struct<ut@test::Empty> [storable: true, drop: true, dup: true
 
 libfunc unbox<test::Empty> = unbox<test::Empty>;
 
-unbox<test::Empty>([0]) -> ([1]); // 0
-return([1]); // 1
+F0:
+unbox<test::Empty>([0]) -> ([1]);
+return([1]);
 
-test::foo@0([0]: Box<test::Empty>) -> (test::Empty);
+test::foo@F0([0]: Box<test::Empty>) -> (test::Empty);

--- a/Aegis/Tests/e2e_libfuncs/builtin_costs_aegis/get_builtin_costs.sierra
+++ b/Aegis/Tests/e2e_libfuncs/builtin_costs_aegis/get_builtin_costs.sierra
@@ -4,10 +4,11 @@ libfunc get_builtin_costs = get_builtin_costs;
 libfunc drop<BuiltinCosts> = drop<BuiltinCosts>;
 libfunc store_temp<BuiltinCosts> = store_temp<BuiltinCosts>;
 
-get_builtin_costs() -> ([0]); // 0
-get_builtin_costs() -> ([1]); // 1
-drop<BuiltinCosts>([1]) -> (); // 2
-store_temp<BuiltinCosts>([0]) -> ([0]); // 3
-return([0]); // 4
+F0:
+get_builtin_costs() -> ([0]);
+get_builtin_costs() -> ([1]);
+drop<BuiltinCosts>([1]) -> ();
+store_temp<BuiltinCosts>([0]) -> ([0]);
+return([0]);
 
-test::foo@0() -> (BuiltinCosts);
+test::foo@F0() -> (BuiltinCosts);

--- a/Aegis/Tests/e2e_libfuncs/bytes31_aegis/bytes31_const.sierra
+++ b/Aegis/Tests/e2e_libfuncs/bytes31_aegis/bytes31_const.sierra
@@ -3,8 +3,9 @@ type bytes31 = bytes31 [storable: true, drop: true, dup: true, zero_sized: false
 libfunc bytes31_const<256> = bytes31_const<256>;
 libfunc store_temp<bytes31> = store_temp<bytes31>;
 
-bytes31_const<256>() -> ([0]); // 0
-store_temp<bytes31>([0]) -> ([0]); // 1
-return([0]); // 2
+F0:
+bytes31_const<256>() -> ([0]);
+store_temp<bytes31>([0]) -> ([0]);
+return([0]);
 
-test::foo@0() -> (bytes31);
+test::foo@F0() -> (bytes31);

--- a/Aegis/Tests/e2e_libfuncs/bytes31_aegis/bytes31_to_felt252.sierra
+++ b/Aegis/Tests/e2e_libfuncs/bytes31_aegis/bytes31_to_felt252.sierra
@@ -4,8 +4,9 @@ type felt252 = felt252 [storable: true, drop: true, dup: true, zero_sized: false
 libfunc bytes31_to_felt252 = bytes31_to_felt252;
 libfunc store_temp<felt252> = store_temp<felt252>;
 
-bytes31_to_felt252([0]) -> ([1]); // 0
-store_temp<felt252>([1]) -> ([1]); // 1
-return([1]); // 2
+F0:
+bytes31_to_felt252([0]) -> ([1]);
+store_temp<felt252>([1]) -> ([1]);
+return([1]);
 
-test::foo@0([0]: bytes31) -> (felt252);
+test::foo@F0([0]: bytes31) -> (felt252);

--- a/Aegis/Tests/e2e_libfuncs/bytes31_aegis/bytes31_try_from_felt252.sierra
+++ b/Aegis/Tests/e2e_libfuncs/bytes31_aegis/bytes31_try_from_felt252.sierra
@@ -12,17 +12,19 @@ libfunc store_temp<core::option::Option::<core::bytes_31::bytes31>> = store_temp
 libfunc struct_construct<Unit> = struct_construct<Unit>;
 libfunc enum_init<core::option::Option::<core::bytes_31::bytes31>, 1> = enum_init<core::option::Option::<core::bytes_31::bytes31>, 1>;
 
-bytes31_try_from_felt252([0], [1]) { fallthrough([2], [3]) 6([4]) }; // 0
-branch_align() -> (); // 1
-enum_init<core::option::Option::<core::bytes_31::bytes31>, 0>([3]) -> ([5]); // 2
-store_temp<RangeCheck>([2]) -> ([2]); // 3
-store_temp<core::option::Option::<core::bytes_31::bytes31>>([5]) -> ([5]); // 4
-return([2], [5]); // 5
-branch_align() -> (); // 6
-struct_construct<Unit>() -> ([6]); // 7
-enum_init<core::option::Option::<core::bytes_31::bytes31>, 1>([6]) -> ([7]); // 8
-store_temp<RangeCheck>([4]) -> ([4]); // 9
-store_temp<core::option::Option::<core::bytes_31::bytes31>>([7]) -> ([7]); // 10
-return([4], [7]); // 11
+F0:
+bytes31_try_from_felt252([0], [1]) { fallthrough([2], [3]) F0_B0([4]) };
+branch_align() -> ();
+enum_init<core::option::Option::<core::bytes_31::bytes31>, 0>([3]) -> ([5]);
+store_temp<RangeCheck>([2]) -> ([2]);
+store_temp<core::option::Option::<core::bytes_31::bytes31>>([5]) -> ([5]);
+return([2], [5]);
+F0_B0:
+branch_align() -> ();
+struct_construct<Unit>() -> ([6]);
+enum_init<core::option::Option::<core::bytes_31::bytes31>, 1>([6]) -> ([7]);
+store_temp<RangeCheck>([4]) -> ([4]);
+store_temp<core::option::Option::<core::bytes_31::bytes31>>([7]) -> ([7]);
+return([4], [7]);
 
-test::foo@0([0]: RangeCheck, [1]: felt252) -> (RangeCheck, core::option::Option::<core::bytes_31::bytes31>);
+test::foo@F0([0]: RangeCheck, [1]: felt252) -> (RangeCheck, core::option::Option::<core::bytes_31::bytes31>);

--- a/Aegis/Tests/e2e_libfuncs/ec_aegis/ec_neg.sierra
+++ b/Aegis/Tests/e2e_libfuncs/ec_aegis/ec_neg.sierra
@@ -3,8 +3,9 @@ type EcPoint = EcPoint [storable: true, drop: true, dup: true, zero_sized: false
 libfunc ec_neg = ec_neg;
 libfunc store_temp<EcPoint> = store_temp<EcPoint>;
 
-ec_neg([0]) -> ([1]); // 0
-store_temp<EcPoint>([1]) -> ([1]); // 1
-return([1]); // 2
+F0:
+ec_neg([0]) -> ([1]);
+store_temp<EcPoint>([1]) -> ([1]);
+return([1]);
 
-test::foo@0([0]: EcPoint) -> (EcPoint);
+test::foo@F0([0]: EcPoint) -> (EcPoint);

--- a/Aegis/Tests/e2e_libfuncs/ec_aegis/ec_point_from_x_nz.sierra
+++ b/Aegis/Tests/e2e_libfuncs/ec_aegis/ec_point_from_x_nz.sierra
@@ -13,17 +13,19 @@ libfunc store_temp<core::option::Option::<core::zeroable::NonZero::<core::ec::Ec
 libfunc struct_construct<Unit> = struct_construct<Unit>;
 libfunc enum_init<core::option::Option::<core::zeroable::NonZero::<core::ec::EcPoint>>, 1> = enum_init<core::option::Option::<core::zeroable::NonZero::<core::ec::EcPoint>>, 1>;
 
-ec_point_from_x_nz([0], [1]) { fallthrough([2], [3]) 6([4]) }; // 0
-branch_align() -> (); // 1
-enum_init<core::option::Option::<core::zeroable::NonZero::<core::ec::EcPoint>>, 0>([3]) -> ([5]); // 2
-store_temp<RangeCheck>([2]) -> ([2]); // 3
-store_temp<core::option::Option::<core::zeroable::NonZero::<core::ec::EcPoint>>>([5]) -> ([5]); // 4
-return([2], [5]); // 5
-branch_align() -> (); // 6
-struct_construct<Unit>() -> ([6]); // 7
-enum_init<core::option::Option::<core::zeroable::NonZero::<core::ec::EcPoint>>, 1>([6]) -> ([7]); // 8
-store_temp<RangeCheck>([4]) -> ([4]); // 9
-store_temp<core::option::Option::<core::zeroable::NonZero::<core::ec::EcPoint>>>([7]) -> ([7]); // 10
-return([4], [7]); // 11
+F0:
+ec_point_from_x_nz([0], [1]) { fallthrough([2], [3]) F0_B0([4]) };
+branch_align() -> ();
+enum_init<core::option::Option::<core::zeroable::NonZero::<core::ec::EcPoint>>, 0>([3]) -> ([5]);
+store_temp<RangeCheck>([2]) -> ([2]);
+store_temp<core::option::Option::<core::zeroable::NonZero::<core::ec::EcPoint>>>([5]) -> ([5]);
+return([2], [5]);
+F0_B0:
+branch_align() -> ();
+struct_construct<Unit>() -> ([6]);
+enum_init<core::option::Option::<core::zeroable::NonZero::<core::ec::EcPoint>>, 1>([6]) -> ([7]);
+store_temp<RangeCheck>([4]) -> ([4]);
+store_temp<core::option::Option::<core::zeroable::NonZero::<core::ec::EcPoint>>>([7]) -> ([7]);
+return([4], [7]);
 
-test::foo@0([0]: RangeCheck, [1]: felt252) -> (RangeCheck, core::option::Option::<core::zeroable::NonZero::<core::ec::EcPoint>>);
+test::foo@F0([0]: RangeCheck, [1]: felt252) -> (RangeCheck, core::option::Option::<core::zeroable::NonZero::<core::ec::EcPoint>>);

--- a/Aegis/Tests/e2e_libfuncs/ec_aegis/ec_point_is_zero.sierra
+++ b/Aegis/Tests/e2e_libfuncs/ec_aegis/ec_point_is_zero.sierra
@@ -1,23 +1,26 @@
 type EcPoint = EcPoint [storable: true, drop: true, dup: true, zero_sized: false];
+type Const<felt252, 1> = Const<felt252, 1> [storable: false, drop: false, dup: false, zero_sized: false];
 type felt252 = felt252 [storable: true, drop: true, dup: true, zero_sized: false];
 type NonZero<EcPoint> = NonZero<EcPoint> [storable: true, drop: true, dup: true, zero_sized: false];
 
 libfunc ec_point_is_zero = ec_point_is_zero;
 libfunc branch_align = branch_align;
-libfunc felt252_const<1> = felt252_const<1>;
+libfunc const_as_immediate<Const<felt252, 1>> = const_as_immediate<Const<felt252, 1>>;
 libfunc store_temp<felt252> = store_temp<felt252>;
 libfunc ec_point_unwrap = ec_point_unwrap;
 libfunc drop<felt252> = drop<felt252>;
 
-ec_point_is_zero([0]) { fallthrough() 5([1]) }; // 0
-branch_align() -> (); // 1
-felt252_const<1>() -> ([2]); // 2
-store_temp<felt252>([2]) -> ([2]); // 3
-return([2]); // 4
-branch_align() -> (); // 5
-ec_point_unwrap([1]) -> ([3], [4]); // 6
-drop<felt252>([4]) -> (); // 7
-store_temp<felt252>([3]) -> ([3]); // 8
-return([3]); // 9
+F0:
+ec_point_is_zero([0]) { fallthrough() F0_B0([1]) };
+branch_align() -> ();
+const_as_immediate<Const<felt252, 1>>() -> ([2]);
+store_temp<felt252>([2]) -> ([2]);
+return([2]);
+F0_B0:
+branch_align() -> ();
+ec_point_unwrap([1]) -> ([3], [4]);
+drop<felt252>([4]) -> ();
+store_temp<felt252>([3]) -> ([3]);
+return([3]);
 
-test::foo@0([0]: EcPoint) -> (felt252);
+test::foo@F0([0]: EcPoint) -> (felt252);

--- a/Aegis/Tests/e2e_libfuncs/ec_aegis/ec_point_try_new_nz.sierra
+++ b/Aegis/Tests/e2e_libfuncs/ec_aegis/ec_point_try_new_nz.sierra
@@ -11,15 +11,17 @@ libfunc store_temp<core::option::Option::<core::zeroable::NonZero::<core::ec::Ec
 libfunc struct_construct<Unit> = struct_construct<Unit>;
 libfunc enum_init<core::option::Option::<core::zeroable::NonZero::<core::ec::EcPoint>>, 1> = enum_init<core::option::Option::<core::zeroable::NonZero::<core::ec::EcPoint>>, 1>;
 
-ec_point_try_new_nz([0], [1]) { fallthrough([2]) 5() }; // 0
-branch_align() -> (); // 1
-enum_init<core::option::Option::<core::zeroable::NonZero::<core::ec::EcPoint>>, 0>([2]) -> ([3]); // 2
-store_temp<core::option::Option::<core::zeroable::NonZero::<core::ec::EcPoint>>>([3]) -> ([3]); // 3
-return([3]); // 4
-branch_align() -> (); // 5
-struct_construct<Unit>() -> ([4]); // 6
-enum_init<core::option::Option::<core::zeroable::NonZero::<core::ec::EcPoint>>, 1>([4]) -> ([5]); // 7
-store_temp<core::option::Option::<core::zeroable::NonZero::<core::ec::EcPoint>>>([5]) -> ([5]); // 8
-return([5]); // 9
+F0:
+ec_point_try_new_nz([0], [1]) { fallthrough([2]) F0_B0() };
+branch_align() -> ();
+enum_init<core::option::Option::<core::zeroable::NonZero::<core::ec::EcPoint>>, 0>([2]) -> ([3]);
+store_temp<core::option::Option::<core::zeroable::NonZero::<core::ec::EcPoint>>>([3]) -> ([3]);
+return([3]);
+F0_B0:
+branch_align() -> ();
+struct_construct<Unit>() -> ([4]);
+enum_init<core::option::Option::<core::zeroable::NonZero::<core::ec::EcPoint>>, 1>([4]) -> ([5]);
+store_temp<core::option::Option::<core::zeroable::NonZero::<core::ec::EcPoint>>>([5]) -> ([5]);
+return([5]);
 
-test::foo@0([0]: felt252, [1]: felt252) -> (core::option::Option::<core::zeroable::NonZero::<core::ec::EcPoint>>);
+test::foo@F0([0]: felt252, [1]: felt252) -> (core::option::Option::<core::zeroable::NonZero::<core::ec::EcPoint>>);

--- a/Aegis/Tests/e2e_libfuncs/ec_aegis/ec_point_unwrap.sierra
+++ b/Aegis/Tests/e2e_libfuncs/ec_aegis/ec_point_unwrap.sierra
@@ -7,9 +7,10 @@ libfunc ec_point_unwrap = ec_point_unwrap;
 libfunc struct_construct<Tuple<felt252, felt252>> = struct_construct<Tuple<felt252, felt252>>;
 libfunc store_temp<Tuple<felt252, felt252>> = store_temp<Tuple<felt252, felt252>>;
 
-ec_point_unwrap([0]) -> ([1], [2]); // 0
-struct_construct<Tuple<felt252, felt252>>([1], [2]) -> ([3]); // 1
-store_temp<Tuple<felt252, felt252>>([3]) -> ([3]); // 2
-return([3]); // 3
+F0:
+ec_point_unwrap([0]) -> ([1], [2]);
+struct_construct<Tuple<felt252, felt252>>([1], [2]) -> ([3]);
+store_temp<Tuple<felt252, felt252>>([3]) -> ([3]);
+return([3]);
 
-test::foo@0([0]: NonZero<EcPoint>) -> (Tuple<felt252, felt252>);
+test::foo@F0([0]: NonZero<EcPoint>) -> (Tuple<felt252, felt252>);

--- a/Aegis/Tests/e2e_libfuncs/ec_aegis/ec_point_zero.sierra
+++ b/Aegis/Tests/e2e_libfuncs/ec_aegis/ec_point_zero.sierra
@@ -3,8 +3,9 @@ type EcPoint = EcPoint [storable: true, drop: true, dup: true, zero_sized: false
 libfunc ec_point_zero = ec_point_zero;
 libfunc store_temp<EcPoint> = store_temp<EcPoint>;
 
-ec_point_zero() -> ([0]); // 0
-store_temp<EcPoint>([0]) -> ([0]); // 1
-return([0]); // 2
+F0:
+ec_point_zero() -> ([0]);
+store_temp<EcPoint>([0]) -> ([0]);
+return([0]);
 
-test::foo@0() -> (EcPoint);
+test::foo@F0() -> (EcPoint);

--- a/Aegis/Tests/e2e_libfuncs/ec_aegis/ec_state_add.sierra
+++ b/Aegis/Tests/e2e_libfuncs/ec_aegis/ec_state_add.sierra
@@ -4,12 +4,11 @@ type EcPoint = EcPoint [storable: true, drop: true, dup: true, zero_sized: false
 type NonZero<EcPoint> = NonZero<EcPoint> [storable: true, drop: true, dup: true, zero_sized: false];
 
 libfunc ec_state_add = ec_state_add;
-libfunc struct_construct<Unit> = struct_construct<Unit>;
 libfunc store_temp<EcState> = store_temp<EcState>;
 
-ec_state_add([0], [1]) -> ([2]); // 0
-struct_construct<Unit>() -> ([3]); // 1
-store_temp<EcState>([2]) -> ([2]); // 2
-return([2], [3]); // 3
+F0:
+ec_state_add([0], [1]) -> ([2]);
+store_temp<EcState>([2]) -> ([2]);
+return([2]);
 
-test::foo@0([0]: EcState, [1]: NonZero<EcPoint>) -> (EcState, Unit);
+test::foo@F0([0]: EcState, [1]: NonZero<EcPoint>) -> (EcState);

--- a/Aegis/Tests/e2e_libfuncs/ec_aegis/ec_state_add_mul.sierra
+++ b/Aegis/Tests/e2e_libfuncs/ec_aegis/ec_state_add_mul.sierra
@@ -6,14 +6,13 @@ type felt252 = felt252 [storable: true, drop: true, dup: true, zero_sized: false
 type EcState = EcState [storable: true, drop: true, dup: true, zero_sized: false];
 
 libfunc ec_state_add_mul = ec_state_add_mul;
-libfunc struct_construct<Unit> = struct_construct<Unit>;
 libfunc store_temp<EcOp> = store_temp<EcOp>;
 libfunc store_temp<EcState> = store_temp<EcState>;
 
-ec_state_add_mul([0], [1], [2], [3]) -> ([4], [5]); // 0
-struct_construct<Unit>() -> ([6]); // 1
-store_temp<EcOp>([4]) -> ([4]); // 2
-store_temp<EcState>([5]) -> ([5]); // 3
-return([4], [5], [6]); // 4
+F0:
+ec_state_add_mul([0], [1], [2], [3]) -> ([4], [5]);
+store_temp<EcOp>([4]) -> ([4]);
+store_temp<EcState>([5]) -> ([5]);
+return([4], [5]);
 
-test::foo@0([0]: EcOp, [1]: EcState, [2]: felt252, [3]: NonZero<EcPoint>) -> (EcOp, EcState, Unit);
+test::foo@F0([0]: EcOp, [1]: EcState, [2]: felt252, [3]: NonZero<EcPoint>) -> (EcOp, EcState);

--- a/Aegis/Tests/e2e_libfuncs/ec_aegis/ec_state_init.sierra
+++ b/Aegis/Tests/e2e_libfuncs/ec_aegis/ec_state_init.sierra
@@ -2,7 +2,8 @@ type EcState = EcState [storable: true, drop: true, dup: true, zero_sized: false
 
 libfunc ec_state_init = ec_state_init;
 
-ec_state_init() -> ([0]); // 0
-return([0]); // 1
+F0:
+ec_state_init() -> ([0]);
+return([0]);
 
-test::foo@0() -> (EcState);
+test::foo@F0() -> (EcState);

--- a/Aegis/Tests/e2e_libfuncs/ec_aegis/ec_state_try_finalize_nz.sierra
+++ b/Aegis/Tests/e2e_libfuncs/ec_aegis/ec_state_try_finalize_nz.sierra
@@ -11,15 +11,17 @@ libfunc store_temp<core::option::Option::<core::zeroable::NonZero::<core::ec::Ec
 libfunc struct_construct<Unit> = struct_construct<Unit>;
 libfunc enum_init<core::option::Option::<core::zeroable::NonZero::<core::ec::EcPoint>>, 1> = enum_init<core::option::Option::<core::zeroable::NonZero::<core::ec::EcPoint>>, 1>;
 
-ec_state_try_finalize_nz([0]) { fallthrough([1]) 5() }; // 0
-branch_align() -> (); // 1
-enum_init<core::option::Option::<core::zeroable::NonZero::<core::ec::EcPoint>>, 0>([1]) -> ([2]); // 2
-store_temp<core::option::Option::<core::zeroable::NonZero::<core::ec::EcPoint>>>([2]) -> ([2]); // 3
-return([2]); // 4
-branch_align() -> (); // 5
-struct_construct<Unit>() -> ([3]); // 6
-enum_init<core::option::Option::<core::zeroable::NonZero::<core::ec::EcPoint>>, 1>([3]) -> ([4]); // 7
-store_temp<core::option::Option::<core::zeroable::NonZero::<core::ec::EcPoint>>>([4]) -> ([4]); // 8
-return([4]); // 9
+F0:
+ec_state_try_finalize_nz([0]) { fallthrough([1]) F0_B0() };
+branch_align() -> ();
+enum_init<core::option::Option::<core::zeroable::NonZero::<core::ec::EcPoint>>, 0>([1]) -> ([2]);
+store_temp<core::option::Option::<core::zeroable::NonZero::<core::ec::EcPoint>>>([2]) -> ([2]);
+return([2]);
+F0_B0:
+branch_align() -> ();
+struct_construct<Unit>() -> ([3]);
+enum_init<core::option::Option::<core::zeroable::NonZero::<core::ec::EcPoint>>, 1>([3]) -> ([4]);
+store_temp<core::option::Option::<core::zeroable::NonZero::<core::ec::EcPoint>>>([4]) -> ([4]);
+return([4]);
 
-test::foo@0([0]: EcState) -> (core::option::Option::<core::zeroable::NonZero::<core::ec::EcPoint>>);
+test::foo@F0([0]: EcState) -> (core::option::Option::<core::zeroable::NonZero::<core::ec::EcPoint>>);

--- a/Aegis/Tests/e2e_libfuncs/felt252_dict_aegis/felt252_dict_new.sierra
+++ b/Aegis/Tests/e2e_libfuncs/felt252_dict_aegis/felt252_dict_new.sierra
@@ -1,14 +1,15 @@
 type SegmentArena = SegmentArena [storable: true, drop: false, dup: false, zero_sized: false];
-type Felt252Dict<felt252> = Felt252Dict<felt252> [storable: true, drop: false, dup: false, zero_sized: false];
 type felt252 = felt252 [storable: true, drop: true, dup: true, zero_sized: false];
+type Felt252Dict<felt252> = Felt252Dict<felt252> [storable: true, drop: false, dup: false, zero_sized: false];
 
 libfunc felt252_dict_new<felt252> = felt252_dict_new<felt252>;
 libfunc store_temp<SegmentArena> = store_temp<SegmentArena>;
 libfunc store_temp<Felt252Dict<felt252>> = store_temp<Felt252Dict<felt252>>;
 
-felt252_dict_new<felt252>([0]) -> ([1], [2]); // 0
-store_temp<SegmentArena>([1]) -> ([1]); // 1
-store_temp<Felt252Dict<felt252>>([2]) -> ([2]); // 2
-return([1], [2]); // 3
+F0:
+felt252_dict_new<felt252>([0]) -> ([1], [2]);
+store_temp<SegmentArena>([1]) -> ([1]);
+store_temp<Felt252Dict<felt252>>([2]) -> ([2]);
+return([1], [2]);
 
-test::foo@0([0]: SegmentArena) -> (SegmentArena, Felt252Dict<felt252>);
+test::foo@F0([0]: SegmentArena) -> (SegmentArena, Felt252Dict<felt252>);

--- a/Aegis/Tests/e2e_libfuncs/felt252_dict_aegis/felt252_dict_squash.sierra
+++ b/Aegis/Tests/e2e_libfuncs/felt252_dict_aegis/felt252_dict_squash.sierra
@@ -1,7 +1,7 @@
 type RangeCheck = RangeCheck [storable: true, drop: false, dup: false, zero_sized: false];
+type felt252 = felt252 [storable: true, drop: true, dup: true, zero_sized: false];
 type SquashedFelt252Dict<felt252> = SquashedFelt252Dict<felt252> [storable: true, drop: true, dup: false, zero_sized: false];
 type Felt252Dict<felt252> = Felt252Dict<felt252> [storable: true, drop: false, dup: false, zero_sized: false];
-type felt252 = felt252 [storable: true, drop: true, dup: true, zero_sized: false];
 type SegmentArena = SegmentArena [storable: true, drop: false, dup: false, zero_sized: false];
 type GasBuiltin = GasBuiltin [storable: true, drop: false, dup: false, zero_sized: false];
 
@@ -12,12 +12,13 @@ libfunc store_temp<SegmentArena> = store_temp<SegmentArena>;
 libfunc store_temp<GasBuiltin> = store_temp<GasBuiltin>;
 libfunc store_temp<SquashedFelt252Dict<felt252>> = store_temp<SquashedFelt252Dict<felt252>>;
 
-disable_ap_tracking() -> (); // 0
-felt252_dict_squash<felt252>([0], [2], [1], [3]) -> ([4], [5], [6], [7]); // 1
-store_temp<RangeCheck>([4]) -> ([4]); // 2
-store_temp<SegmentArena>([6]) -> ([6]); // 3
-store_temp<GasBuiltin>([5]) -> ([5]); // 4
-store_temp<SquashedFelt252Dict<felt252>>([7]) -> ([7]); // 5
-return([4], [6], [5], [7]); // 6
+F0:
+disable_ap_tracking() -> ();
+felt252_dict_squash<felt252>([0], [2], [1], [3]) -> ([4], [5], [6], [7]);
+store_temp<RangeCheck>([4]) -> ([4]);
+store_temp<SegmentArena>([6]) -> ([6]);
+store_temp<GasBuiltin>([5]) -> ([5]);
+store_temp<SquashedFelt252Dict<felt252>>([7]) -> ([7]);
+return([4], [6], [5], [7]);
 
-test::foo@0([0]: RangeCheck, [1]: SegmentArena, [2]: GasBuiltin, [3]: Felt252Dict<felt252>) -> (RangeCheck, SegmentArena, GasBuiltin, SquashedFelt252Dict<felt252>);
+test::foo@F0([0]: RangeCheck, [1]: SegmentArena, [2]: GasBuiltin, [3]: Felt252Dict<felt252>) -> (RangeCheck, SegmentArena, GasBuiltin, SquashedFelt252Dict<felt252>);

--- a/Aegis/Tests/e2e_libfuncs/felt252_dict_aegis/felt252_dict_squash_entries.sierra
+++ b/Aegis/Tests/e2e_libfuncs/felt252_dict_aegis/felt252_dict_squash_entries.sierra
@@ -1,0 +1,14 @@
+type SquashedFelt252Dict<felt252> = SquashedFelt252Dict<felt252> [storable: true, drop: true, dup: false, zero_sized: false];
+type felt252 = felt252 [storable: true, drop: true, dup: true, zero_sized: false];
+type Array<Tuple<felt252, felt252, felt252>> = Array<Tuple<felt252, felt252, felt252>> [storable: true, drop: true, dup: false, zero_sized: false];
+type Tuple<felt252, felt252, felt252> = Struct<ut@Tuple, felt252, felt252, felt252> [storable: true, drop: true, dup: true, zero_sized: false];
+
+libfunc squashed_felt252_dict_entries<felt252> = squashed_felt252_dict_entries<felt252>;
+libfunc store_temp<Array<Tuple<felt252, felt252, felt252>>> = store_temp<Array<Tuple<felt252, felt252, felt252>>>;
+
+F0:
+squashed_felt252_dict_entries<felt252>([0]) -> ([1]);
+store_temp<Array<Tuple<felt252, felt252, felt252>>>([1]) -> ([1]);
+return([1]);
+
+test::test_squashed_dict_entries@F0([0]: SquashedFelt252Dict<felt252>) -> (Array<Tuple<felt252, felt252, felt252>>);

--- a/Aegis/Tests/e2e_libfuncs/gas_aegis/redeposit_gas.sierra
+++ b/Aegis/Tests/e2e_libfuncs/gas_aegis/redeposit_gas.sierra
@@ -1,36 +1,73 @@
 type felt252 = felt252 [storable: true, drop: true, dup: true, zero_sized: false];
-type GasBuiltin = GasBuiltin [storable: true, drop: false, dup: false, zero_sized: false];
 type Unit = Struct<ut@Tuple> [storable: true, drop: true, dup: true, zero_sized: true];
+type GasBuiltin = GasBuiltin [storable: true, drop: false, dup: false, zero_sized: false];
+type Pedersen = Pedersen [storable: true, drop: false, dup: false, zero_sized: false];
+type Const<felt252, 1> = Const<felt252, 1> [storable: false, drop: false, dup: false, zero_sized: false];
+type Bitwise = Bitwise [storable: true, drop: false, dup: false, zero_sized: false];
+type Const<u128, 2> = Const<u128, 2> [storable: false, drop: false, dup: false, zero_sized: false];
+type Const<u128, 1> = Const<u128, 1> [storable: false, drop: false, dup: false, zero_sized: false];
+type u128 = u128 [storable: true, drop: true, dup: true, zero_sized: false];
 type NonZero<felt252> = NonZero<felt252> [storable: true, drop: true, dup: true, zero_sized: false];
+type Const<felt252, 0> = Const<felt252, 0> [storable: false, drop: false, dup: false, zero_sized: false];
 
+libfunc const_as_immediate<Const<felt252, 0>> = const_as_immediate<Const<felt252, 0>>;
+libfunc felt252_sub = felt252_sub;
+libfunc store_temp<felt252> = store_temp<felt252>;
 libfunc felt252_is_zero = felt252_is_zero;
 libfunc branch_align = branch_align;
-libfunc function_call<user@test::bar> = function_call<user@test::bar>;
-libfunc drop<Unit> = drop<Unit>;
-libfunc struct_construct<Unit> = struct_construct<Unit>;
+libfunc const_as_immediate<Const<u128, 1>> = const_as_immediate<Const<u128, 1>>;
+libfunc const_as_immediate<Const<u128, 2>> = const_as_immediate<Const<u128, 2>>;
+libfunc store_temp<u128> = store_temp<u128>;
+libfunc bitwise = bitwise;
+libfunc drop<u128> = drop<u128>;
+libfunc const_as_immediate<Const<felt252, 1>> = const_as_immediate<Const<felt252, 1>>;
+libfunc pedersen = pedersen;
+libfunc drop<felt252> = drop<felt252>;
 libfunc store_temp<GasBuiltin> = store_temp<GasBuiltin>;
+libfunc store_temp<Bitwise> = store_temp<Bitwise>;
+libfunc store_temp<Pedersen> = store_temp<Pedersen>;
 libfunc drop<NonZero<felt252>> = drop<NonZero<felt252>>;
 libfunc redeposit_gas = redeposit_gas;
 
-felt252_is_zero([1]) { fallthrough() 11([2]) }; // 0
-branch_align() -> (); // 1
-function_call<user@test::bar>() -> ([3]); // 2
-drop<Unit>([3]) -> (); // 3
-function_call<user@test::bar>() -> ([4]); // 4
-drop<Unit>([4]) -> (); // 5
-function_call<user@test::bar>() -> ([5]); // 6
-drop<Unit>([5]) -> (); // 7
-struct_construct<Unit>() -> ([6]); // 8
-store_temp<GasBuiltin>([0]) -> ([0]); // 9
-return([0], [6]); // 10
-branch_align() -> (); // 11
-drop<NonZero<felt252>>([2]) -> (); // 12
-redeposit_gas([0]) -> ([7]); // 13
-struct_construct<Unit>() -> ([8]); // 14
-store_temp<GasBuiltin>([7]) -> ([7]); // 15
-return([7], [8]); // 16
-struct_construct<Unit>() -> ([0]); // 17
-return([0]); // 18
+F0:
+const_as_immediate<Const<felt252, 0>>() -> ([4]);
+felt252_sub([3], [4]) -> ([5]);
+store_temp<felt252>([5]) -> ([5]);
+felt252_is_zero([5]) { fallthrough() F0_B0([6]) };
+branch_align() -> ();
+const_as_immediate<Const<u128, 1>>() -> ([7]);
+const_as_immediate<Const<u128, 2>>() -> ([8]);
+store_temp<u128>([7]) -> ([7]);
+store_temp<u128>([8]) -> ([8]);
+bitwise([1], [7], [8]) -> ([9], [10], [11], [12]);
+drop<u128>([10]) -> ();
+drop<u128>([11]) -> ();
+drop<u128>([12]) -> ();
+const_as_immediate<Const<u128, 1>>() -> ([13]);
+const_as_immediate<Const<u128, 2>>() -> ([14]);
+store_temp<u128>([13]) -> ([13]);
+store_temp<u128>([14]) -> ([14]);
+bitwise([9], [13], [14]) -> ([15], [16], [17], [18]);
+drop<u128>([16]) -> ();
+drop<u128>([17]) -> ();
+drop<u128>([18]) -> ();
+const_as_immediate<Const<felt252, 1>>() -> ([19]);
+const_as_immediate<Const<felt252, 1>>() -> ([20]);
+store_temp<felt252>([19]) -> ([19]);
+store_temp<felt252>([20]) -> ([20]);
+pedersen([2], [19], [20]) -> ([21], [22]);
+drop<felt252>([22]) -> ();
+store_temp<GasBuiltin>([0]) -> ([0]);
+store_temp<Bitwise>([15]) -> ([15]);
+store_temp<Pedersen>([21]) -> ([21]);
+return([0], [15], [21]);
+F0_B0:
+branch_align() -> ();
+drop<NonZero<felt252>>([6]) -> ();
+redeposit_gas([0]) -> ([23]);
+store_temp<GasBuiltin>([23]) -> ([23]);
+store_temp<Bitwise>([1]) -> ([1]);
+store_temp<Pedersen>([2]) -> ([2]);
+return([23], [1], [2]);
 
-test::foo@0([0]: GasBuiltin, [1]: felt252) -> (GasBuiltin, Unit);
-test::bar@17() -> (Unit);
+test::foo@F0([0]: GasBuiltin, [1]: Bitwise, [2]: Pedersen, [3]: felt252) -> (GasBuiltin, Bitwise, Pedersen);

--- a/Aegis/Tests/e2e_libfuncs/i128_aegis/i128_diff.sierra
+++ b/Aegis/Tests/e2e_libfuncs/i128_aegis/i128_diff.sierra
@@ -10,16 +10,18 @@ libfunc store_temp<RangeCheck> = store_temp<RangeCheck>;
 libfunc store_temp<core::result::Result::<core::integer::u128, core::integer::u128>> = store_temp<core::result::Result::<core::integer::u128, core::integer::u128>>;
 libfunc enum_init<core::result::Result::<core::integer::u128, core::integer::u128>, 1> = enum_init<core::result::Result::<core::integer::u128, core::integer::u128>, 1>;
 
-i128_diff([0], [1], [2]) { fallthrough([3], [4]) 6([5], [6]) }; // 0
-branch_align() -> (); // 1
-enum_init<core::result::Result::<core::integer::u128, core::integer::u128>, 0>([4]) -> ([7]); // 2
-store_temp<RangeCheck>([3]) -> ([3]); // 3
-store_temp<core::result::Result::<core::integer::u128, core::integer::u128>>([7]) -> ([7]); // 4
-return([3], [7]); // 5
-branch_align() -> (); // 6
-enum_init<core::result::Result::<core::integer::u128, core::integer::u128>, 1>([6]) -> ([8]); // 7
-store_temp<RangeCheck>([5]) -> ([5]); // 8
-store_temp<core::result::Result::<core::integer::u128, core::integer::u128>>([8]) -> ([8]); // 9
-return([5], [8]); // 10
+F0:
+i128_diff([0], [1], [2]) { fallthrough([3], [4]) F0_B0([5], [6]) };
+branch_align() -> ();
+enum_init<core::result::Result::<core::integer::u128, core::integer::u128>, 0>([4]) -> ([7]);
+store_temp<RangeCheck>([3]) -> ([3]);
+store_temp<core::result::Result::<core::integer::u128, core::integer::u128>>([7]) -> ([7]);
+return([3], [7]);
+F0_B0:
+branch_align() -> ();
+enum_init<core::result::Result::<core::integer::u128, core::integer::u128>, 1>([6]) -> ([8]);
+store_temp<RangeCheck>([5]) -> ([5]);
+store_temp<core::result::Result::<core::integer::u128, core::integer::u128>>([8]) -> ([8]);
+return([5], [8]);
 
-test::foo@0([0]: RangeCheck, [1]: i128, [2]: i128) -> (RangeCheck, core::result::Result::<core::integer::u128, core::integer::u128>);
+test::foo@F0([0]: RangeCheck, [1]: i128, [2]: i128) -> (RangeCheck, core::result::Result::<core::integer::u128, core::integer::u128>);

--- a/Aegis/Tests/e2e_libfuncs/i128_aegis/i128_eq.sierra
+++ b/Aegis/Tests/e2e_libfuncs/i128_aegis/i128_eq.sierra
@@ -1,9 +1,11 @@
 type i128 = i128 [storable: true, drop: true, dup: true, zero_sized: false];
 type Unit = Struct<ut@Tuple> [storable: true, drop: true, dup: true, zero_sized: true];
 type core::bool = Enum<ut@core::bool, Unit, Unit> [storable: true, drop: true, dup: true, zero_sized: false];
+type Const<i128, 12> = Const<i128, 12> [storable: false, drop: false, dup: false, zero_sized: false];
+type Const<i128, 11> = Const<i128, 11> [storable: false, drop: false, dup: false, zero_sized: false];
 
-libfunc i128_const<11> = i128_const<11>;
-libfunc i128_const<12> = i128_const<12>;
+libfunc const_as_immediate<Const<i128, 11>> = const_as_immediate<Const<i128, 11>>;
+libfunc const_as_immediate<Const<i128, 12>> = const_as_immediate<Const<i128, 12>>;
 libfunc store_temp<i128> = store_temp<i128>;
 libfunc i128_eq = i128_eq;
 libfunc branch_align = branch_align;
@@ -12,19 +14,21 @@ libfunc enum_init<core::bool, 0> = enum_init<core::bool, 0>;
 libfunc store_temp<core::bool> = store_temp<core::bool>;
 libfunc enum_init<core::bool, 1> = enum_init<core::bool, 1>;
 
-i128_const<11>() -> ([0]); // 0
-i128_const<12>() -> ([1]); // 1
-store_temp<i128>([0]) -> ([0]); // 2
-i128_eq([0], [1]) { fallthrough() 9() }; // 3
-branch_align() -> (); // 4
-struct_construct<Unit>() -> ([2]); // 5
-enum_init<core::bool, 0>([2]) -> ([3]); // 6
-store_temp<core::bool>([3]) -> ([3]); // 7
-return([3]); // 8
-branch_align() -> (); // 9
-struct_construct<Unit>() -> ([4]); // 10
-enum_init<core::bool, 1>([4]) -> ([5]); // 11
-store_temp<core::bool>([5]) -> ([5]); // 12
-return([5]); // 13
+F0:
+const_as_immediate<Const<i128, 11>>() -> ([0]);
+const_as_immediate<Const<i128, 12>>() -> ([1]);
+store_temp<i128>([0]) -> ([0]);
+i128_eq([0], [1]) { fallthrough() F0_B0() };
+branch_align() -> ();
+struct_construct<Unit>() -> ([2]);
+enum_init<core::bool, 0>([2]) -> ([3]);
+store_temp<core::bool>([3]) -> ([3]);
+return([3]);
+F0_B0:
+branch_align() -> ();
+struct_construct<Unit>() -> ([4]);
+enum_init<core::bool, 1>([4]) -> ([5]);
+store_temp<core::bool>([5]) -> ([5]);
+return([5]);
 
-test::foo@0() -> (core::bool);
+test::foo@F0() -> (core::bool);

--- a/Aegis/Tests/e2e_libfuncs/i128_aegis/i128_overflowing_add_impl.sierra
+++ b/Aegis/Tests/e2e_libfuncs/i128_aegis/i128_overflowing_add_impl.sierra
@@ -10,21 +10,24 @@ libfunc store_temp<core::integer::SignedIntegerResult::<core::integer::i128>> = 
 libfunc enum_init<core::integer::SignedIntegerResult::<core::integer::i128>, 1> = enum_init<core::integer::SignedIntegerResult::<core::integer::i128>, 1>;
 libfunc enum_init<core::integer::SignedIntegerResult::<core::integer::i128>, 2> = enum_init<core::integer::SignedIntegerResult::<core::integer::i128>, 2>;
 
-i128_overflowing_add_impl([0], [1], [2]) { fallthrough([3], [4]) 6([5], [6]) 11([7], [8]) }; // 0
-branch_align() -> (); // 1
-enum_init<core::integer::SignedIntegerResult::<core::integer::i128>, 0>([4]) -> ([9]); // 2
-store_temp<RangeCheck>([3]) -> ([3]); // 3
-store_temp<core::integer::SignedIntegerResult::<core::integer::i128>>([9]) -> ([9]); // 4
-return([3], [9]); // 5
-branch_align() -> (); // 6
-enum_init<core::integer::SignedIntegerResult::<core::integer::i128>, 1>([6]) -> ([10]); // 7
-store_temp<RangeCheck>([5]) -> ([5]); // 8
-store_temp<core::integer::SignedIntegerResult::<core::integer::i128>>([10]) -> ([10]); // 9
-return([5], [10]); // 10
-branch_align() -> (); // 11
-enum_init<core::integer::SignedIntegerResult::<core::integer::i128>, 2>([8]) -> ([11]); // 12
-store_temp<RangeCheck>([7]) -> ([7]); // 13
-store_temp<core::integer::SignedIntegerResult::<core::integer::i128>>([11]) -> ([11]); // 14
-return([7], [11]); // 15
+F0:
+i128_overflowing_add_impl([0], [1], [2]) { fallthrough([3], [4]) F0_B0([5], [6]) F0_B1([7], [8]) };
+branch_align() -> ();
+enum_init<core::integer::SignedIntegerResult::<core::integer::i128>, 0>([4]) -> ([9]);
+store_temp<RangeCheck>([3]) -> ([3]);
+store_temp<core::integer::SignedIntegerResult::<core::integer::i128>>([9]) -> ([9]);
+return([3], [9]);
+F0_B0:
+branch_align() -> ();
+enum_init<core::integer::SignedIntegerResult::<core::integer::i128>, 1>([6]) -> ([10]);
+store_temp<RangeCheck>([5]) -> ([5]);
+store_temp<core::integer::SignedIntegerResult::<core::integer::i128>>([10]) -> ([10]);
+return([5], [10]);
+F0_B1:
+branch_align() -> ();
+enum_init<core::integer::SignedIntegerResult::<core::integer::i128>, 2>([8]) -> ([11]);
+store_temp<RangeCheck>([7]) -> ([7]);
+store_temp<core::integer::SignedIntegerResult::<core::integer::i128>>([11]) -> ([11]);
+return([7], [11]);
 
-test::foo@0([0]: RangeCheck, [1]: i128, [2]: i128) -> (RangeCheck, core::integer::SignedIntegerResult::<core::integer::i128>);
+test::foo@F0([0]: RangeCheck, [1]: i128, [2]: i128) -> (RangeCheck, core::integer::SignedIntegerResult::<core::integer::i128>);

--- a/Aegis/Tests/e2e_libfuncs/i128_aegis/i128_overflowing_sub_impl.sierra
+++ b/Aegis/Tests/e2e_libfuncs/i128_aegis/i128_overflowing_sub_impl.sierra
@@ -10,21 +10,24 @@ libfunc store_temp<core::integer::SignedIntegerResult::<core::integer::i128>> = 
 libfunc enum_init<core::integer::SignedIntegerResult::<core::integer::i128>, 1> = enum_init<core::integer::SignedIntegerResult::<core::integer::i128>, 1>;
 libfunc enum_init<core::integer::SignedIntegerResult::<core::integer::i128>, 2> = enum_init<core::integer::SignedIntegerResult::<core::integer::i128>, 2>;
 
-i128_overflowing_sub_impl([0], [1], [2]) { fallthrough([3], [4]) 6([5], [6]) 11([7], [8]) }; // 0
-branch_align() -> (); // 1
-enum_init<core::integer::SignedIntegerResult::<core::integer::i128>, 0>([4]) -> ([9]); // 2
-store_temp<RangeCheck>([3]) -> ([3]); // 3
-store_temp<core::integer::SignedIntegerResult::<core::integer::i128>>([9]) -> ([9]); // 4
-return([3], [9]); // 5
-branch_align() -> (); // 6
-enum_init<core::integer::SignedIntegerResult::<core::integer::i128>, 1>([6]) -> ([10]); // 7
-store_temp<RangeCheck>([5]) -> ([5]); // 8
-store_temp<core::integer::SignedIntegerResult::<core::integer::i128>>([10]) -> ([10]); // 9
-return([5], [10]); // 10
-branch_align() -> (); // 11
-enum_init<core::integer::SignedIntegerResult::<core::integer::i128>, 2>([8]) -> ([11]); // 12
-store_temp<RangeCheck>([7]) -> ([7]); // 13
-store_temp<core::integer::SignedIntegerResult::<core::integer::i128>>([11]) -> ([11]); // 14
-return([7], [11]); // 15
+F0:
+i128_overflowing_sub_impl([0], [1], [2]) { fallthrough([3], [4]) F0_B0([5], [6]) F0_B1([7], [8]) };
+branch_align() -> ();
+enum_init<core::integer::SignedIntegerResult::<core::integer::i128>, 0>([4]) -> ([9]);
+store_temp<RangeCheck>([3]) -> ([3]);
+store_temp<core::integer::SignedIntegerResult::<core::integer::i128>>([9]) -> ([9]);
+return([3], [9]);
+F0_B0:
+branch_align() -> ();
+enum_init<core::integer::SignedIntegerResult::<core::integer::i128>, 1>([6]) -> ([10]);
+store_temp<RangeCheck>([5]) -> ([5]);
+store_temp<core::integer::SignedIntegerResult::<core::integer::i128>>([10]) -> ([10]);
+return([5], [10]);
+F0_B1:
+branch_align() -> ();
+enum_init<core::integer::SignedIntegerResult::<core::integer::i128>, 2>([8]) -> ([11]);
+store_temp<RangeCheck>([7]) -> ([7]);
+store_temp<core::integer::SignedIntegerResult::<core::integer::i128>>([11]) -> ([11]);
+return([7], [11]);
 
-test::foo@0([0]: RangeCheck, [1]: i128, [2]: i128) -> (RangeCheck, core::integer::SignedIntegerResult::<core::integer::i128>);
+test::foo@F0([0]: RangeCheck, [1]: i128, [2]: i128) -> (RangeCheck, core::integer::SignedIntegerResult::<core::integer::i128>);

--- a/Aegis/Tests/e2e_libfuncs/i128_aegis/i128_to_felt252.sierra
+++ b/Aegis/Tests/e2e_libfuncs/i128_aegis/i128_to_felt252.sierra
@@ -4,8 +4,9 @@ type felt252 = felt252 [storable: true, drop: true, dup: true, zero_sized: false
 libfunc i128_to_felt252 = i128_to_felt252;
 libfunc store_temp<felt252> = store_temp<felt252>;
 
-i128_to_felt252([0]) -> ([1]); // 0
-store_temp<felt252>([1]) -> ([1]); // 1
-return([1]); // 2
+F0:
+i128_to_felt252([0]) -> ([1]);
+store_temp<felt252>([1]) -> ([1]);
+return([1]);
 
-test::foo@0([0]: i128) -> (felt252);
+test::foo@F0([0]: i128) -> (felt252);

--- a/Aegis/Tests/e2e_libfuncs/i128_aegis/i128_try_from_felt252.sierra
+++ b/Aegis/Tests/e2e_libfuncs/i128_aegis/i128_try_from_felt252.sierra
@@ -12,17 +12,19 @@ libfunc store_temp<core::option::Option::<core::integer::i128>> = store_temp<cor
 libfunc struct_construct<Unit> = struct_construct<Unit>;
 libfunc enum_init<core::option::Option::<core::integer::i128>, 1> = enum_init<core::option::Option::<core::integer::i128>, 1>;
 
-i128_try_from_felt252([0], [1]) { fallthrough([2], [3]) 6([4]) }; // 0
-branch_align() -> (); // 1
-enum_init<core::option::Option::<core::integer::i128>, 0>([3]) -> ([5]); // 2
-store_temp<RangeCheck>([2]) -> ([2]); // 3
-store_temp<core::option::Option::<core::integer::i128>>([5]) -> ([5]); // 4
-return([2], [5]); // 5
-branch_align() -> (); // 6
-struct_construct<Unit>() -> ([6]); // 7
-enum_init<core::option::Option::<core::integer::i128>, 1>([6]) -> ([7]); // 8
-store_temp<RangeCheck>([4]) -> ([4]); // 9
-store_temp<core::option::Option::<core::integer::i128>>([7]) -> ([7]); // 10
-return([4], [7]); // 11
+F0:
+i128_try_from_felt252([0], [1]) { fallthrough([2], [3]) F0_B0([4]) };
+branch_align() -> ();
+enum_init<core::option::Option::<core::integer::i128>, 0>([3]) -> ([5]);
+store_temp<RangeCheck>([2]) -> ([2]);
+store_temp<core::option::Option::<core::integer::i128>>([5]) -> ([5]);
+return([2], [5]);
+F0_B0:
+branch_align() -> ();
+struct_construct<Unit>() -> ([6]);
+enum_init<core::option::Option::<core::integer::i128>, 1>([6]) -> ([7]);
+store_temp<RangeCheck>([4]) -> ([4]);
+store_temp<core::option::Option::<core::integer::i128>>([7]) -> ([7]);
+return([4], [7]);
 
-test::foo@0([0]: RangeCheck, [1]: felt252) -> (RangeCheck, core::option::Option::<core::integer::i128>);
+test::foo@F0([0]: RangeCheck, [1]: felt252) -> (RangeCheck, core::option::Option::<core::integer::i128>);

--- a/Aegis/Tests/e2e_libfuncs/i16_aegis/i16_diff.sierra
+++ b/Aegis/Tests/e2e_libfuncs/i16_aegis/i16_diff.sierra
@@ -10,16 +10,18 @@ libfunc store_temp<RangeCheck> = store_temp<RangeCheck>;
 libfunc store_temp<core::result::Result::<core::integer::u16, core::integer::u16>> = store_temp<core::result::Result::<core::integer::u16, core::integer::u16>>;
 libfunc enum_init<core::result::Result::<core::integer::u16, core::integer::u16>, 1> = enum_init<core::result::Result::<core::integer::u16, core::integer::u16>, 1>;
 
-i16_diff([0], [1], [2]) { fallthrough([3], [4]) 6([5], [6]) }; // 0
-branch_align() -> (); // 1
-enum_init<core::result::Result::<core::integer::u16, core::integer::u16>, 0>([4]) -> ([7]); // 2
-store_temp<RangeCheck>([3]) -> ([3]); // 3
-store_temp<core::result::Result::<core::integer::u16, core::integer::u16>>([7]) -> ([7]); // 4
-return([3], [7]); // 5
-branch_align() -> (); // 6
-enum_init<core::result::Result::<core::integer::u16, core::integer::u16>, 1>([6]) -> ([8]); // 7
-store_temp<RangeCheck>([5]) -> ([5]); // 8
-store_temp<core::result::Result::<core::integer::u16, core::integer::u16>>([8]) -> ([8]); // 9
-return([5], [8]); // 10
+F0:
+i16_diff([0], [1], [2]) { fallthrough([3], [4]) F0_B0([5], [6]) };
+branch_align() -> ();
+enum_init<core::result::Result::<core::integer::u16, core::integer::u16>, 0>([4]) -> ([7]);
+store_temp<RangeCheck>([3]) -> ([3]);
+store_temp<core::result::Result::<core::integer::u16, core::integer::u16>>([7]) -> ([7]);
+return([3], [7]);
+F0_B0:
+branch_align() -> ();
+enum_init<core::result::Result::<core::integer::u16, core::integer::u16>, 1>([6]) -> ([8]);
+store_temp<RangeCheck>([5]) -> ([5]);
+store_temp<core::result::Result::<core::integer::u16, core::integer::u16>>([8]) -> ([8]);
+return([5], [8]);
 
-test::foo@0([0]: RangeCheck, [1]: i16, [2]: i16) -> (RangeCheck, core::result::Result::<core::integer::u16, core::integer::u16>);
+test::foo@F0([0]: RangeCheck, [1]: i16, [2]: i16) -> (RangeCheck, core::result::Result::<core::integer::u16, core::integer::u16>);

--- a/Aegis/Tests/e2e_libfuncs/i16_aegis/i16_eq.sierra
+++ b/Aegis/Tests/e2e_libfuncs/i16_aegis/i16_eq.sierra
@@ -1,9 +1,11 @@
 type i16 = i16 [storable: true, drop: true, dup: true, zero_sized: false];
 type Unit = Struct<ut@Tuple> [storable: true, drop: true, dup: true, zero_sized: true];
 type core::bool = Enum<ut@core::bool, Unit, Unit> [storable: true, drop: true, dup: true, zero_sized: false];
+type Const<i16, 12> = Const<i16, 12> [storable: false, drop: false, dup: false, zero_sized: false];
+type Const<i16, 11> = Const<i16, 11> [storable: false, drop: false, dup: false, zero_sized: false];
 
-libfunc i16_const<11> = i16_const<11>;
-libfunc i16_const<12> = i16_const<12>;
+libfunc const_as_immediate<Const<i16, 11>> = const_as_immediate<Const<i16, 11>>;
+libfunc const_as_immediate<Const<i16, 12>> = const_as_immediate<Const<i16, 12>>;
 libfunc store_temp<i16> = store_temp<i16>;
 libfunc i16_eq = i16_eq;
 libfunc branch_align = branch_align;
@@ -12,19 +14,21 @@ libfunc enum_init<core::bool, 0> = enum_init<core::bool, 0>;
 libfunc store_temp<core::bool> = store_temp<core::bool>;
 libfunc enum_init<core::bool, 1> = enum_init<core::bool, 1>;
 
-i16_const<11>() -> ([0]); // 0
-i16_const<12>() -> ([1]); // 1
-store_temp<i16>([0]) -> ([0]); // 2
-i16_eq([0], [1]) { fallthrough() 9() }; // 3
-branch_align() -> (); // 4
-struct_construct<Unit>() -> ([2]); // 5
-enum_init<core::bool, 0>([2]) -> ([3]); // 6
-store_temp<core::bool>([3]) -> ([3]); // 7
-return([3]); // 8
-branch_align() -> (); // 9
-struct_construct<Unit>() -> ([4]); // 10
-enum_init<core::bool, 1>([4]) -> ([5]); // 11
-store_temp<core::bool>([5]) -> ([5]); // 12
-return([5]); // 13
+F0:
+const_as_immediate<Const<i16, 11>>() -> ([0]);
+const_as_immediate<Const<i16, 12>>() -> ([1]);
+store_temp<i16>([0]) -> ([0]);
+i16_eq([0], [1]) { fallthrough() F0_B0() };
+branch_align() -> ();
+struct_construct<Unit>() -> ([2]);
+enum_init<core::bool, 0>([2]) -> ([3]);
+store_temp<core::bool>([3]) -> ([3]);
+return([3]);
+F0_B0:
+branch_align() -> ();
+struct_construct<Unit>() -> ([4]);
+enum_init<core::bool, 1>([4]) -> ([5]);
+store_temp<core::bool>([5]) -> ([5]);
+return([5]);
 
-test::foo@0() -> (core::bool);
+test::foo@F0() -> (core::bool);

--- a/Aegis/Tests/e2e_libfuncs/i16_aegis/i16_overflowing_add_impl.sierra
+++ b/Aegis/Tests/e2e_libfuncs/i16_aegis/i16_overflowing_add_impl.sierra
@@ -10,21 +10,24 @@ libfunc store_temp<core::integer::SignedIntegerResult::<core::integer::i16>> = s
 libfunc enum_init<core::integer::SignedIntegerResult::<core::integer::i16>, 1> = enum_init<core::integer::SignedIntegerResult::<core::integer::i16>, 1>;
 libfunc enum_init<core::integer::SignedIntegerResult::<core::integer::i16>, 2> = enum_init<core::integer::SignedIntegerResult::<core::integer::i16>, 2>;
 
-i16_overflowing_add_impl([0], [1], [2]) { fallthrough([3], [4]) 6([5], [6]) 11([7], [8]) }; // 0
-branch_align() -> (); // 1
-enum_init<core::integer::SignedIntegerResult::<core::integer::i16>, 0>([4]) -> ([9]); // 2
-store_temp<RangeCheck>([3]) -> ([3]); // 3
-store_temp<core::integer::SignedIntegerResult::<core::integer::i16>>([9]) -> ([9]); // 4
-return([3], [9]); // 5
-branch_align() -> (); // 6
-enum_init<core::integer::SignedIntegerResult::<core::integer::i16>, 1>([6]) -> ([10]); // 7
-store_temp<RangeCheck>([5]) -> ([5]); // 8
-store_temp<core::integer::SignedIntegerResult::<core::integer::i16>>([10]) -> ([10]); // 9
-return([5], [10]); // 10
-branch_align() -> (); // 11
-enum_init<core::integer::SignedIntegerResult::<core::integer::i16>, 2>([8]) -> ([11]); // 12
-store_temp<RangeCheck>([7]) -> ([7]); // 13
-store_temp<core::integer::SignedIntegerResult::<core::integer::i16>>([11]) -> ([11]); // 14
-return([7], [11]); // 15
+F0:
+i16_overflowing_add_impl([0], [1], [2]) { fallthrough([3], [4]) F0_B0([5], [6]) F0_B1([7], [8]) };
+branch_align() -> ();
+enum_init<core::integer::SignedIntegerResult::<core::integer::i16>, 0>([4]) -> ([9]);
+store_temp<RangeCheck>([3]) -> ([3]);
+store_temp<core::integer::SignedIntegerResult::<core::integer::i16>>([9]) -> ([9]);
+return([3], [9]);
+F0_B0:
+branch_align() -> ();
+enum_init<core::integer::SignedIntegerResult::<core::integer::i16>, 1>([6]) -> ([10]);
+store_temp<RangeCheck>([5]) -> ([5]);
+store_temp<core::integer::SignedIntegerResult::<core::integer::i16>>([10]) -> ([10]);
+return([5], [10]);
+F0_B1:
+branch_align() -> ();
+enum_init<core::integer::SignedIntegerResult::<core::integer::i16>, 2>([8]) -> ([11]);
+store_temp<RangeCheck>([7]) -> ([7]);
+store_temp<core::integer::SignedIntegerResult::<core::integer::i16>>([11]) -> ([11]);
+return([7], [11]);
 
-test::foo@0([0]: RangeCheck, [1]: i16, [2]: i16) -> (RangeCheck, core::integer::SignedIntegerResult::<core::integer::i16>);
+test::foo@F0([0]: RangeCheck, [1]: i16, [2]: i16) -> (RangeCheck, core::integer::SignedIntegerResult::<core::integer::i16>);

--- a/Aegis/Tests/e2e_libfuncs/i16_aegis/i16_overflowing_sub_impl.sierra
+++ b/Aegis/Tests/e2e_libfuncs/i16_aegis/i16_overflowing_sub_impl.sierra
@@ -10,21 +10,24 @@ libfunc store_temp<core::integer::SignedIntegerResult::<core::integer::i16>> = s
 libfunc enum_init<core::integer::SignedIntegerResult::<core::integer::i16>, 1> = enum_init<core::integer::SignedIntegerResult::<core::integer::i16>, 1>;
 libfunc enum_init<core::integer::SignedIntegerResult::<core::integer::i16>, 2> = enum_init<core::integer::SignedIntegerResult::<core::integer::i16>, 2>;
 
-i16_overflowing_sub_impl([0], [1], [2]) { fallthrough([3], [4]) 6([5], [6]) 11([7], [8]) }; // 0
-branch_align() -> (); // 1
-enum_init<core::integer::SignedIntegerResult::<core::integer::i16>, 0>([4]) -> ([9]); // 2
-store_temp<RangeCheck>([3]) -> ([3]); // 3
-store_temp<core::integer::SignedIntegerResult::<core::integer::i16>>([9]) -> ([9]); // 4
-return([3], [9]); // 5
-branch_align() -> (); // 6
-enum_init<core::integer::SignedIntegerResult::<core::integer::i16>, 1>([6]) -> ([10]); // 7
-store_temp<RangeCheck>([5]) -> ([5]); // 8
-store_temp<core::integer::SignedIntegerResult::<core::integer::i16>>([10]) -> ([10]); // 9
-return([5], [10]); // 10
-branch_align() -> (); // 11
-enum_init<core::integer::SignedIntegerResult::<core::integer::i16>, 2>([8]) -> ([11]); // 12
-store_temp<RangeCheck>([7]) -> ([7]); // 13
-store_temp<core::integer::SignedIntegerResult::<core::integer::i16>>([11]) -> ([11]); // 14
-return([7], [11]); // 15
+F0:
+i16_overflowing_sub_impl([0], [1], [2]) { fallthrough([3], [4]) F0_B0([5], [6]) F0_B1([7], [8]) };
+branch_align() -> ();
+enum_init<core::integer::SignedIntegerResult::<core::integer::i16>, 0>([4]) -> ([9]);
+store_temp<RangeCheck>([3]) -> ([3]);
+store_temp<core::integer::SignedIntegerResult::<core::integer::i16>>([9]) -> ([9]);
+return([3], [9]);
+F0_B0:
+branch_align() -> ();
+enum_init<core::integer::SignedIntegerResult::<core::integer::i16>, 1>([6]) -> ([10]);
+store_temp<RangeCheck>([5]) -> ([5]);
+store_temp<core::integer::SignedIntegerResult::<core::integer::i16>>([10]) -> ([10]);
+return([5], [10]);
+F0_B1:
+branch_align() -> ();
+enum_init<core::integer::SignedIntegerResult::<core::integer::i16>, 2>([8]) -> ([11]);
+store_temp<RangeCheck>([7]) -> ([7]);
+store_temp<core::integer::SignedIntegerResult::<core::integer::i16>>([11]) -> ([11]);
+return([7], [11]);
 
-test::foo@0([0]: RangeCheck, [1]: i16, [2]: i16) -> (RangeCheck, core::integer::SignedIntegerResult::<core::integer::i16>);
+test::foo@F0([0]: RangeCheck, [1]: i16, [2]: i16) -> (RangeCheck, core::integer::SignedIntegerResult::<core::integer::i16>);

--- a/Aegis/Tests/e2e_libfuncs/i16_aegis/i16_to_felt252.sierra
+++ b/Aegis/Tests/e2e_libfuncs/i16_aegis/i16_to_felt252.sierra
@@ -4,8 +4,9 @@ type felt252 = felt252 [storable: true, drop: true, dup: true, zero_sized: false
 libfunc i16_to_felt252 = i16_to_felt252;
 libfunc store_temp<felt252> = store_temp<felt252>;
 
-i16_to_felt252([0]) -> ([1]); // 0
-store_temp<felt252>([1]) -> ([1]); // 1
-return([1]); // 2
+F0:
+i16_to_felt252([0]) -> ([1]);
+store_temp<felt252>([1]) -> ([1]);
+return([1]);
 
-test::foo@0([0]: i16) -> (felt252);
+test::foo@F0([0]: i16) -> (felt252);

--- a/Aegis/Tests/e2e_libfuncs/i16_aegis/i16_try_from_felt252.sierra
+++ b/Aegis/Tests/e2e_libfuncs/i16_aegis/i16_try_from_felt252.sierra
@@ -12,17 +12,19 @@ libfunc store_temp<core::option::Option::<core::integer::i16>> = store_temp<core
 libfunc struct_construct<Unit> = struct_construct<Unit>;
 libfunc enum_init<core::option::Option::<core::integer::i16>, 1> = enum_init<core::option::Option::<core::integer::i16>, 1>;
 
-i16_try_from_felt252([0], [1]) { fallthrough([2], [3]) 6([4]) }; // 0
-branch_align() -> (); // 1
-enum_init<core::option::Option::<core::integer::i16>, 0>([3]) -> ([5]); // 2
-store_temp<RangeCheck>([2]) -> ([2]); // 3
-store_temp<core::option::Option::<core::integer::i16>>([5]) -> ([5]); // 4
-return([2], [5]); // 5
-branch_align() -> (); // 6
-struct_construct<Unit>() -> ([6]); // 7
-enum_init<core::option::Option::<core::integer::i16>, 1>([6]) -> ([7]); // 8
-store_temp<RangeCheck>([4]) -> ([4]); // 9
-store_temp<core::option::Option::<core::integer::i16>>([7]) -> ([7]); // 10
-return([4], [7]); // 11
+F0:
+i16_try_from_felt252([0], [1]) { fallthrough([2], [3]) F0_B0([4]) };
+branch_align() -> ();
+enum_init<core::option::Option::<core::integer::i16>, 0>([3]) -> ([5]);
+store_temp<RangeCheck>([2]) -> ([2]);
+store_temp<core::option::Option::<core::integer::i16>>([5]) -> ([5]);
+return([2], [5]);
+F0_B0:
+branch_align() -> ();
+struct_construct<Unit>() -> ([6]);
+enum_init<core::option::Option::<core::integer::i16>, 1>([6]) -> ([7]);
+store_temp<RangeCheck>([4]) -> ([4]);
+store_temp<core::option::Option::<core::integer::i16>>([7]) -> ([7]);
+return([4], [7]);
 
-test::foo@0([0]: RangeCheck, [1]: felt252) -> (RangeCheck, core::option::Option::<core::integer::i16>);
+test::foo@F0([0]: RangeCheck, [1]: felt252) -> (RangeCheck, core::option::Option::<core::integer::i16>);

--- a/Aegis/Tests/e2e_libfuncs/i16_aegis/i16_wide_mul.sierra
+++ b/Aegis/Tests/e2e_libfuncs/i16_aegis/i16_wide_mul.sierra
@@ -4,8 +4,9 @@ type i32 = i32 [storable: true, drop: true, dup: true, zero_sized: false];
 libfunc i16_wide_mul = i16_wide_mul;
 libfunc store_temp<i32> = store_temp<i32>;
 
-i16_wide_mul([0], [1]) -> ([2]); // 0
-store_temp<i32>([2]) -> ([2]); // 1
-return([2]); // 2
+F0:
+i16_wide_mul([0], [1]) -> ([2]);
+store_temp<i32>([2]) -> ([2]);
+return([2]);
 
-test::foo@0([0]: i16, [1]: i16) -> (i32);
+test::foo@F0([0]: i16, [1]: i16) -> (i32);

--- a/Aegis/Tests/e2e_libfuncs/i32_aegis/i32_diff.sierra
+++ b/Aegis/Tests/e2e_libfuncs/i32_aegis/i32_diff.sierra
@@ -10,16 +10,18 @@ libfunc store_temp<RangeCheck> = store_temp<RangeCheck>;
 libfunc store_temp<core::result::Result::<core::integer::u32, core::integer::u32>> = store_temp<core::result::Result::<core::integer::u32, core::integer::u32>>;
 libfunc enum_init<core::result::Result::<core::integer::u32, core::integer::u32>, 1> = enum_init<core::result::Result::<core::integer::u32, core::integer::u32>, 1>;
 
-i32_diff([0], [1], [2]) { fallthrough([3], [4]) 6([5], [6]) }; // 0
-branch_align() -> (); // 1
-enum_init<core::result::Result::<core::integer::u32, core::integer::u32>, 0>([4]) -> ([7]); // 2
-store_temp<RangeCheck>([3]) -> ([3]); // 3
-store_temp<core::result::Result::<core::integer::u32, core::integer::u32>>([7]) -> ([7]); // 4
-return([3], [7]); // 5
-branch_align() -> (); // 6
-enum_init<core::result::Result::<core::integer::u32, core::integer::u32>, 1>([6]) -> ([8]); // 7
-store_temp<RangeCheck>([5]) -> ([5]); // 8
-store_temp<core::result::Result::<core::integer::u32, core::integer::u32>>([8]) -> ([8]); // 9
-return([5], [8]); // 10
+F0:
+i32_diff([0], [1], [2]) { fallthrough([3], [4]) F0_B0([5], [6]) };
+branch_align() -> ();
+enum_init<core::result::Result::<core::integer::u32, core::integer::u32>, 0>([4]) -> ([7]);
+store_temp<RangeCheck>([3]) -> ([3]);
+store_temp<core::result::Result::<core::integer::u32, core::integer::u32>>([7]) -> ([7]);
+return([3], [7]);
+F0_B0:
+branch_align() -> ();
+enum_init<core::result::Result::<core::integer::u32, core::integer::u32>, 1>([6]) -> ([8]);
+store_temp<RangeCheck>([5]) -> ([5]);
+store_temp<core::result::Result::<core::integer::u32, core::integer::u32>>([8]) -> ([8]);
+return([5], [8]);
 
-test::foo@0([0]: RangeCheck, [1]: i32, [2]: i32) -> (RangeCheck, core::result::Result::<core::integer::u32, core::integer::u32>);
+test::foo@F0([0]: RangeCheck, [1]: i32, [2]: i32) -> (RangeCheck, core::result::Result::<core::integer::u32, core::integer::u32>);

--- a/Aegis/Tests/e2e_libfuncs/i32_aegis/i32_eq.sierra
+++ b/Aegis/Tests/e2e_libfuncs/i32_aegis/i32_eq.sierra
@@ -1,9 +1,11 @@
 type i32 = i32 [storable: true, drop: true, dup: true, zero_sized: false];
 type Unit = Struct<ut@Tuple> [storable: true, drop: true, dup: true, zero_sized: true];
 type core::bool = Enum<ut@core::bool, Unit, Unit> [storable: true, drop: true, dup: true, zero_sized: false];
+type Const<i32, 12> = Const<i32, 12> [storable: false, drop: false, dup: false, zero_sized: false];
+type Const<i32, 11> = Const<i32, 11> [storable: false, drop: false, dup: false, zero_sized: false];
 
-libfunc i32_const<11> = i32_const<11>;
-libfunc i32_const<12> = i32_const<12>;
+libfunc const_as_immediate<Const<i32, 11>> = const_as_immediate<Const<i32, 11>>;
+libfunc const_as_immediate<Const<i32, 12>> = const_as_immediate<Const<i32, 12>>;
 libfunc store_temp<i32> = store_temp<i32>;
 libfunc i32_eq = i32_eq;
 libfunc branch_align = branch_align;
@@ -12,19 +14,21 @@ libfunc enum_init<core::bool, 0> = enum_init<core::bool, 0>;
 libfunc store_temp<core::bool> = store_temp<core::bool>;
 libfunc enum_init<core::bool, 1> = enum_init<core::bool, 1>;
 
-i32_const<11>() -> ([0]); // 0
-i32_const<12>() -> ([1]); // 1
-store_temp<i32>([0]) -> ([0]); // 2
-i32_eq([0], [1]) { fallthrough() 9() }; // 3
-branch_align() -> (); // 4
-struct_construct<Unit>() -> ([2]); // 5
-enum_init<core::bool, 0>([2]) -> ([3]); // 6
-store_temp<core::bool>([3]) -> ([3]); // 7
-return([3]); // 8
-branch_align() -> (); // 9
-struct_construct<Unit>() -> ([4]); // 10
-enum_init<core::bool, 1>([4]) -> ([5]); // 11
-store_temp<core::bool>([5]) -> ([5]); // 12
-return([5]); // 13
+F0:
+const_as_immediate<Const<i32, 11>>() -> ([0]);
+const_as_immediate<Const<i32, 12>>() -> ([1]);
+store_temp<i32>([0]) -> ([0]);
+i32_eq([0], [1]) { fallthrough() F0_B0() };
+branch_align() -> ();
+struct_construct<Unit>() -> ([2]);
+enum_init<core::bool, 0>([2]) -> ([3]);
+store_temp<core::bool>([3]) -> ([3]);
+return([3]);
+F0_B0:
+branch_align() -> ();
+struct_construct<Unit>() -> ([4]);
+enum_init<core::bool, 1>([4]) -> ([5]);
+store_temp<core::bool>([5]) -> ([5]);
+return([5]);
 
-test::foo@0() -> (core::bool);
+test::foo@F0() -> (core::bool);

--- a/Aegis/Tests/e2e_libfuncs/i32_aegis/i32_overflowing_add_impl.sierra
+++ b/Aegis/Tests/e2e_libfuncs/i32_aegis/i32_overflowing_add_impl.sierra
@@ -10,21 +10,24 @@ libfunc store_temp<core::integer::SignedIntegerResult::<core::integer::i32>> = s
 libfunc enum_init<core::integer::SignedIntegerResult::<core::integer::i32>, 1> = enum_init<core::integer::SignedIntegerResult::<core::integer::i32>, 1>;
 libfunc enum_init<core::integer::SignedIntegerResult::<core::integer::i32>, 2> = enum_init<core::integer::SignedIntegerResult::<core::integer::i32>, 2>;
 
-i32_overflowing_add_impl([0], [1], [2]) { fallthrough([3], [4]) 6([5], [6]) 11([7], [8]) }; // 0
-branch_align() -> (); // 1
-enum_init<core::integer::SignedIntegerResult::<core::integer::i32>, 0>([4]) -> ([9]); // 2
-store_temp<RangeCheck>([3]) -> ([3]); // 3
-store_temp<core::integer::SignedIntegerResult::<core::integer::i32>>([9]) -> ([9]); // 4
-return([3], [9]); // 5
-branch_align() -> (); // 6
-enum_init<core::integer::SignedIntegerResult::<core::integer::i32>, 1>([6]) -> ([10]); // 7
-store_temp<RangeCheck>([5]) -> ([5]); // 8
-store_temp<core::integer::SignedIntegerResult::<core::integer::i32>>([10]) -> ([10]); // 9
-return([5], [10]); // 10
-branch_align() -> (); // 11
-enum_init<core::integer::SignedIntegerResult::<core::integer::i32>, 2>([8]) -> ([11]); // 12
-store_temp<RangeCheck>([7]) -> ([7]); // 13
-store_temp<core::integer::SignedIntegerResult::<core::integer::i32>>([11]) -> ([11]); // 14
-return([7], [11]); // 15
+F0:
+i32_overflowing_add_impl([0], [1], [2]) { fallthrough([3], [4]) F0_B0([5], [6]) F0_B1([7], [8]) };
+branch_align() -> ();
+enum_init<core::integer::SignedIntegerResult::<core::integer::i32>, 0>([4]) -> ([9]);
+store_temp<RangeCheck>([3]) -> ([3]);
+store_temp<core::integer::SignedIntegerResult::<core::integer::i32>>([9]) -> ([9]);
+return([3], [9]);
+F0_B0:
+branch_align() -> ();
+enum_init<core::integer::SignedIntegerResult::<core::integer::i32>, 1>([6]) -> ([10]);
+store_temp<RangeCheck>([5]) -> ([5]);
+store_temp<core::integer::SignedIntegerResult::<core::integer::i32>>([10]) -> ([10]);
+return([5], [10]);
+F0_B1:
+branch_align() -> ();
+enum_init<core::integer::SignedIntegerResult::<core::integer::i32>, 2>([8]) -> ([11]);
+store_temp<RangeCheck>([7]) -> ([7]);
+store_temp<core::integer::SignedIntegerResult::<core::integer::i32>>([11]) -> ([11]);
+return([7], [11]);
 
-test::foo@0([0]: RangeCheck, [1]: i32, [2]: i32) -> (RangeCheck, core::integer::SignedIntegerResult::<core::integer::i32>);
+test::foo@F0([0]: RangeCheck, [1]: i32, [2]: i32) -> (RangeCheck, core::integer::SignedIntegerResult::<core::integer::i32>);

--- a/Aegis/Tests/e2e_libfuncs/i32_aegis/i32_overflowing_sub_impl.sierra
+++ b/Aegis/Tests/e2e_libfuncs/i32_aegis/i32_overflowing_sub_impl.sierra
@@ -10,21 +10,24 @@ libfunc store_temp<core::integer::SignedIntegerResult::<core::integer::i32>> = s
 libfunc enum_init<core::integer::SignedIntegerResult::<core::integer::i32>, 1> = enum_init<core::integer::SignedIntegerResult::<core::integer::i32>, 1>;
 libfunc enum_init<core::integer::SignedIntegerResult::<core::integer::i32>, 2> = enum_init<core::integer::SignedIntegerResult::<core::integer::i32>, 2>;
 
-i32_overflowing_sub_impl([0], [1], [2]) { fallthrough([3], [4]) 6([5], [6]) 11([7], [8]) }; // 0
-branch_align() -> (); // 1
-enum_init<core::integer::SignedIntegerResult::<core::integer::i32>, 0>([4]) -> ([9]); // 2
-store_temp<RangeCheck>([3]) -> ([3]); // 3
-store_temp<core::integer::SignedIntegerResult::<core::integer::i32>>([9]) -> ([9]); // 4
-return([3], [9]); // 5
-branch_align() -> (); // 6
-enum_init<core::integer::SignedIntegerResult::<core::integer::i32>, 1>([6]) -> ([10]); // 7
-store_temp<RangeCheck>([5]) -> ([5]); // 8
-store_temp<core::integer::SignedIntegerResult::<core::integer::i32>>([10]) -> ([10]); // 9
-return([5], [10]); // 10
-branch_align() -> (); // 11
-enum_init<core::integer::SignedIntegerResult::<core::integer::i32>, 2>([8]) -> ([11]); // 12
-store_temp<RangeCheck>([7]) -> ([7]); // 13
-store_temp<core::integer::SignedIntegerResult::<core::integer::i32>>([11]) -> ([11]); // 14
-return([7], [11]); // 15
+F0:
+i32_overflowing_sub_impl([0], [1], [2]) { fallthrough([3], [4]) F0_B0([5], [6]) F0_B1([7], [8]) };
+branch_align() -> ();
+enum_init<core::integer::SignedIntegerResult::<core::integer::i32>, 0>([4]) -> ([9]);
+store_temp<RangeCheck>([3]) -> ([3]);
+store_temp<core::integer::SignedIntegerResult::<core::integer::i32>>([9]) -> ([9]);
+return([3], [9]);
+F0_B0:
+branch_align() -> ();
+enum_init<core::integer::SignedIntegerResult::<core::integer::i32>, 1>([6]) -> ([10]);
+store_temp<RangeCheck>([5]) -> ([5]);
+store_temp<core::integer::SignedIntegerResult::<core::integer::i32>>([10]) -> ([10]);
+return([5], [10]);
+F0_B1:
+branch_align() -> ();
+enum_init<core::integer::SignedIntegerResult::<core::integer::i32>, 2>([8]) -> ([11]);
+store_temp<RangeCheck>([7]) -> ([7]);
+store_temp<core::integer::SignedIntegerResult::<core::integer::i32>>([11]) -> ([11]);
+return([7], [11]);
 
-test::foo@0([0]: RangeCheck, [1]: i32, [2]: i32) -> (RangeCheck, core::integer::SignedIntegerResult::<core::integer::i32>);
+test::foo@F0([0]: RangeCheck, [1]: i32, [2]: i32) -> (RangeCheck, core::integer::SignedIntegerResult::<core::integer::i32>);

--- a/Aegis/Tests/e2e_libfuncs/i32_aegis/i32_to_felt252.sierra
+++ b/Aegis/Tests/e2e_libfuncs/i32_aegis/i32_to_felt252.sierra
@@ -4,8 +4,9 @@ type felt252 = felt252 [storable: true, drop: true, dup: true, zero_sized: false
 libfunc i32_to_felt252 = i32_to_felt252;
 libfunc store_temp<felt252> = store_temp<felt252>;
 
-i32_to_felt252([0]) -> ([1]); // 0
-store_temp<felt252>([1]) -> ([1]); // 1
-return([1]); // 2
+F0:
+i32_to_felt252([0]) -> ([1]);
+store_temp<felt252>([1]) -> ([1]);
+return([1]);
 
-test::foo@0([0]: i32) -> (felt252);
+test::foo@F0([0]: i32) -> (felt252);

--- a/Aegis/Tests/e2e_libfuncs/i32_aegis/i32_try_from_felt252.sierra
+++ b/Aegis/Tests/e2e_libfuncs/i32_aegis/i32_try_from_felt252.sierra
@@ -12,17 +12,19 @@ libfunc store_temp<core::option::Option::<core::integer::i32>> = store_temp<core
 libfunc struct_construct<Unit> = struct_construct<Unit>;
 libfunc enum_init<core::option::Option::<core::integer::i32>, 1> = enum_init<core::option::Option::<core::integer::i32>, 1>;
 
-i32_try_from_felt252([0], [1]) { fallthrough([2], [3]) 6([4]) }; // 0
-branch_align() -> (); // 1
-enum_init<core::option::Option::<core::integer::i32>, 0>([3]) -> ([5]); // 2
-store_temp<RangeCheck>([2]) -> ([2]); // 3
-store_temp<core::option::Option::<core::integer::i32>>([5]) -> ([5]); // 4
-return([2], [5]); // 5
-branch_align() -> (); // 6
-struct_construct<Unit>() -> ([6]); // 7
-enum_init<core::option::Option::<core::integer::i32>, 1>([6]) -> ([7]); // 8
-store_temp<RangeCheck>([4]) -> ([4]); // 9
-store_temp<core::option::Option::<core::integer::i32>>([7]) -> ([7]); // 10
-return([4], [7]); // 11
+F0:
+i32_try_from_felt252([0], [1]) { fallthrough([2], [3]) F0_B0([4]) };
+branch_align() -> ();
+enum_init<core::option::Option::<core::integer::i32>, 0>([3]) -> ([5]);
+store_temp<RangeCheck>([2]) -> ([2]);
+store_temp<core::option::Option::<core::integer::i32>>([5]) -> ([5]);
+return([2], [5]);
+F0_B0:
+branch_align() -> ();
+struct_construct<Unit>() -> ([6]);
+enum_init<core::option::Option::<core::integer::i32>, 1>([6]) -> ([7]);
+store_temp<RangeCheck>([4]) -> ([4]);
+store_temp<core::option::Option::<core::integer::i32>>([7]) -> ([7]);
+return([4], [7]);
 
-test::foo@0([0]: RangeCheck, [1]: felt252) -> (RangeCheck, core::option::Option::<core::integer::i32>);
+test::foo@F0([0]: RangeCheck, [1]: felt252) -> (RangeCheck, core::option::Option::<core::integer::i32>);

--- a/Aegis/Tests/e2e_libfuncs/i32_aegis/i32_wide_mul.sierra
+++ b/Aegis/Tests/e2e_libfuncs/i32_aegis/i32_wide_mul.sierra
@@ -4,8 +4,9 @@ type i64 = i64 [storable: true, drop: true, dup: true, zero_sized: false];
 libfunc i32_wide_mul = i32_wide_mul;
 libfunc store_temp<i64> = store_temp<i64>;
 
-i32_wide_mul([0], [1]) -> ([2]); // 0
-store_temp<i64>([2]) -> ([2]); // 1
-return([2]); // 2
+F0:
+i32_wide_mul([0], [1]) -> ([2]);
+store_temp<i64>([2]) -> ([2]);
+return([2]);
 
-test::foo@0([0]: i32, [1]: i32) -> (i64);
+test::foo@F0([0]: i32, [1]: i32) -> (i64);

--- a/Aegis/Tests/e2e_libfuncs/i64_aegis/i64_diff.sierra
+++ b/Aegis/Tests/e2e_libfuncs/i64_aegis/i64_diff.sierra
@@ -10,16 +10,18 @@ libfunc store_temp<RangeCheck> = store_temp<RangeCheck>;
 libfunc store_temp<core::result::Result::<core::integer::u64, core::integer::u64>> = store_temp<core::result::Result::<core::integer::u64, core::integer::u64>>;
 libfunc enum_init<core::result::Result::<core::integer::u64, core::integer::u64>, 1> = enum_init<core::result::Result::<core::integer::u64, core::integer::u64>, 1>;
 
-i64_diff([0], [1], [2]) { fallthrough([3], [4]) 6([5], [6]) }; // 0
-branch_align() -> (); // 1
-enum_init<core::result::Result::<core::integer::u64, core::integer::u64>, 0>([4]) -> ([7]); // 2
-store_temp<RangeCheck>([3]) -> ([3]); // 3
-store_temp<core::result::Result::<core::integer::u64, core::integer::u64>>([7]) -> ([7]); // 4
-return([3], [7]); // 5
-branch_align() -> (); // 6
-enum_init<core::result::Result::<core::integer::u64, core::integer::u64>, 1>([6]) -> ([8]); // 7
-store_temp<RangeCheck>([5]) -> ([5]); // 8
-store_temp<core::result::Result::<core::integer::u64, core::integer::u64>>([8]) -> ([8]); // 9
-return([5], [8]); // 10
+F0:
+i64_diff([0], [1], [2]) { fallthrough([3], [4]) F0_B0([5], [6]) };
+branch_align() -> ();
+enum_init<core::result::Result::<core::integer::u64, core::integer::u64>, 0>([4]) -> ([7]);
+store_temp<RangeCheck>([3]) -> ([3]);
+store_temp<core::result::Result::<core::integer::u64, core::integer::u64>>([7]) -> ([7]);
+return([3], [7]);
+F0_B0:
+branch_align() -> ();
+enum_init<core::result::Result::<core::integer::u64, core::integer::u64>, 1>([6]) -> ([8]);
+store_temp<RangeCheck>([5]) -> ([5]);
+store_temp<core::result::Result::<core::integer::u64, core::integer::u64>>([8]) -> ([8]);
+return([5], [8]);
 
-test::foo@0([0]: RangeCheck, [1]: i64, [2]: i64) -> (RangeCheck, core::result::Result::<core::integer::u64, core::integer::u64>);
+test::foo@F0([0]: RangeCheck, [1]: i64, [2]: i64) -> (RangeCheck, core::result::Result::<core::integer::u64, core::integer::u64>);

--- a/Aegis/Tests/e2e_libfuncs/i64_aegis/i64_eq.sierra
+++ b/Aegis/Tests/e2e_libfuncs/i64_aegis/i64_eq.sierra
@@ -1,9 +1,11 @@
 type i64 = i64 [storable: true, drop: true, dup: true, zero_sized: false];
 type Unit = Struct<ut@Tuple> [storable: true, drop: true, dup: true, zero_sized: true];
 type core::bool = Enum<ut@core::bool, Unit, Unit> [storable: true, drop: true, dup: true, zero_sized: false];
+type Const<i64, 12> = Const<i64, 12> [storable: false, drop: false, dup: false, zero_sized: false];
+type Const<i64, 11> = Const<i64, 11> [storable: false, drop: false, dup: false, zero_sized: false];
 
-libfunc i64_const<11> = i64_const<11>;
-libfunc i64_const<12> = i64_const<12>;
+libfunc const_as_immediate<Const<i64, 11>> = const_as_immediate<Const<i64, 11>>;
+libfunc const_as_immediate<Const<i64, 12>> = const_as_immediate<Const<i64, 12>>;
 libfunc store_temp<i64> = store_temp<i64>;
 libfunc i64_eq = i64_eq;
 libfunc branch_align = branch_align;
@@ -12,19 +14,21 @@ libfunc enum_init<core::bool, 0> = enum_init<core::bool, 0>;
 libfunc store_temp<core::bool> = store_temp<core::bool>;
 libfunc enum_init<core::bool, 1> = enum_init<core::bool, 1>;
 
-i64_const<11>() -> ([0]); // 0
-i64_const<12>() -> ([1]); // 1
-store_temp<i64>([0]) -> ([0]); // 2
-i64_eq([0], [1]) { fallthrough() 9() }; // 3
-branch_align() -> (); // 4
-struct_construct<Unit>() -> ([2]); // 5
-enum_init<core::bool, 0>([2]) -> ([3]); // 6
-store_temp<core::bool>([3]) -> ([3]); // 7
-return([3]); // 8
-branch_align() -> (); // 9
-struct_construct<Unit>() -> ([4]); // 10
-enum_init<core::bool, 1>([4]) -> ([5]); // 11
-store_temp<core::bool>([5]) -> ([5]); // 12
-return([5]); // 13
+F0:
+const_as_immediate<Const<i64, 11>>() -> ([0]);
+const_as_immediate<Const<i64, 12>>() -> ([1]);
+store_temp<i64>([0]) -> ([0]);
+i64_eq([0], [1]) { fallthrough() F0_B0() };
+branch_align() -> ();
+struct_construct<Unit>() -> ([2]);
+enum_init<core::bool, 0>([2]) -> ([3]);
+store_temp<core::bool>([3]) -> ([3]);
+return([3]);
+F0_B0:
+branch_align() -> ();
+struct_construct<Unit>() -> ([4]);
+enum_init<core::bool, 1>([4]) -> ([5]);
+store_temp<core::bool>([5]) -> ([5]);
+return([5]);
 
-test::foo@0() -> (core::bool);
+test::foo@F0() -> (core::bool);

--- a/Aegis/Tests/e2e_libfuncs/i64_aegis/i64_overflowing_add_impl.sierra
+++ b/Aegis/Tests/e2e_libfuncs/i64_aegis/i64_overflowing_add_impl.sierra
@@ -10,21 +10,24 @@ libfunc store_temp<core::integer::SignedIntegerResult::<core::integer::i64>> = s
 libfunc enum_init<core::integer::SignedIntegerResult::<core::integer::i64>, 1> = enum_init<core::integer::SignedIntegerResult::<core::integer::i64>, 1>;
 libfunc enum_init<core::integer::SignedIntegerResult::<core::integer::i64>, 2> = enum_init<core::integer::SignedIntegerResult::<core::integer::i64>, 2>;
 
-i64_overflowing_add_impl([0], [1], [2]) { fallthrough([3], [4]) 6([5], [6]) 11([7], [8]) }; // 0
-branch_align() -> (); // 1
-enum_init<core::integer::SignedIntegerResult::<core::integer::i64>, 0>([4]) -> ([9]); // 2
-store_temp<RangeCheck>([3]) -> ([3]); // 3
-store_temp<core::integer::SignedIntegerResult::<core::integer::i64>>([9]) -> ([9]); // 4
-return([3], [9]); // 5
-branch_align() -> (); // 6
-enum_init<core::integer::SignedIntegerResult::<core::integer::i64>, 1>([6]) -> ([10]); // 7
-store_temp<RangeCheck>([5]) -> ([5]); // 8
-store_temp<core::integer::SignedIntegerResult::<core::integer::i64>>([10]) -> ([10]); // 9
-return([5], [10]); // 10
-branch_align() -> (); // 11
-enum_init<core::integer::SignedIntegerResult::<core::integer::i64>, 2>([8]) -> ([11]); // 12
-store_temp<RangeCheck>([7]) -> ([7]); // 13
-store_temp<core::integer::SignedIntegerResult::<core::integer::i64>>([11]) -> ([11]); // 14
-return([7], [11]); // 15
+F0:
+i64_overflowing_add_impl([0], [1], [2]) { fallthrough([3], [4]) F0_B0([5], [6]) F0_B1([7], [8]) };
+branch_align() -> ();
+enum_init<core::integer::SignedIntegerResult::<core::integer::i64>, 0>([4]) -> ([9]);
+store_temp<RangeCheck>([3]) -> ([3]);
+store_temp<core::integer::SignedIntegerResult::<core::integer::i64>>([9]) -> ([9]);
+return([3], [9]);
+F0_B0:
+branch_align() -> ();
+enum_init<core::integer::SignedIntegerResult::<core::integer::i64>, 1>([6]) -> ([10]);
+store_temp<RangeCheck>([5]) -> ([5]);
+store_temp<core::integer::SignedIntegerResult::<core::integer::i64>>([10]) -> ([10]);
+return([5], [10]);
+F0_B1:
+branch_align() -> ();
+enum_init<core::integer::SignedIntegerResult::<core::integer::i64>, 2>([8]) -> ([11]);
+store_temp<RangeCheck>([7]) -> ([7]);
+store_temp<core::integer::SignedIntegerResult::<core::integer::i64>>([11]) -> ([11]);
+return([7], [11]);
 
-test::foo@0([0]: RangeCheck, [1]: i64, [2]: i64) -> (RangeCheck, core::integer::SignedIntegerResult::<core::integer::i64>);
+test::foo@F0([0]: RangeCheck, [1]: i64, [2]: i64) -> (RangeCheck, core::integer::SignedIntegerResult::<core::integer::i64>);

--- a/Aegis/Tests/e2e_libfuncs/i64_aegis/i64_overflowing_sub_impl.sierra
+++ b/Aegis/Tests/e2e_libfuncs/i64_aegis/i64_overflowing_sub_impl.sierra
@@ -10,21 +10,24 @@ libfunc store_temp<core::integer::SignedIntegerResult::<core::integer::i64>> = s
 libfunc enum_init<core::integer::SignedIntegerResult::<core::integer::i64>, 1> = enum_init<core::integer::SignedIntegerResult::<core::integer::i64>, 1>;
 libfunc enum_init<core::integer::SignedIntegerResult::<core::integer::i64>, 2> = enum_init<core::integer::SignedIntegerResult::<core::integer::i64>, 2>;
 
-i64_overflowing_sub_impl([0], [1], [2]) { fallthrough([3], [4]) 6([5], [6]) 11([7], [8]) }; // 0
-branch_align() -> (); // 1
-enum_init<core::integer::SignedIntegerResult::<core::integer::i64>, 0>([4]) -> ([9]); // 2
-store_temp<RangeCheck>([3]) -> ([3]); // 3
-store_temp<core::integer::SignedIntegerResult::<core::integer::i64>>([9]) -> ([9]); // 4
-return([3], [9]); // 5
-branch_align() -> (); // 6
-enum_init<core::integer::SignedIntegerResult::<core::integer::i64>, 1>([6]) -> ([10]); // 7
-store_temp<RangeCheck>([5]) -> ([5]); // 8
-store_temp<core::integer::SignedIntegerResult::<core::integer::i64>>([10]) -> ([10]); // 9
-return([5], [10]); // 10
-branch_align() -> (); // 11
-enum_init<core::integer::SignedIntegerResult::<core::integer::i64>, 2>([8]) -> ([11]); // 12
-store_temp<RangeCheck>([7]) -> ([7]); // 13
-store_temp<core::integer::SignedIntegerResult::<core::integer::i64>>([11]) -> ([11]); // 14
-return([7], [11]); // 15
+F0:
+i64_overflowing_sub_impl([0], [1], [2]) { fallthrough([3], [4]) F0_B0([5], [6]) F0_B1([7], [8]) };
+branch_align() -> ();
+enum_init<core::integer::SignedIntegerResult::<core::integer::i64>, 0>([4]) -> ([9]);
+store_temp<RangeCheck>([3]) -> ([3]);
+store_temp<core::integer::SignedIntegerResult::<core::integer::i64>>([9]) -> ([9]);
+return([3], [9]);
+F0_B0:
+branch_align() -> ();
+enum_init<core::integer::SignedIntegerResult::<core::integer::i64>, 1>([6]) -> ([10]);
+store_temp<RangeCheck>([5]) -> ([5]);
+store_temp<core::integer::SignedIntegerResult::<core::integer::i64>>([10]) -> ([10]);
+return([5], [10]);
+F0_B1:
+branch_align() -> ();
+enum_init<core::integer::SignedIntegerResult::<core::integer::i64>, 2>([8]) -> ([11]);
+store_temp<RangeCheck>([7]) -> ([7]);
+store_temp<core::integer::SignedIntegerResult::<core::integer::i64>>([11]) -> ([11]);
+return([7], [11]);
 
-test::foo@0([0]: RangeCheck, [1]: i64, [2]: i64) -> (RangeCheck, core::integer::SignedIntegerResult::<core::integer::i64>);
+test::foo@F0([0]: RangeCheck, [1]: i64, [2]: i64) -> (RangeCheck, core::integer::SignedIntegerResult::<core::integer::i64>);

--- a/Aegis/Tests/e2e_libfuncs/i64_aegis/i64_to_felt252.sierra
+++ b/Aegis/Tests/e2e_libfuncs/i64_aegis/i64_to_felt252.sierra
@@ -4,8 +4,9 @@ type felt252 = felt252 [storable: true, drop: true, dup: true, zero_sized: false
 libfunc i64_to_felt252 = i64_to_felt252;
 libfunc store_temp<felt252> = store_temp<felt252>;
 
-i64_to_felt252([0]) -> ([1]); // 0
-store_temp<felt252>([1]) -> ([1]); // 1
-return([1]); // 2
+F0:
+i64_to_felt252([0]) -> ([1]);
+store_temp<felt252>([1]) -> ([1]);
+return([1]);
 
-test::foo@0([0]: i64) -> (felt252);
+test::foo@F0([0]: i64) -> (felt252);

--- a/Aegis/Tests/e2e_libfuncs/i64_aegis/i64_try_from_felt252.sierra
+++ b/Aegis/Tests/e2e_libfuncs/i64_aegis/i64_try_from_felt252.sierra
@@ -12,17 +12,19 @@ libfunc store_temp<core::option::Option::<core::integer::i64>> = store_temp<core
 libfunc struct_construct<Unit> = struct_construct<Unit>;
 libfunc enum_init<core::option::Option::<core::integer::i64>, 1> = enum_init<core::option::Option::<core::integer::i64>, 1>;
 
-i64_try_from_felt252([0], [1]) { fallthrough([2], [3]) 6([4]) }; // 0
-branch_align() -> (); // 1
-enum_init<core::option::Option::<core::integer::i64>, 0>([3]) -> ([5]); // 2
-store_temp<RangeCheck>([2]) -> ([2]); // 3
-store_temp<core::option::Option::<core::integer::i64>>([5]) -> ([5]); // 4
-return([2], [5]); // 5
-branch_align() -> (); // 6
-struct_construct<Unit>() -> ([6]); // 7
-enum_init<core::option::Option::<core::integer::i64>, 1>([6]) -> ([7]); // 8
-store_temp<RangeCheck>([4]) -> ([4]); // 9
-store_temp<core::option::Option::<core::integer::i64>>([7]) -> ([7]); // 10
-return([4], [7]); // 11
+F0:
+i64_try_from_felt252([0], [1]) { fallthrough([2], [3]) F0_B0([4]) };
+branch_align() -> ();
+enum_init<core::option::Option::<core::integer::i64>, 0>([3]) -> ([5]);
+store_temp<RangeCheck>([2]) -> ([2]);
+store_temp<core::option::Option::<core::integer::i64>>([5]) -> ([5]);
+return([2], [5]);
+F0_B0:
+branch_align() -> ();
+struct_construct<Unit>() -> ([6]);
+enum_init<core::option::Option::<core::integer::i64>, 1>([6]) -> ([7]);
+store_temp<RangeCheck>([4]) -> ([4]);
+store_temp<core::option::Option::<core::integer::i64>>([7]) -> ([7]);
+return([4], [7]);
 
-test::foo@0([0]: RangeCheck, [1]: felt252) -> (RangeCheck, core::option::Option::<core::integer::i64>);
+test::foo@F0([0]: RangeCheck, [1]: felt252) -> (RangeCheck, core::option::Option::<core::integer::i64>);

--- a/Aegis/Tests/e2e_libfuncs/i64_aegis/i64_wide_mul.sierra
+++ b/Aegis/Tests/e2e_libfuncs/i64_aegis/i64_wide_mul.sierra
@@ -4,8 +4,9 @@ type i128 = i128 [storable: true, drop: true, dup: true, zero_sized: false];
 libfunc i64_wide_mul = i64_wide_mul;
 libfunc store_temp<i128> = store_temp<i128>;
 
-i64_wide_mul([0], [1]) -> ([2]); // 0
-store_temp<i128>([2]) -> ([2]); // 1
-return([2]); // 2
+F0:
+i64_wide_mul([0], [1]) -> ([2]);
+store_temp<i128>([2]) -> ([2]);
+return([2]);
 
-test::foo@0([0]: i64, [1]: i64) -> (i128);
+test::foo@F0([0]: i64, [1]: i64) -> (i128);

--- a/Aegis/Tests/e2e_libfuncs/i8_aegis/i8_diff.sierra
+++ b/Aegis/Tests/e2e_libfuncs/i8_aegis/i8_diff.sierra
@@ -10,16 +10,18 @@ libfunc store_temp<RangeCheck> = store_temp<RangeCheck>;
 libfunc store_temp<core::result::Result::<core::integer::u8, core::integer::u8>> = store_temp<core::result::Result::<core::integer::u8, core::integer::u8>>;
 libfunc enum_init<core::result::Result::<core::integer::u8, core::integer::u8>, 1> = enum_init<core::result::Result::<core::integer::u8, core::integer::u8>, 1>;
 
-i8_diff([0], [1], [2]) { fallthrough([3], [4]) 6([5], [6]) }; // 0
-branch_align() -> (); // 1
-enum_init<core::result::Result::<core::integer::u8, core::integer::u8>, 0>([4]) -> ([7]); // 2
-store_temp<RangeCheck>([3]) -> ([3]); // 3
-store_temp<core::result::Result::<core::integer::u8, core::integer::u8>>([7]) -> ([7]); // 4
-return([3], [7]); // 5
-branch_align() -> (); // 6
-enum_init<core::result::Result::<core::integer::u8, core::integer::u8>, 1>([6]) -> ([8]); // 7
-store_temp<RangeCheck>([5]) -> ([5]); // 8
-store_temp<core::result::Result::<core::integer::u8, core::integer::u8>>([8]) -> ([8]); // 9
-return([5], [8]); // 10
+F0:
+i8_diff([0], [1], [2]) { fallthrough([3], [4]) F0_B0([5], [6]) };
+branch_align() -> ();
+enum_init<core::result::Result::<core::integer::u8, core::integer::u8>, 0>([4]) -> ([7]);
+store_temp<RangeCheck>([3]) -> ([3]);
+store_temp<core::result::Result::<core::integer::u8, core::integer::u8>>([7]) -> ([7]);
+return([3], [7]);
+F0_B0:
+branch_align() -> ();
+enum_init<core::result::Result::<core::integer::u8, core::integer::u8>, 1>([6]) -> ([8]);
+store_temp<RangeCheck>([5]) -> ([5]);
+store_temp<core::result::Result::<core::integer::u8, core::integer::u8>>([8]) -> ([8]);
+return([5], [8]);
 
-test::foo@0([0]: RangeCheck, [1]: i8, [2]: i8) -> (RangeCheck, core::result::Result::<core::integer::u8, core::integer::u8>);
+test::foo@F0([0]: RangeCheck, [1]: i8, [2]: i8) -> (RangeCheck, core::result::Result::<core::integer::u8, core::integer::u8>);

--- a/Aegis/Tests/e2e_libfuncs/i8_aegis/i8_eq.sierra
+++ b/Aegis/Tests/e2e_libfuncs/i8_aegis/i8_eq.sierra
@@ -1,9 +1,11 @@
 type i8 = i8 [storable: true, drop: true, dup: true, zero_sized: false];
 type Unit = Struct<ut@Tuple> [storable: true, drop: true, dup: true, zero_sized: true];
 type core::bool = Enum<ut@core::bool, Unit, Unit> [storable: true, drop: true, dup: true, zero_sized: false];
+type Const<i8, 12> = Const<i8, 12> [storable: false, drop: false, dup: false, zero_sized: false];
+type Const<i8, 11> = Const<i8, 11> [storable: false, drop: false, dup: false, zero_sized: false];
 
-libfunc i8_const<11> = i8_const<11>;
-libfunc i8_const<12> = i8_const<12>;
+libfunc const_as_immediate<Const<i8, 11>> = const_as_immediate<Const<i8, 11>>;
+libfunc const_as_immediate<Const<i8, 12>> = const_as_immediate<Const<i8, 12>>;
 libfunc store_temp<i8> = store_temp<i8>;
 libfunc i8_eq = i8_eq;
 libfunc branch_align = branch_align;
@@ -12,19 +14,21 @@ libfunc enum_init<core::bool, 0> = enum_init<core::bool, 0>;
 libfunc store_temp<core::bool> = store_temp<core::bool>;
 libfunc enum_init<core::bool, 1> = enum_init<core::bool, 1>;
 
-i8_const<11>() -> ([0]); // 0
-i8_const<12>() -> ([1]); // 1
-store_temp<i8>([0]) -> ([0]); // 2
-i8_eq([0], [1]) { fallthrough() 9() }; // 3
-branch_align() -> (); // 4
-struct_construct<Unit>() -> ([2]); // 5
-enum_init<core::bool, 0>([2]) -> ([3]); // 6
-store_temp<core::bool>([3]) -> ([3]); // 7
-return([3]); // 8
-branch_align() -> (); // 9
-struct_construct<Unit>() -> ([4]); // 10
-enum_init<core::bool, 1>([4]) -> ([5]); // 11
-store_temp<core::bool>([5]) -> ([5]); // 12
-return([5]); // 13
+F0:
+const_as_immediate<Const<i8, 11>>() -> ([0]);
+const_as_immediate<Const<i8, 12>>() -> ([1]);
+store_temp<i8>([0]) -> ([0]);
+i8_eq([0], [1]) { fallthrough() F0_B0() };
+branch_align() -> ();
+struct_construct<Unit>() -> ([2]);
+enum_init<core::bool, 0>([2]) -> ([3]);
+store_temp<core::bool>([3]) -> ([3]);
+return([3]);
+F0_B0:
+branch_align() -> ();
+struct_construct<Unit>() -> ([4]);
+enum_init<core::bool, 1>([4]) -> ([5]);
+store_temp<core::bool>([5]) -> ([5]);
+return([5]);
 
-test::foo@0() -> (core::bool);
+test::foo@F0() -> (core::bool);

--- a/Aegis/Tests/e2e_libfuncs/i8_aegis/i8_overflowing_add_impl.sierra
+++ b/Aegis/Tests/e2e_libfuncs/i8_aegis/i8_overflowing_add_impl.sierra
@@ -10,21 +10,24 @@ libfunc store_temp<core::integer::SignedIntegerResult::<core::integer::i8>> = st
 libfunc enum_init<core::integer::SignedIntegerResult::<core::integer::i8>, 1> = enum_init<core::integer::SignedIntegerResult::<core::integer::i8>, 1>;
 libfunc enum_init<core::integer::SignedIntegerResult::<core::integer::i8>, 2> = enum_init<core::integer::SignedIntegerResult::<core::integer::i8>, 2>;
 
-i8_overflowing_add_impl([0], [1], [2]) { fallthrough([3], [4]) 6([5], [6]) 11([7], [8]) }; // 0
-branch_align() -> (); // 1
-enum_init<core::integer::SignedIntegerResult::<core::integer::i8>, 0>([4]) -> ([9]); // 2
-store_temp<RangeCheck>([3]) -> ([3]); // 3
-store_temp<core::integer::SignedIntegerResult::<core::integer::i8>>([9]) -> ([9]); // 4
-return([3], [9]); // 5
-branch_align() -> (); // 6
-enum_init<core::integer::SignedIntegerResult::<core::integer::i8>, 1>([6]) -> ([10]); // 7
-store_temp<RangeCheck>([5]) -> ([5]); // 8
-store_temp<core::integer::SignedIntegerResult::<core::integer::i8>>([10]) -> ([10]); // 9
-return([5], [10]); // 10
-branch_align() -> (); // 11
-enum_init<core::integer::SignedIntegerResult::<core::integer::i8>, 2>([8]) -> ([11]); // 12
-store_temp<RangeCheck>([7]) -> ([7]); // 13
-store_temp<core::integer::SignedIntegerResult::<core::integer::i8>>([11]) -> ([11]); // 14
-return([7], [11]); // 15
+F0:
+i8_overflowing_add_impl([0], [1], [2]) { fallthrough([3], [4]) F0_B0([5], [6]) F0_B1([7], [8]) };
+branch_align() -> ();
+enum_init<core::integer::SignedIntegerResult::<core::integer::i8>, 0>([4]) -> ([9]);
+store_temp<RangeCheck>([3]) -> ([3]);
+store_temp<core::integer::SignedIntegerResult::<core::integer::i8>>([9]) -> ([9]);
+return([3], [9]);
+F0_B0:
+branch_align() -> ();
+enum_init<core::integer::SignedIntegerResult::<core::integer::i8>, 1>([6]) -> ([10]);
+store_temp<RangeCheck>([5]) -> ([5]);
+store_temp<core::integer::SignedIntegerResult::<core::integer::i8>>([10]) -> ([10]);
+return([5], [10]);
+F0_B1:
+branch_align() -> ();
+enum_init<core::integer::SignedIntegerResult::<core::integer::i8>, 2>([8]) -> ([11]);
+store_temp<RangeCheck>([7]) -> ([7]);
+store_temp<core::integer::SignedIntegerResult::<core::integer::i8>>([11]) -> ([11]);
+return([7], [11]);
 
-test::foo@0([0]: RangeCheck, [1]: i8, [2]: i8) -> (RangeCheck, core::integer::SignedIntegerResult::<core::integer::i8>);
+test::foo@F0([0]: RangeCheck, [1]: i8, [2]: i8) -> (RangeCheck, core::integer::SignedIntegerResult::<core::integer::i8>);

--- a/Aegis/Tests/e2e_libfuncs/i8_aegis/i8_overflowing_sub_impl.sierra
+++ b/Aegis/Tests/e2e_libfuncs/i8_aegis/i8_overflowing_sub_impl.sierra
@@ -10,21 +10,24 @@ libfunc store_temp<core::integer::SignedIntegerResult::<core::integer::i8>> = st
 libfunc enum_init<core::integer::SignedIntegerResult::<core::integer::i8>, 1> = enum_init<core::integer::SignedIntegerResult::<core::integer::i8>, 1>;
 libfunc enum_init<core::integer::SignedIntegerResult::<core::integer::i8>, 2> = enum_init<core::integer::SignedIntegerResult::<core::integer::i8>, 2>;
 
-i8_overflowing_sub_impl([0], [1], [2]) { fallthrough([3], [4]) 6([5], [6]) 11([7], [8]) }; // 0
-branch_align() -> (); // 1
-enum_init<core::integer::SignedIntegerResult::<core::integer::i8>, 0>([4]) -> ([9]); // 2
-store_temp<RangeCheck>([3]) -> ([3]); // 3
-store_temp<core::integer::SignedIntegerResult::<core::integer::i8>>([9]) -> ([9]); // 4
-return([3], [9]); // 5
-branch_align() -> (); // 6
-enum_init<core::integer::SignedIntegerResult::<core::integer::i8>, 1>([6]) -> ([10]); // 7
-store_temp<RangeCheck>([5]) -> ([5]); // 8
-store_temp<core::integer::SignedIntegerResult::<core::integer::i8>>([10]) -> ([10]); // 9
-return([5], [10]); // 10
-branch_align() -> (); // 11
-enum_init<core::integer::SignedIntegerResult::<core::integer::i8>, 2>([8]) -> ([11]); // 12
-store_temp<RangeCheck>([7]) -> ([7]); // 13
-store_temp<core::integer::SignedIntegerResult::<core::integer::i8>>([11]) -> ([11]); // 14
-return([7], [11]); // 15
+F0:
+i8_overflowing_sub_impl([0], [1], [2]) { fallthrough([3], [4]) F0_B0([5], [6]) F0_B1([7], [8]) };
+branch_align() -> ();
+enum_init<core::integer::SignedIntegerResult::<core::integer::i8>, 0>([4]) -> ([9]);
+store_temp<RangeCheck>([3]) -> ([3]);
+store_temp<core::integer::SignedIntegerResult::<core::integer::i8>>([9]) -> ([9]);
+return([3], [9]);
+F0_B0:
+branch_align() -> ();
+enum_init<core::integer::SignedIntegerResult::<core::integer::i8>, 1>([6]) -> ([10]);
+store_temp<RangeCheck>([5]) -> ([5]);
+store_temp<core::integer::SignedIntegerResult::<core::integer::i8>>([10]) -> ([10]);
+return([5], [10]);
+F0_B1:
+branch_align() -> ();
+enum_init<core::integer::SignedIntegerResult::<core::integer::i8>, 2>([8]) -> ([11]);
+store_temp<RangeCheck>([7]) -> ([7]);
+store_temp<core::integer::SignedIntegerResult::<core::integer::i8>>([11]) -> ([11]);
+return([7], [11]);
 
-test::foo@0([0]: RangeCheck, [1]: i8, [2]: i8) -> (RangeCheck, core::integer::SignedIntegerResult::<core::integer::i8>);
+test::foo@F0([0]: RangeCheck, [1]: i8, [2]: i8) -> (RangeCheck, core::integer::SignedIntegerResult::<core::integer::i8>);

--- a/Aegis/Tests/e2e_libfuncs/i8_aegis/i8_to_felt252.sierra
+++ b/Aegis/Tests/e2e_libfuncs/i8_aegis/i8_to_felt252.sierra
@@ -4,8 +4,9 @@ type felt252 = felt252 [storable: true, drop: true, dup: true, zero_sized: false
 libfunc i8_to_felt252 = i8_to_felt252;
 libfunc store_temp<felt252> = store_temp<felt252>;
 
-i8_to_felt252([0]) -> ([1]); // 0
-store_temp<felt252>([1]) -> ([1]); // 1
-return([1]); // 2
+F0:
+i8_to_felt252([0]) -> ([1]);
+store_temp<felt252>([1]) -> ([1]);
+return([1]);
 
-test::foo@0([0]: i8) -> (felt252);
+test::foo@F0([0]: i8) -> (felt252);

--- a/Aegis/Tests/e2e_libfuncs/i8_aegis/i8_try_from_felt252.sierra
+++ b/Aegis/Tests/e2e_libfuncs/i8_aegis/i8_try_from_felt252.sierra
@@ -12,17 +12,19 @@ libfunc store_temp<core::option::Option::<core::integer::i8>> = store_temp<core:
 libfunc struct_construct<Unit> = struct_construct<Unit>;
 libfunc enum_init<core::option::Option::<core::integer::i8>, 1> = enum_init<core::option::Option::<core::integer::i8>, 1>;
 
-i8_try_from_felt252([0], [1]) { fallthrough([2], [3]) 6([4]) }; // 0
-branch_align() -> (); // 1
-enum_init<core::option::Option::<core::integer::i8>, 0>([3]) -> ([5]); // 2
-store_temp<RangeCheck>([2]) -> ([2]); // 3
-store_temp<core::option::Option::<core::integer::i8>>([5]) -> ([5]); // 4
-return([2], [5]); // 5
-branch_align() -> (); // 6
-struct_construct<Unit>() -> ([6]); // 7
-enum_init<core::option::Option::<core::integer::i8>, 1>([6]) -> ([7]); // 8
-store_temp<RangeCheck>([4]) -> ([4]); // 9
-store_temp<core::option::Option::<core::integer::i8>>([7]) -> ([7]); // 10
-return([4], [7]); // 11
+F0:
+i8_try_from_felt252([0], [1]) { fallthrough([2], [3]) F0_B0([4]) };
+branch_align() -> ();
+enum_init<core::option::Option::<core::integer::i8>, 0>([3]) -> ([5]);
+store_temp<RangeCheck>([2]) -> ([2]);
+store_temp<core::option::Option::<core::integer::i8>>([5]) -> ([5]);
+return([2], [5]);
+F0_B0:
+branch_align() -> ();
+struct_construct<Unit>() -> ([6]);
+enum_init<core::option::Option::<core::integer::i8>, 1>([6]) -> ([7]);
+store_temp<RangeCheck>([4]) -> ([4]);
+store_temp<core::option::Option::<core::integer::i8>>([7]) -> ([7]);
+return([4], [7]);
 
-test::foo@0([0]: RangeCheck, [1]: felt252) -> (RangeCheck, core::option::Option::<core::integer::i8>);
+test::foo@F0([0]: RangeCheck, [1]: felt252) -> (RangeCheck, core::option::Option::<core::integer::i8>);

--- a/Aegis/Tests/e2e_libfuncs/i8_aegis/i8_wide_mul.sierra
+++ b/Aegis/Tests/e2e_libfuncs/i8_aegis/i8_wide_mul.sierra
@@ -4,8 +4,9 @@ type i16 = i16 [storable: true, drop: true, dup: true, zero_sized: false];
 libfunc i8_wide_mul = i8_wide_mul;
 libfunc store_temp<i16> = store_temp<i16>;
 
-i8_wide_mul([0], [1]) -> ([2]); // 0
-store_temp<i16>([2]) -> ([2]); // 1
-return([2]); // 2
+F0:
+i8_wide_mul([0], [1]) -> ([2]);
+store_temp<i16>([2]) -> ([2]);
+return([2]);
 
-test::foo@0([0]: i8, [1]: i8) -> (i16);
+test::foo@F0([0]: i8, [1]: i8) -> (i16);

--- a/Aegis/Tests/e2e_libfuncs/nullable_aegis/match_nullable.sierra
+++ b/Aegis/Tests/e2e_libfuncs/nullable_aegis/match_nullable.sierra
@@ -1,19 +1,21 @@
 type Nullable<felt252> = Nullable<felt252> [storable: true, drop: true, dup: true, zero_sized: false];
-type Box<felt252> = Box<felt252> [storable: true, drop: true, dup: true, zero_sized: false];
 type felt252 = felt252 [storable: true, drop: true, dup: true, zero_sized: false];
+type Box<felt252> = Box<felt252> [storable: true, drop: true, dup: true, zero_sized: false];
 
 libfunc match_nullable<felt252> = match_nullable<felt252>;
 libfunc branch_align = branch_align;
 libfunc store_temp<Box<felt252>> = store_temp<Box<felt252>>;
 libfunc drop<Box<felt252>> = drop<Box<felt252>>;
 
-match_nullable<felt252>([0]) { fallthrough() 4([2]) }; // 0
-branch_align() -> (); // 1
-store_temp<Box<felt252>>([1]) -> ([1]); // 2
-return([1]); // 3
-branch_align() -> (); // 4
-drop<Box<felt252>>([1]) -> (); // 5
-store_temp<Box<felt252>>([2]) -> ([2]); // 6
-return([2]); // 7
+F0:
+match_nullable<felt252>([0]) { fallthrough() F0_B0([2]) };
+branch_align() -> ();
+store_temp<Box<felt252>>([1]) -> ([1]);
+return([1]);
+F0_B0:
+branch_align() -> ();
+drop<Box<felt252>>([1]) -> ();
+store_temp<Box<felt252>>([2]) -> ([2]);
+return([2]);
 
-test::foo@0([0]: Nullable<felt252>, [1]: Box<felt252>) -> (Box<felt252>);
+test::foo@F0([0]: Nullable<felt252>, [1]: Box<felt252>) -> (Box<felt252>);

--- a/Aegis/Tests/e2e_libfuncs/nullable_aegis/null.sierra
+++ b/Aegis/Tests/e2e_libfuncs/nullable_aegis/null.sierra
@@ -4,8 +4,9 @@ type felt252 = felt252 [storable: true, drop: true, dup: true, zero_sized: false
 libfunc null<felt252> = null<felt252>;
 libfunc store_temp<Nullable<felt252>> = store_temp<Nullable<felt252>>;
 
-null<felt252>() -> ([0]); // 0
-store_temp<Nullable<felt252>>([0]) -> ([0]); // 1
-return([0]); // 2
+F0:
+null<felt252>() -> ([0]);
+store_temp<Nullable<felt252>>([0]) -> ([0]);
+return([0]);
 
-test::foo@0() -> (Nullable<felt252>);
+test::foo@F0() -> (Nullable<felt252>);

--- a/Aegis/Tests/e2e_libfuncs/nullable_aegis/nullable snapshot matching.sierra
+++ b/Aegis/Tests/e2e_libfuncs/nullable_aegis/nullable snapshot matching.sierra
@@ -1,8 +1,8 @@
 type Nullable<Array<felt252>> = Nullable<Array<felt252>> [storable: true, drop: true, dup: false, zero_sized: false];
 type Snapshot<Nullable<Array<felt252>>> = Snapshot<Nullable<Array<felt252>>> [storable: true, drop: true, dup: true, zero_sized: false];
-type Box<Snapshot<Array<felt252>>> = Box<Snapshot<Array<felt252>>> [storable: true, drop: true, dup: true, zero_sized: false];
 type Array<felt252> = Array<felt252> [storable: true, drop: true, dup: false, zero_sized: false];
 type Snapshot<Array<felt252>> = Snapshot<Array<felt252>> [storable: true, drop: true, dup: true, zero_sized: false];
+type Box<Snapshot<Array<felt252>>> = Box<Snapshot<Array<felt252>>> [storable: true, drop: true, dup: true, zero_sized: false];
 type felt252 = felt252 [storable: true, drop: true, dup: true, zero_sized: false];
 type Nullable<Snapshot<Array<felt252>>> = Nullable<Snapshot<Array<felt252>>> [storable: true, drop: true, dup: true, zero_sized: false];
 
@@ -12,14 +12,16 @@ libfunc branch_align = branch_align;
 libfunc store_temp<Box<Snapshot<Array<felt252>>>> = store_temp<Box<Snapshot<Array<felt252>>>>;
 libfunc drop<Box<Snapshot<Array<felt252>>>> = drop<Box<Snapshot<Array<felt252>>>>;
 
-nullable_forward_snapshot<Array<felt252>>([0]) -> ([2]); // 0
-match_nullable<Snapshot<Array<felt252>>>([2]) { fallthrough() 5([3]) }; // 1
-branch_align() -> (); // 2
-store_temp<Box<Snapshot<Array<felt252>>>>([1]) -> ([1]); // 3
-return([1]); // 4
-branch_align() -> (); // 5
-drop<Box<Snapshot<Array<felt252>>>>([1]) -> (); // 6
-store_temp<Box<Snapshot<Array<felt252>>>>([3]) -> ([3]); // 7
-return([3]); // 8
+F0:
+nullable_forward_snapshot<Array<felt252>>([0]) -> ([2]);
+match_nullable<Snapshot<Array<felt252>>>([2]) { fallthrough() F0_B0([3]) };
+branch_align() -> ();
+store_temp<Box<Snapshot<Array<felt252>>>>([1]) -> ([1]);
+return([1]);
+F0_B0:
+branch_align() -> ();
+drop<Box<Snapshot<Array<felt252>>>>([1]) -> ();
+store_temp<Box<Snapshot<Array<felt252>>>>([3]) -> ([3]);
+return([3]);
 
-test::foo@0([0]: Snapshot<Nullable<Array<felt252>>>, [1]: Box<Snapshot<Array<felt252>>>) -> (Box<Snapshot<Array<felt252>>>);
+test::foo@F0([0]: Snapshot<Nullable<Array<felt252>>>, [1]: Box<Snapshot<Array<felt252>>>) -> (Box<Snapshot<Array<felt252>>>);

--- a/Aegis/Tests/e2e_libfuncs/nullable_aegis/nullable.sierra
+++ b/Aegis/Tests/e2e_libfuncs/nullable_aegis/nullable.sierra
@@ -1,30 +1,32 @@
 type Unit = Struct<ut@Tuple> [storable: true, drop: true, dup: true, zero_sized: true];
+type Const<felt252, 1> = Const<felt252, 1> [storable: false, drop: false, dup: false, zero_sized: false];
+type Const<felt252, 0> = Const<felt252, 0> [storable: false, drop: false, dup: false, zero_sized: false];
 type felt252 = felt252 [storable: true, drop: true, dup: true, zero_sized: false];
 type Nullable<Unit> = Nullable<Unit> [storable: true, drop: true, dup: true, zero_sized: false];
 type Box<Unit> = Box<Unit> [storable: true, drop: true, dup: true, zero_sized: false];
 
-libfunc struct_construct<Unit> = struct_construct<Unit>;
 libfunc into_box<Unit> = into_box<Unit>;
 libfunc nullable_from_box<Unit> = nullable_from_box<Unit>;
 libfunc match_nullable<Unit> = match_nullable<Unit>;
 libfunc branch_align = branch_align;
-libfunc felt252_const<0> = felt252_const<0>;
+libfunc const_as_immediate<Const<felt252, 0>> = const_as_immediate<Const<felt252, 0>>;
 libfunc store_temp<felt252> = store_temp<felt252>;
 libfunc drop<Box<Unit>> = drop<Box<Unit>>;
-libfunc felt252_const<1> = felt252_const<1>;
+libfunc const_as_immediate<Const<felt252, 1>> = const_as_immediate<Const<felt252, 1>>;
 
-struct_construct<Unit>() -> ([0]); // 0
-into_box<Unit>([0]) -> ([1]); // 1
-nullable_from_box<Unit>([1]) -> ([2]); // 2
-match_nullable<Unit>([2]) { fallthrough() 8([3]) }; // 3
-branch_align() -> (); // 4
-felt252_const<0>() -> ([4]); // 5
-store_temp<felt252>([4]) -> ([4]); // 6
-return([4]); // 7
-branch_align() -> (); // 8
-drop<Box<Unit>>([3]) -> (); // 9
-felt252_const<1>() -> ([5]); // 10
-store_temp<felt252>([5]) -> ([5]); // 11
-return([5]); // 12
+F0:
+into_box<Unit>([0]) -> ([1]);
+nullable_from_box<Unit>([1]) -> ([2]);
+match_nullable<Unit>([2]) { fallthrough() F0_B0([3]) };
+branch_align() -> ();
+const_as_immediate<Const<felt252, 0>>() -> ([4]);
+store_temp<felt252>([4]) -> ([4]);
+return([4]);
+F0_B0:
+branch_align() -> ();
+drop<Box<Unit>>([3]) -> ();
+const_as_immediate<Const<felt252, 1>>() -> ([5]);
+store_temp<felt252>([5]) -> ([5]);
+return([5]);
 
-test::foo@0() -> (felt252);
+test::foo@F0([0]: Unit) -> (felt252);

--- a/Aegis/Tests/e2e_libfuncs/nullable_aegis/nullable_forward_snapshot.sierra
+++ b/Aegis/Tests/e2e_libfuncs/nullable_aegis/nullable_forward_snapshot.sierra
@@ -1,15 +1,16 @@
 type Nullable<Array<felt252>> = Nullable<Array<felt252>> [storable: true, drop: true, dup: false, zero_sized: false];
 type Snapshot<Nullable<Array<felt252>>> = Snapshot<Nullable<Array<felt252>>> [storable: true, drop: true, dup: true, zero_sized: false];
-type Nullable<Snapshot<Array<felt252>>> = Nullable<Snapshot<Array<felt252>>> [storable: true, drop: true, dup: true, zero_sized: false];
 type Array<felt252> = Array<felt252> [storable: true, drop: true, dup: false, zero_sized: false];
-type Snapshot<Array<felt252>> = Snapshot<Array<felt252>> [storable: true, drop: true, dup: true, zero_sized: false];
+type Nullable<Snapshot<Array<felt252>>> = Nullable<Snapshot<Array<felt252>>> [storable: true, drop: true, dup: true, zero_sized: false];
 type felt252 = felt252 [storable: true, drop: true, dup: true, zero_sized: false];
+type Snapshot<Array<felt252>> = Snapshot<Array<felt252>> [storable: true, drop: true, dup: true, zero_sized: false];
 
 libfunc nullable_forward_snapshot<Array<felt252>> = nullable_forward_snapshot<Array<felt252>>;
 libfunc store_temp<Nullable<Snapshot<Array<felt252>>>> = store_temp<Nullable<Snapshot<Array<felt252>>>>;
 
-nullable_forward_snapshot<Array<felt252>>([0]) -> ([1]); // 0
-store_temp<Nullable<Snapshot<Array<felt252>>>>([1]) -> ([1]); // 1
-return([1]); // 2
+F0:
+nullable_forward_snapshot<Array<felt252>>([0]) -> ([1]);
+store_temp<Nullable<Snapshot<Array<felt252>>>>([1]) -> ([1]);
+return([1]);
 
-test::foo@0([0]: Snapshot<Nullable<Array<felt252>>>) -> (Nullable<Snapshot<Array<felt252>>>);
+test::foo@F0([0]: Snapshot<Nullable<Array<felt252>>>) -> (Nullable<Snapshot<Array<felt252>>>);

--- a/Aegis/Tests/e2e_libfuncs/nullable_aegis/nullable_from_box.sierra
+++ b/Aegis/Tests/e2e_libfuncs/nullable_aegis/nullable_from_box.sierra
@@ -1,12 +1,13 @@
 type Box<felt252> = Box<felt252> [storable: true, drop: true, dup: true, zero_sized: false];
-type Nullable<felt252> = Nullable<felt252> [storable: true, drop: true, dup: true, zero_sized: false];
 type felt252 = felt252 [storable: true, drop: true, dup: true, zero_sized: false];
+type Nullable<felt252> = Nullable<felt252> [storable: true, drop: true, dup: true, zero_sized: false];
 
 libfunc nullable_from_box<felt252> = nullable_from_box<felt252>;
 libfunc store_temp<Nullable<felt252>> = store_temp<Nullable<felt252>>;
 
-nullable_from_box<felt252>([0]) -> ([1]); // 0
-store_temp<Nullable<felt252>>([1]) -> ([1]); // 1
-return([1]); // 2
+F0:
+nullable_from_box<felt252>([0]) -> ([1]);
+store_temp<Nullable<felt252>>([1]) -> ([1]);
+return([1]);
 
-test::foo@0([0]: Box<felt252>) -> (Nullable<felt252>);
+test::foo@F0([0]: Box<felt252>) -> (Nullable<felt252>);

--- a/Aegis/Tests/e2e_libfuncs/poseidon_aegis/hades_permutation.sierra
+++ b/Aegis/Tests/e2e_libfuncs/poseidon_aegis/hades_permutation.sierra
@@ -7,10 +7,11 @@ libfunc struct_construct<Tuple<felt252, felt252, felt252>> = struct_construct<Tu
 libfunc store_temp<Poseidon> = store_temp<Poseidon>;
 libfunc store_temp<Tuple<felt252, felt252, felt252>> = store_temp<Tuple<felt252, felt252, felt252>>;
 
-hades_permutation([0], [1], [2], [3]) -> ([4], [5], [6], [7]); // 0
-struct_construct<Tuple<felt252, felt252, felt252>>([5], [6], [7]) -> ([8]); // 1
-store_temp<Poseidon>([4]) -> ([4]); // 2
-store_temp<Tuple<felt252, felt252, felt252>>([8]) -> ([8]); // 3
-return([4], [8]); // 4
+F0:
+hades_permutation([0], [1], [2], [3]) -> ([4], [5], [6], [7]);
+struct_construct<Tuple<felt252, felt252, felt252>>([5], [6], [7]) -> ([8]);
+store_temp<Poseidon>([4]) -> ([4]);
+store_temp<Tuple<felt252, felt252, felt252>>([8]) -> ([8]);
+return([4], [8]);
 
-test::foo@0([0]: Poseidon, [1]: felt252, [2]: felt252, [3]: felt252) -> (Poseidon, Tuple<felt252, felt252, felt252>);
+test::foo@F0([0]: Poseidon, [1]: felt252, [2]: felt252, [3]: felt252) -> (Poseidon, Tuple<felt252, felt252, felt252>);

--- a/Aegis/Tests/e2e_libfuncs/range_aegis/int_range_pop_front.sierra
+++ b/Aegis/Tests/e2e_libfuncs/range_aegis/int_range_pop_front.sierra
@@ -1,0 +1,29 @@
+type IntRange<i16> = IntRange<i16> [storable: true, drop: true, dup: true, zero_sized: false];
+type i16 = i16 [storable: true, drop: true, dup: true, zero_sized: false];
+type Tuple<IntRange<i16>, i16> = Struct<ut@Tuple, IntRange<i16>, i16> [storable: true, drop: true, dup: true, zero_sized: false];
+type Unit = Struct<ut@Tuple> [storable: true, drop: true, dup: true, zero_sized: true];
+type core::internal::OptionRev::<(core::ops::range::internal::IntRange::<core::integer::i16>, core::integer::i16)> = Enum<ut@core::internal::OptionRev::<(core::ops::range::internal::IntRange::<core::integer::i16>, core::integer::i16)>, Unit, Tuple<IntRange<i16>, i16>> [storable: true, drop: true, dup: true, zero_sized: false];
+
+libfunc int_range_pop_front<i16> = int_range_pop_front<i16>;
+libfunc branch_align = branch_align;
+libfunc struct_construct<Unit> = struct_construct<Unit>;
+libfunc enum_init<core::internal::OptionRev::<(core::ops::range::internal::IntRange::<core::integer::i16>, core::integer::i16)>, 0> = enum_init<core::internal::OptionRev::<(core::ops::range::internal::IntRange::<core::integer::i16>, core::integer::i16)>, 0>;
+libfunc store_temp<core::internal::OptionRev::<(core::ops::range::internal::IntRange::<core::integer::i16>, core::integer::i16)>> = store_temp<core::internal::OptionRev::<(core::ops::range::internal::IntRange::<core::integer::i16>, core::integer::i16)>>;
+libfunc struct_construct<Tuple<IntRange<i16>, i16>> = struct_construct<Tuple<IntRange<i16>, i16>>;
+libfunc enum_init<core::internal::OptionRev::<(core::ops::range::internal::IntRange::<core::integer::i16>, core::integer::i16)>, 1> = enum_init<core::internal::OptionRev::<(core::ops::range::internal::IntRange::<core::integer::i16>, core::integer::i16)>, 1>;
+
+F0:
+int_range_pop_front<i16>([0]) { fallthrough() F0_B0([1], [2]) };
+branch_align() -> ();
+struct_construct<Unit>() -> ([3]);
+enum_init<core::internal::OptionRev::<(core::ops::range::internal::IntRange::<core::integer::i16>, core::integer::i16)>, 0>([3]) -> ([4]);
+store_temp<core::internal::OptionRev::<(core::ops::range::internal::IntRange::<core::integer::i16>, core::integer::i16)>>([4]) -> ([4]);
+return([4]);
+F0_B0:
+branch_align() -> ();
+struct_construct<Tuple<IntRange<i16>, i16>>([1], [2]) -> ([5]);
+enum_init<core::internal::OptionRev::<(core::ops::range::internal::IntRange::<core::integer::i16>, core::integer::i16)>, 1>([5]) -> ([6]);
+store_temp<core::internal::OptionRev::<(core::ops::range::internal::IntRange::<core::integer::i16>, core::integer::i16)>>([6]) -> ([6]);
+return([6]);
+
+test::foo@F0([0]: IntRange<i16>) -> (core::internal::OptionRev::<(core::ops::range::internal::IntRange::<core::integer::i16>, core::integer::i16)>);

--- a/Aegis/Tests/e2e_libfuncs/range_aegis/range_try_new.sierra
+++ b/Aegis/Tests/e2e_libfuncs/range_aegis/range_try_new.sierra
@@ -1,0 +1,27 @@
+type RangeCheck = RangeCheck [storable: true, drop: false, dup: false, zero_sized: false];
+type IntRange<i16> = IntRange<i16> [storable: true, drop: true, dup: true, zero_sized: false];
+type core::result::Result::<core::ops::range::internal::IntRange::<core::integer::i16>, core::ops::range::internal::IntRange::<core::integer::i16>> = Enum<ut@core::result::Result::<core::ops::range::internal::IntRange::<core::integer::i16>, core::ops::range::internal::IntRange::<core::integer::i16>>, IntRange<i16>, IntRange<i16>> [storable: true, drop: true, dup: true, zero_sized: false];
+type i16 = i16 [storable: true, drop: true, dup: true, zero_sized: false];
+
+libfunc int_range_try_new<i16> = int_range_try_new<i16>;
+libfunc branch_align = branch_align;
+libfunc enum_init<core::result::Result::<core::ops::range::internal::IntRange::<core::integer::i16>, core::ops::range::internal::IntRange::<core::integer::i16>>, 0> = enum_init<core::result::Result::<core::ops::range::internal::IntRange::<core::integer::i16>, core::ops::range::internal::IntRange::<core::integer::i16>>, 0>;
+libfunc store_temp<RangeCheck> = store_temp<RangeCheck>;
+libfunc store_temp<core::result::Result::<core::ops::range::internal::IntRange::<core::integer::i16>, core::ops::range::internal::IntRange::<core::integer::i16>>> = store_temp<core::result::Result::<core::ops::range::internal::IntRange::<core::integer::i16>, core::ops::range::internal::IntRange::<core::integer::i16>>>;
+libfunc enum_init<core::result::Result::<core::ops::range::internal::IntRange::<core::integer::i16>, core::ops::range::internal::IntRange::<core::integer::i16>>, 1> = enum_init<core::result::Result::<core::ops::range::internal::IntRange::<core::integer::i16>, core::ops::range::internal::IntRange::<core::integer::i16>>, 1>;
+
+F0:
+int_range_try_new<i16>([0], [1], [2]) { fallthrough([3], [4]) F0_B0([5], [6]) };
+branch_align() -> ();
+enum_init<core::result::Result::<core::ops::range::internal::IntRange::<core::integer::i16>, core::ops::range::internal::IntRange::<core::integer::i16>>, 0>([4]) -> ([7]);
+store_temp<RangeCheck>([3]) -> ([3]);
+store_temp<core::result::Result::<core::ops::range::internal::IntRange::<core::integer::i16>, core::ops::range::internal::IntRange::<core::integer::i16>>>([7]) -> ([7]);
+return([3], [7]);
+F0_B0:
+branch_align() -> ();
+enum_init<core::result::Result::<core::ops::range::internal::IntRange::<core::integer::i16>, core::ops::range::internal::IntRange::<core::integer::i16>>, 1>([6]) -> ([8]);
+store_temp<RangeCheck>([5]) -> ([5]);
+store_temp<core::result::Result::<core::ops::range::internal::IntRange::<core::integer::i16>, core::ops::range::internal::IntRange::<core::integer::i16>>>([8]) -> ([8]);
+return([5], [8]);
+
+test::foo@F0([0]: RangeCheck, [1]: i16, [2]: i16) -> (RangeCheck, core::result::Result::<core::ops::range::internal::IntRange::<core::integer::i16>, core::ops::range::internal::IntRange::<core::integer::i16>>);

--- a/Aegis/Tests/e2e_libfuncs/u128_aegis/u128_byte_reverse.sierra
+++ b/Aegis/Tests/e2e_libfuncs/u128_aegis/u128_byte_reverse.sierra
@@ -5,9 +5,10 @@ libfunc u128_byte_reverse = u128_byte_reverse;
 libfunc store_temp<Bitwise> = store_temp<Bitwise>;
 libfunc store_temp<u128> = store_temp<u128>;
 
-u128_byte_reverse([0], [1]) -> ([2], [3]); // 0
-store_temp<Bitwise>([2]) -> ([2]); // 1
-store_temp<u128>([3]) -> ([3]); // 2
-return([2], [3]); // 3
+F0:
+u128_byte_reverse([0], [1]) -> ([2], [3]);
+store_temp<Bitwise>([2]) -> ([2]);
+store_temp<u128>([3]) -> ([3]);
+return([2], [3]);
 
-test::foo@0([0]: Bitwise, [1]: u128) -> (Bitwise, u128);
+test::foo@F0([0]: Bitwise, [1]: u128) -> (Bitwise, u128);

--- a/Aegis/Tests/e2e_libfuncs/u128_aegis/u128_eq.sierra
+++ b/Aegis/Tests/e2e_libfuncs/u128_aegis/u128_eq.sierra
@@ -1,9 +1,11 @@
 type u128 = u128 [storable: true, drop: true, dup: true, zero_sized: false];
 type Unit = Struct<ut@Tuple> [storable: true, drop: true, dup: true, zero_sized: true];
 type core::bool = Enum<ut@core::bool, Unit, Unit> [storable: true, drop: true, dup: true, zero_sized: false];
+type Const<u128, 12> = Const<u128, 12> [storable: false, drop: false, dup: false, zero_sized: false];
+type Const<u128, 11> = Const<u128, 11> [storable: false, drop: false, dup: false, zero_sized: false];
 
-libfunc u128_const<11> = u128_const<11>;
-libfunc u128_const<12> = u128_const<12>;
+libfunc const_as_immediate<Const<u128, 11>> = const_as_immediate<Const<u128, 11>>;
+libfunc const_as_immediate<Const<u128, 12>> = const_as_immediate<Const<u128, 12>>;
 libfunc store_temp<u128> = store_temp<u128>;
 libfunc u128_eq = u128_eq;
 libfunc branch_align = branch_align;
@@ -12,19 +14,21 @@ libfunc enum_init<core::bool, 0> = enum_init<core::bool, 0>;
 libfunc store_temp<core::bool> = store_temp<core::bool>;
 libfunc enum_init<core::bool, 1> = enum_init<core::bool, 1>;
 
-u128_const<11>() -> ([0]); // 0
-u128_const<12>() -> ([1]); // 1
-store_temp<u128>([0]) -> ([0]); // 2
-u128_eq([0], [1]) { fallthrough() 9() }; // 3
-branch_align() -> (); // 4
-struct_construct<Unit>() -> ([2]); // 5
-enum_init<core::bool, 0>([2]) -> ([3]); // 6
-store_temp<core::bool>([3]) -> ([3]); // 7
-return([3]); // 8
-branch_align() -> (); // 9
-struct_construct<Unit>() -> ([4]); // 10
-enum_init<core::bool, 1>([4]) -> ([5]); // 11
-store_temp<core::bool>([5]) -> ([5]); // 12
-return([5]); // 13
+F0:
+const_as_immediate<Const<u128, 11>>() -> ([0]);
+const_as_immediate<Const<u128, 12>>() -> ([1]);
+store_temp<u128>([0]) -> ([0]);
+u128_eq([0], [1]) { fallthrough() F0_B0() };
+branch_align() -> ();
+struct_construct<Unit>() -> ([2]);
+enum_init<core::bool, 0>([2]) -> ([3]);
+store_temp<core::bool>([3]) -> ([3]);
+return([3]);
+F0_B0:
+branch_align() -> ();
+struct_construct<Unit>() -> ([4]);
+enum_init<core::bool, 1>([4]) -> ([5]);
+store_temp<core::bool>([5]) -> ([5]);
+return([5]);
 
-test::foo@0() -> (core::bool);
+test::foo@F0() -> (core::bool);

--- a/Aegis/Tests/e2e_libfuncs/u128_aegis/u128_overflowing_add.sierra
+++ b/Aegis/Tests/e2e_libfuncs/u128_aegis/u128_overflowing_add.sierra
@@ -9,16 +9,18 @@ libfunc store_temp<RangeCheck> = store_temp<RangeCheck>;
 libfunc store_temp<core::result::Result::<core::integer::u128, core::integer::u128>> = store_temp<core::result::Result::<core::integer::u128, core::integer::u128>>;
 libfunc enum_init<core::result::Result::<core::integer::u128, core::integer::u128>, 1> = enum_init<core::result::Result::<core::integer::u128, core::integer::u128>, 1>;
 
-u128_overflowing_add([0], [1], [2]) { fallthrough([3], [4]) 6([5], [6]) }; // 0
-branch_align() -> (); // 1
-enum_init<core::result::Result::<core::integer::u128, core::integer::u128>, 0>([4]) -> ([7]); // 2
-store_temp<RangeCheck>([3]) -> ([3]); // 3
-store_temp<core::result::Result::<core::integer::u128, core::integer::u128>>([7]) -> ([7]); // 4
-return([3], [7]); // 5
-branch_align() -> (); // 6
-enum_init<core::result::Result::<core::integer::u128, core::integer::u128>, 1>([6]) -> ([8]); // 7
-store_temp<RangeCheck>([5]) -> ([5]); // 8
-store_temp<core::result::Result::<core::integer::u128, core::integer::u128>>([8]) -> ([8]); // 9
-return([5], [8]); // 10
+F0:
+u128_overflowing_add([0], [1], [2]) { fallthrough([3], [4]) F0_B0([5], [6]) };
+branch_align() -> ();
+enum_init<core::result::Result::<core::integer::u128, core::integer::u128>, 0>([4]) -> ([7]);
+store_temp<RangeCheck>([3]) -> ([3]);
+store_temp<core::result::Result::<core::integer::u128, core::integer::u128>>([7]) -> ([7]);
+return([3], [7]);
+F0_B0:
+branch_align() -> ();
+enum_init<core::result::Result::<core::integer::u128, core::integer::u128>, 1>([6]) -> ([8]);
+store_temp<RangeCheck>([5]) -> ([5]);
+store_temp<core::result::Result::<core::integer::u128, core::integer::u128>>([8]) -> ([8]);
+return([5], [8]);
 
-test::foo@0([0]: RangeCheck, [1]: u128, [2]: u128) -> (RangeCheck, core::result::Result::<core::integer::u128, core::integer::u128>);
+test::foo@F0([0]: RangeCheck, [1]: u128, [2]: u128) -> (RangeCheck, core::result::Result::<core::integer::u128, core::integer::u128>);

--- a/Aegis/Tests/e2e_libfuncs/u128_aegis/u128_overflowing_sub.sierra
+++ b/Aegis/Tests/e2e_libfuncs/u128_aegis/u128_overflowing_sub.sierra
@@ -9,16 +9,18 @@ libfunc store_temp<RangeCheck> = store_temp<RangeCheck>;
 libfunc store_temp<core::result::Result::<core::integer::u128, core::integer::u128>> = store_temp<core::result::Result::<core::integer::u128, core::integer::u128>>;
 libfunc enum_init<core::result::Result::<core::integer::u128, core::integer::u128>, 1> = enum_init<core::result::Result::<core::integer::u128, core::integer::u128>, 1>;
 
-u128_overflowing_sub([0], [1], [2]) { fallthrough([3], [4]) 6([5], [6]) }; // 0
-branch_align() -> (); // 1
-enum_init<core::result::Result::<core::integer::u128, core::integer::u128>, 0>([4]) -> ([7]); // 2
-store_temp<RangeCheck>([3]) -> ([3]); // 3
-store_temp<core::result::Result::<core::integer::u128, core::integer::u128>>([7]) -> ([7]); // 4
-return([3], [7]); // 5
-branch_align() -> (); // 6
-enum_init<core::result::Result::<core::integer::u128, core::integer::u128>, 1>([6]) -> ([8]); // 7
-store_temp<RangeCheck>([5]) -> ([5]); // 8
-store_temp<core::result::Result::<core::integer::u128, core::integer::u128>>([8]) -> ([8]); // 9
-return([5], [8]); // 10
+F0:
+u128_overflowing_sub([0], [1], [2]) { fallthrough([3], [4]) F0_B0([5], [6]) };
+branch_align() -> ();
+enum_init<core::result::Result::<core::integer::u128, core::integer::u128>, 0>([4]) -> ([7]);
+store_temp<RangeCheck>([3]) -> ([3]);
+store_temp<core::result::Result::<core::integer::u128, core::integer::u128>>([7]) -> ([7]);
+return([3], [7]);
+F0_B0:
+branch_align() -> ();
+enum_init<core::result::Result::<core::integer::u128, core::integer::u128>, 1>([6]) -> ([8]);
+store_temp<RangeCheck>([5]) -> ([5]);
+store_temp<core::result::Result::<core::integer::u128, core::integer::u128>>([8]) -> ([8]);
+return([5], [8]);
 
-test::foo@0([0]: RangeCheck, [1]: u128, [2]: u128) -> (RangeCheck, core::result::Result::<core::integer::u128, core::integer::u128>);
+test::foo@F0([0]: RangeCheck, [1]: u128, [2]: u128) -> (RangeCheck, core::result::Result::<core::integer::u128, core::integer::u128>);

--- a/Aegis/Tests/e2e_libfuncs/u128_aegis/u128_safe_divmod.sierra
+++ b/Aegis/Tests/e2e_libfuncs/u128_aegis/u128_safe_divmod.sierra
@@ -8,10 +8,11 @@ libfunc struct_construct<Tuple<u128, u128>> = struct_construct<Tuple<u128, u128>
 libfunc store_temp<RangeCheck> = store_temp<RangeCheck>;
 libfunc store_temp<Tuple<u128, u128>> = store_temp<Tuple<u128, u128>>;
 
-u128_safe_divmod([0], [1], [2]) -> ([3], [4], [5]); // 0
-struct_construct<Tuple<u128, u128>>([4], [5]) -> ([6]); // 1
-store_temp<RangeCheck>([3]) -> ([3]); // 2
-store_temp<Tuple<u128, u128>>([6]) -> ([6]); // 3
-return([3], [6]); // 4
+F0:
+u128_safe_divmod([0], [1], [2]) -> ([3], [4], [5]);
+struct_construct<Tuple<u128, u128>>([4], [5]) -> ([6]);
+store_temp<RangeCheck>([3]) -> ([3]);
+store_temp<Tuple<u128, u128>>([6]) -> ([6]);
+return([3], [6]);
 
-test::foo@0([0]: RangeCheck, [1]: u128, [2]: NonZero<u128>) -> (RangeCheck, Tuple<u128, u128>);
+test::foo@F0([0]: RangeCheck, [1]: u128, [2]: NonZero<u128>) -> (RangeCheck, Tuple<u128, u128>);

--- a/Aegis/Tests/e2e_libfuncs/u128_aegis/u128_sqrt.sierra
+++ b/Aegis/Tests/e2e_libfuncs/u128_aegis/u128_sqrt.sierra
@@ -6,9 +6,10 @@ libfunc u128_sqrt = u128_sqrt;
 libfunc store_temp<RangeCheck> = store_temp<RangeCheck>;
 libfunc store_temp<u64> = store_temp<u64>;
 
-u128_sqrt([0], [1]) -> ([2], [3]); // 0
-store_temp<RangeCheck>([2]) -> ([2]); // 1
-store_temp<u64>([3]) -> ([3]); // 2
-return([2], [3]); // 3
+F0:
+u128_sqrt([0], [1]) -> ([2], [3]);
+store_temp<RangeCheck>([2]) -> ([2]);
+store_temp<u64>([3]) -> ([3]);
+return([2], [3]);
 
-test::foo@0([0]: RangeCheck, [1]: u128) -> (RangeCheck, u64);
+test::foo@F0([0]: RangeCheck, [1]: u128) -> (RangeCheck, u64);

--- a/Aegis/Tests/e2e_libfuncs/u128_aegis/u128s_from_felt252.sierra
+++ b/Aegis/Tests/e2e_libfuncs/u128_aegis/u128s_from_felt252.sierra
@@ -12,17 +12,19 @@ libfunc store_temp<core::integer::U128sFromFelt252Result> = store_temp<core::int
 libfunc struct_construct<Tuple<u128, u128>> = struct_construct<Tuple<u128, u128>>;
 libfunc enum_init<core::integer::U128sFromFelt252Result, 1> = enum_init<core::integer::U128sFromFelt252Result, 1>;
 
-u128s_from_felt252([0], [1]) { fallthrough([2], [3]) 6([4], [5], [6]) }; // 0
-branch_align() -> (); // 1
-enum_init<core::integer::U128sFromFelt252Result, 0>([3]) -> ([7]); // 2
-store_temp<RangeCheck>([2]) -> ([2]); // 3
-store_temp<core::integer::U128sFromFelt252Result>([7]) -> ([7]); // 4
-return([2], [7]); // 5
-branch_align() -> (); // 6
-struct_construct<Tuple<u128, u128>>([5], [6]) -> ([8]); // 7
-enum_init<core::integer::U128sFromFelt252Result, 1>([8]) -> ([9]); // 8
-store_temp<RangeCheck>([4]) -> ([4]); // 9
-store_temp<core::integer::U128sFromFelt252Result>([9]) -> ([9]); // 10
-return([4], [9]); // 11
+F0:
+u128s_from_felt252([0], [1]) { fallthrough([2], [3]) F0_B0([4], [5], [6]) };
+branch_align() -> ();
+enum_init<core::integer::U128sFromFelt252Result, 0>([3]) -> ([7]);
+store_temp<RangeCheck>([2]) -> ([2]);
+store_temp<core::integer::U128sFromFelt252Result>([7]) -> ([7]);
+return([2], [7]);
+F0_B0:
+branch_align() -> ();
+struct_construct<Tuple<u128, u128>>([5], [6]) -> ([8]);
+enum_init<core::integer::U128sFromFelt252Result, 1>([8]) -> ([9]);
+store_temp<RangeCheck>([4]) -> ([4]);
+store_temp<core::integer::U128sFromFelt252Result>([9]) -> ([9]);
+return([4], [9]);
 
-test::foo@0([0]: RangeCheck, [1]: felt252) -> (RangeCheck, core::integer::U128sFromFelt252Result);
+test::foo@F0([0]: RangeCheck, [1]: felt252) -> (RangeCheck, core::integer::U128sFromFelt252Result);

--- a/Aegis/Tests/e2e_libfuncs/u16_aegis/u16_eq.sierra
+++ b/Aegis/Tests/e2e_libfuncs/u16_aegis/u16_eq.sierra
@@ -1,9 +1,11 @@
 type u16 = u16 [storable: true, drop: true, dup: true, zero_sized: false];
 type Unit = Struct<ut@Tuple> [storable: true, drop: true, dup: true, zero_sized: true];
 type core::bool = Enum<ut@core::bool, Unit, Unit> [storable: true, drop: true, dup: true, zero_sized: false];
+type Const<u16, 12> = Const<u16, 12> [storable: false, drop: false, dup: false, zero_sized: false];
+type Const<u16, 11> = Const<u16, 11> [storable: false, drop: false, dup: false, zero_sized: false];
 
-libfunc u16_const<11> = u16_const<11>;
-libfunc u16_const<12> = u16_const<12>;
+libfunc const_as_immediate<Const<u16, 11>> = const_as_immediate<Const<u16, 11>>;
+libfunc const_as_immediate<Const<u16, 12>> = const_as_immediate<Const<u16, 12>>;
 libfunc store_temp<u16> = store_temp<u16>;
 libfunc u16_eq = u16_eq;
 libfunc branch_align = branch_align;
@@ -12,19 +14,21 @@ libfunc enum_init<core::bool, 0> = enum_init<core::bool, 0>;
 libfunc store_temp<core::bool> = store_temp<core::bool>;
 libfunc enum_init<core::bool, 1> = enum_init<core::bool, 1>;
 
-u16_const<11>() -> ([0]); // 0
-u16_const<12>() -> ([1]); // 1
-store_temp<u16>([0]) -> ([0]); // 2
-u16_eq([0], [1]) { fallthrough() 9() }; // 3
-branch_align() -> (); // 4
-struct_construct<Unit>() -> ([2]); // 5
-enum_init<core::bool, 0>([2]) -> ([3]); // 6
-store_temp<core::bool>([3]) -> ([3]); // 7
-return([3]); // 8
-branch_align() -> (); // 9
-struct_construct<Unit>() -> ([4]); // 10
-enum_init<core::bool, 1>([4]) -> ([5]); // 11
-store_temp<core::bool>([5]) -> ([5]); // 12
-return([5]); // 13
+F0:
+const_as_immediate<Const<u16, 11>>() -> ([0]);
+const_as_immediate<Const<u16, 12>>() -> ([1]);
+store_temp<u16>([0]) -> ([0]);
+u16_eq([0], [1]) { fallthrough() F0_B0() };
+branch_align() -> ();
+struct_construct<Unit>() -> ([2]);
+enum_init<core::bool, 0>([2]) -> ([3]);
+store_temp<core::bool>([3]) -> ([3]);
+return([3]);
+F0_B0:
+branch_align() -> ();
+struct_construct<Unit>() -> ([4]);
+enum_init<core::bool, 1>([4]) -> ([5]);
+store_temp<core::bool>([5]) -> ([5]);
+return([5]);
 
-test::foo@0() -> (core::bool);
+test::foo@F0() -> (core::bool);

--- a/Aegis/Tests/e2e_libfuncs/u16_aegis/u16_is_zero.sierra
+++ b/Aegis/Tests/e2e_libfuncs/u16_aegis/u16_is_zero.sierra
@@ -1,20 +1,23 @@
 type u16 = u16 [storable: true, drop: true, dup: true, zero_sized: false];
+type Const<u16, 1234> = Const<u16, 1234> [storable: false, drop: false, dup: false, zero_sized: false];
 type NonZero<u16> = NonZero<u16> [storable: true, drop: true, dup: true, zero_sized: false];
 
 libfunc u16_is_zero = u16_is_zero;
 libfunc branch_align = branch_align;
-libfunc u16_const<1234> = u16_const<1234>;
+libfunc const_as_immediate<Const<u16, 1234>> = const_as_immediate<Const<u16, 1234>>;
 libfunc store_temp<u16> = store_temp<u16>;
 libfunc unwrap_non_zero<u16> = unwrap_non_zero<u16>;
 
-u16_is_zero([0]) { fallthrough() 5([1]) }; // 0
-branch_align() -> (); // 1
-u16_const<1234>() -> ([2]); // 2
-store_temp<u16>([2]) -> ([2]); // 3
-return([2]); // 4
-branch_align() -> (); // 5
-unwrap_non_zero<u16>([1]) -> ([3]); // 6
-store_temp<u16>([3]) -> ([3]); // 7
-return([3]); // 8
+F0:
+u16_is_zero([0]) { fallthrough() F0_B0([1]) };
+branch_align() -> ();
+const_as_immediate<Const<u16, 1234>>() -> ([2]);
+store_temp<u16>([2]) -> ([2]);
+return([2]);
+F0_B0:
+branch_align() -> ();
+unwrap_non_zero<u16>([1]) -> ([3]);
+store_temp<u16>([3]) -> ([3]);
+return([3]);
 
-test::foo@0([0]: u16) -> (u16);
+test::foo@F0([0]: u16) -> (u16);

--- a/Aegis/Tests/e2e_libfuncs/u16_aegis/u16_overflowing_add.sierra
+++ b/Aegis/Tests/e2e_libfuncs/u16_aegis/u16_overflowing_add.sierra
@@ -9,16 +9,18 @@ libfunc store_temp<RangeCheck> = store_temp<RangeCheck>;
 libfunc store_temp<core::result::Result::<core::integer::u16, core::integer::u16>> = store_temp<core::result::Result::<core::integer::u16, core::integer::u16>>;
 libfunc enum_init<core::result::Result::<core::integer::u16, core::integer::u16>, 1> = enum_init<core::result::Result::<core::integer::u16, core::integer::u16>, 1>;
 
-u16_overflowing_add([0], [1], [2]) { fallthrough([3], [4]) 6([5], [6]) }; // 0
-branch_align() -> (); // 1
-enum_init<core::result::Result::<core::integer::u16, core::integer::u16>, 0>([4]) -> ([7]); // 2
-store_temp<RangeCheck>([3]) -> ([3]); // 3
-store_temp<core::result::Result::<core::integer::u16, core::integer::u16>>([7]) -> ([7]); // 4
-return([3], [7]); // 5
-branch_align() -> (); // 6
-enum_init<core::result::Result::<core::integer::u16, core::integer::u16>, 1>([6]) -> ([8]); // 7
-store_temp<RangeCheck>([5]) -> ([5]); // 8
-store_temp<core::result::Result::<core::integer::u16, core::integer::u16>>([8]) -> ([8]); // 9
-return([5], [8]); // 10
+F0:
+u16_overflowing_add([0], [1], [2]) { fallthrough([3], [4]) F0_B0([5], [6]) };
+branch_align() -> ();
+enum_init<core::result::Result::<core::integer::u16, core::integer::u16>, 0>([4]) -> ([7]);
+store_temp<RangeCheck>([3]) -> ([3]);
+store_temp<core::result::Result::<core::integer::u16, core::integer::u16>>([7]) -> ([7]);
+return([3], [7]);
+F0_B0:
+branch_align() -> ();
+enum_init<core::result::Result::<core::integer::u16, core::integer::u16>, 1>([6]) -> ([8]);
+store_temp<RangeCheck>([5]) -> ([5]);
+store_temp<core::result::Result::<core::integer::u16, core::integer::u16>>([8]) -> ([8]);
+return([5], [8]);
 
-test::foo@0([0]: RangeCheck, [1]: u16, [2]: u16) -> (RangeCheck, core::result::Result::<core::integer::u16, core::integer::u16>);
+test::foo@F0([0]: RangeCheck, [1]: u16, [2]: u16) -> (RangeCheck, core::result::Result::<core::integer::u16, core::integer::u16>);

--- a/Aegis/Tests/e2e_libfuncs/u16_aegis/u16_overflowing_sub.sierra
+++ b/Aegis/Tests/e2e_libfuncs/u16_aegis/u16_overflowing_sub.sierra
@@ -9,16 +9,18 @@ libfunc store_temp<RangeCheck> = store_temp<RangeCheck>;
 libfunc store_temp<core::result::Result::<core::integer::u16, core::integer::u16>> = store_temp<core::result::Result::<core::integer::u16, core::integer::u16>>;
 libfunc enum_init<core::result::Result::<core::integer::u16, core::integer::u16>, 1> = enum_init<core::result::Result::<core::integer::u16, core::integer::u16>, 1>;
 
-u16_overflowing_sub([0], [1], [2]) { fallthrough([3], [4]) 6([5], [6]) }; // 0
-branch_align() -> (); // 1
-enum_init<core::result::Result::<core::integer::u16, core::integer::u16>, 0>([4]) -> ([7]); // 2
-store_temp<RangeCheck>([3]) -> ([3]); // 3
-store_temp<core::result::Result::<core::integer::u16, core::integer::u16>>([7]) -> ([7]); // 4
-return([3], [7]); // 5
-branch_align() -> (); // 6
-enum_init<core::result::Result::<core::integer::u16, core::integer::u16>, 1>([6]) -> ([8]); // 7
-store_temp<RangeCheck>([5]) -> ([5]); // 8
-store_temp<core::result::Result::<core::integer::u16, core::integer::u16>>([8]) -> ([8]); // 9
-return([5], [8]); // 10
+F0:
+u16_overflowing_sub([0], [1], [2]) { fallthrough([3], [4]) F0_B0([5], [6]) };
+branch_align() -> ();
+enum_init<core::result::Result::<core::integer::u16, core::integer::u16>, 0>([4]) -> ([7]);
+store_temp<RangeCheck>([3]) -> ([3]);
+store_temp<core::result::Result::<core::integer::u16, core::integer::u16>>([7]) -> ([7]);
+return([3], [7]);
+F0_B0:
+branch_align() -> ();
+enum_init<core::result::Result::<core::integer::u16, core::integer::u16>, 1>([6]) -> ([8]);
+store_temp<RangeCheck>([5]) -> ([5]);
+store_temp<core::result::Result::<core::integer::u16, core::integer::u16>>([8]) -> ([8]);
+return([5], [8]);
 
-test::foo@0([0]: RangeCheck, [1]: u16, [2]: u16) -> (RangeCheck, core::result::Result::<core::integer::u16, core::integer::u16>);
+test::foo@F0([0]: RangeCheck, [1]: u16, [2]: u16) -> (RangeCheck, core::result::Result::<core::integer::u16, core::integer::u16>);

--- a/Aegis/Tests/e2e_libfuncs/u16_aegis/u16_safe_divmod.sierra
+++ b/Aegis/Tests/e2e_libfuncs/u16_aegis/u16_safe_divmod.sierra
@@ -8,10 +8,11 @@ libfunc struct_construct<Tuple<u16, u16>> = struct_construct<Tuple<u16, u16>>;
 libfunc store_temp<RangeCheck> = store_temp<RangeCheck>;
 libfunc store_temp<Tuple<u16, u16>> = store_temp<Tuple<u16, u16>>;
 
-u16_safe_divmod([0], [1], [2]) -> ([3], [4], [5]); // 0
-struct_construct<Tuple<u16, u16>>([4], [5]) -> ([6]); // 1
-store_temp<RangeCheck>([3]) -> ([3]); // 2
-store_temp<Tuple<u16, u16>>([6]) -> ([6]); // 3
-return([3], [6]); // 4
+F0:
+u16_safe_divmod([0], [1], [2]) -> ([3], [4], [5]);
+struct_construct<Tuple<u16, u16>>([4], [5]) -> ([6]);
+store_temp<RangeCheck>([3]) -> ([3]);
+store_temp<Tuple<u16, u16>>([6]) -> ([6]);
+return([3], [6]);
 
-test::foo@0([0]: RangeCheck, [1]: u16, [2]: NonZero<u16>) -> (RangeCheck, Tuple<u16, u16>);
+test::foo@F0([0]: RangeCheck, [1]: u16, [2]: NonZero<u16>) -> (RangeCheck, Tuple<u16, u16>);

--- a/Aegis/Tests/e2e_libfuncs/u16_aegis/u16_sqrt.sierra
+++ b/Aegis/Tests/e2e_libfuncs/u16_aegis/u16_sqrt.sierra
@@ -6,9 +6,10 @@ libfunc u16_sqrt = u16_sqrt;
 libfunc store_temp<RangeCheck> = store_temp<RangeCheck>;
 libfunc store_temp<u8> = store_temp<u8>;
 
-u16_sqrt([0], [1]) -> ([2], [3]); // 0
-store_temp<RangeCheck>([2]) -> ([2]); // 1
-store_temp<u8>([3]) -> ([3]); // 2
-return([2], [3]); // 3
+F0:
+u16_sqrt([0], [1]) -> ([2], [3]);
+store_temp<RangeCheck>([2]) -> ([2]);
+store_temp<u8>([3]) -> ([3]);
+return([2], [3]);
 
-test::foo@0([0]: RangeCheck, [1]: u16) -> (RangeCheck, u8);
+test::foo@F0([0]: RangeCheck, [1]: u16) -> (RangeCheck, u8);

--- a/Aegis/Tests/e2e_libfuncs/u16_aegis/u16_try_from_felt252.sierra
+++ b/Aegis/Tests/e2e_libfuncs/u16_aegis/u16_try_from_felt252.sierra
@@ -12,17 +12,19 @@ libfunc store_temp<core::option::Option::<core::integer::u16>> = store_temp<core
 libfunc struct_construct<Unit> = struct_construct<Unit>;
 libfunc enum_init<core::option::Option::<core::integer::u16>, 1> = enum_init<core::option::Option::<core::integer::u16>, 1>;
 
-u16_try_from_felt252([0], [1]) { fallthrough([2], [3]) 6([4]) }; // 0
-branch_align() -> (); // 1
-enum_init<core::option::Option::<core::integer::u16>, 0>([3]) -> ([5]); // 2
-store_temp<RangeCheck>([2]) -> ([2]); // 3
-store_temp<core::option::Option::<core::integer::u16>>([5]) -> ([5]); // 4
-return([2], [5]); // 5
-branch_align() -> (); // 6
-struct_construct<Unit>() -> ([6]); // 7
-enum_init<core::option::Option::<core::integer::u16>, 1>([6]) -> ([7]); // 8
-store_temp<RangeCheck>([4]) -> ([4]); // 9
-store_temp<core::option::Option::<core::integer::u16>>([7]) -> ([7]); // 10
-return([4], [7]); // 11
+F0:
+u16_try_from_felt252([0], [1]) { fallthrough([2], [3]) F0_B0([4]) };
+branch_align() -> ();
+enum_init<core::option::Option::<core::integer::u16>, 0>([3]) -> ([5]);
+store_temp<RangeCheck>([2]) -> ([2]);
+store_temp<core::option::Option::<core::integer::u16>>([5]) -> ([5]);
+return([2], [5]);
+F0_B0:
+branch_align() -> ();
+struct_construct<Unit>() -> ([6]);
+enum_init<core::option::Option::<core::integer::u16>, 1>([6]) -> ([7]);
+store_temp<RangeCheck>([4]) -> ([4]);
+store_temp<core::option::Option::<core::integer::u16>>([7]) -> ([7]);
+return([4], [7]);
 
-test::foo@0([0]: RangeCheck, [1]: felt252) -> (RangeCheck, core::option::Option::<core::integer::u16>);
+test::foo@F0([0]: RangeCheck, [1]: felt252) -> (RangeCheck, core::option::Option::<core::integer::u16>);

--- a/Aegis/Tests/e2e_libfuncs/u16_aegis/u16_wide_mul.sierra
+++ b/Aegis/Tests/e2e_libfuncs/u16_aegis/u16_wide_mul.sierra
@@ -4,8 +4,9 @@ type u32 = u32 [storable: true, drop: true, dup: true, zero_sized: false];
 libfunc u16_wide_mul = u16_wide_mul;
 libfunc store_temp<u32> = store_temp<u32>;
 
-u16_wide_mul([0], [1]) -> ([2]); // 0
-store_temp<u32>([2]) -> ([2]); // 1
-return([2]); // 2
+F0:
+u16_wide_mul([0], [1]) -> ([2]);
+store_temp<u32>([2]) -> ([2]);
+return([2]);
 
-test::foo@0([0]: u16, [1]: u16) -> (u32);
+test::foo@F0([0]: u16, [1]: u16) -> (u32);

--- a/Aegis/Tests/e2e_libfuncs/u256_aegis/u256_guarantee_inv_mod_n.sierra
+++ b/Aegis/Tests/e2e_libfuncs/u256_aegis/u256_guarantee_inv_mod_n.sierra
@@ -15,27 +15,29 @@ libfunc store_temp<core::option::Option::<core::zeroable::NonZero::<core::intege
 libfunc struct_construct<Unit> = struct_construct<Unit>;
 libfunc enum_init<core::option::Option::<core::zeroable::NonZero::<core::integer::u256>>, 1> = enum_init<core::option::Option::<core::zeroable::NonZero::<core::integer::u256>>, 1>;
 
-u256_guarantee_inv_mod_n([0], [1], [2]) { fallthrough([3], [4], [5], [6], [7], [8], [9], [10], [11], [12]) 14([13], [14], [15]) }; // 0
-branch_align() -> (); // 1
-u128_mul_guarantee_verify([3], [12]) -> ([16]); // 2
-u128_mul_guarantee_verify([16], [11]) -> ([17]); // 3
-u128_mul_guarantee_verify([17], [10]) -> ([18]); // 4
-u128_mul_guarantee_verify([18], [9]) -> ([19]); // 5
-u128_mul_guarantee_verify([19], [8]) -> ([20]); // 6
-u128_mul_guarantee_verify([20], [7]) -> ([21]); // 7
-u128_mul_guarantee_verify([21], [6]) -> ([22]); // 8
-u128_mul_guarantee_verify([22], [5]) -> ([23]); // 9
-enum_init<core::option::Option::<core::zeroable::NonZero::<core::integer::u256>>, 0>([4]) -> ([24]); // 10
-store_temp<RangeCheck>([23]) -> ([23]); // 11
-store_temp<core::option::Option::<core::zeroable::NonZero::<core::integer::u256>>>([24]) -> ([24]); // 12
-return([23], [24]); // 13
-branch_align() -> (); // 14
-u128_mul_guarantee_verify([13], [15]) -> ([25]); // 15
-u128_mul_guarantee_verify([25], [14]) -> ([26]); // 16
-struct_construct<Unit>() -> ([27]); // 17
-enum_init<core::option::Option::<core::zeroable::NonZero::<core::integer::u256>>, 1>([27]) -> ([28]); // 18
-store_temp<RangeCheck>([26]) -> ([26]); // 19
-store_temp<core::option::Option::<core::zeroable::NonZero::<core::integer::u256>>>([28]) -> ([28]); // 20
-return([26], [28]); // 21
+F0:
+u256_guarantee_inv_mod_n([0], [1], [2]) { fallthrough([3], [4], [5], [6], [7], [8], [9], [10], [11], [12]) F0_B0([13], [14], [15]) };
+branch_align() -> ();
+u128_mul_guarantee_verify([3], [12]) -> ([16]);
+u128_mul_guarantee_verify([16], [11]) -> ([17]);
+u128_mul_guarantee_verify([17], [10]) -> ([18]);
+u128_mul_guarantee_verify([18], [9]) -> ([19]);
+u128_mul_guarantee_verify([19], [8]) -> ([20]);
+u128_mul_guarantee_verify([20], [7]) -> ([21]);
+u128_mul_guarantee_verify([21], [6]) -> ([22]);
+u128_mul_guarantee_verify([22], [5]) -> ([23]);
+enum_init<core::option::Option::<core::zeroable::NonZero::<core::integer::u256>>, 0>([4]) -> ([24]);
+store_temp<RangeCheck>([23]) -> ([23]);
+store_temp<core::option::Option::<core::zeroable::NonZero::<core::integer::u256>>>([24]) -> ([24]);
+return([23], [24]);
+F0_B0:
+branch_align() -> ();
+u128_mul_guarantee_verify([13], [15]) -> ([25]);
+u128_mul_guarantee_verify([25], [14]) -> ([26]);
+struct_construct<Unit>() -> ([27]);
+enum_init<core::option::Option::<core::zeroable::NonZero::<core::integer::u256>>, 1>([27]) -> ([28]);
+store_temp<RangeCheck>([26]) -> ([26]);
+store_temp<core::option::Option::<core::zeroable::NonZero::<core::integer::u256>>>([28]) -> ([28]);
+return([26], [28]);
 
-test::foo@0([0]: RangeCheck, [1]: core::integer::u256, [2]: NonZero<core::integer::u256>) -> (RangeCheck, core::option::Option::<core::zeroable::NonZero::<core::integer::u256>>);
+test::foo@F0([0]: RangeCheck, [1]: core::integer::u256, [2]: NonZero<core::integer::u256>) -> (RangeCheck, core::option::Option::<core::zeroable::NonZero::<core::integer::u256>>);

--- a/Aegis/Tests/e2e_libfuncs/u256_aegis/u256_is_zero.sierra
+++ b/Aegis/Tests/e2e_libfuncs/u256_aegis/u256_is_zero.sierra
@@ -1,24 +1,27 @@
 type u128 = u128 [storable: true, drop: true, dup: true, zero_sized: false];
 type core::integer::u256 = Struct<ut@core::integer::u256, u128, u128> [storable: true, drop: true, dup: true, zero_sized: false];
+type Const<u128, 0> = Const<u128, 0> [storable: false, drop: false, dup: false, zero_sized: false];
 type NonZero<core::integer::u256> = NonZero<core::integer::u256> [storable: true, drop: true, dup: true, zero_sized: false];
 
 libfunc u256_is_zero = u256_is_zero;
 libfunc branch_align = branch_align;
-libfunc u128_const<0> = u128_const<0>;
+libfunc const_as_immediate<Const<u128, 0>> = const_as_immediate<Const<u128, 0>>;
 libfunc struct_construct<core::integer::u256> = struct_construct<core::integer::u256>;
 libfunc store_temp<core::integer::u256> = store_temp<core::integer::u256>;
 libfunc unwrap_non_zero<core::integer::u256> = unwrap_non_zero<core::integer::u256>;
 
-u256_is_zero([0]) { fallthrough() 7([1]) }; // 0
-branch_align() -> (); // 1
-u128_const<0>() -> ([2]); // 2
-u128_const<0>() -> ([3]); // 3
-struct_construct<core::integer::u256>([2], [3]) -> ([4]); // 4
-store_temp<core::integer::u256>([4]) -> ([4]); // 5
-return([4]); // 6
-branch_align() -> (); // 7
-unwrap_non_zero<core::integer::u256>([1]) -> ([5]); // 8
-store_temp<core::integer::u256>([5]) -> ([5]); // 9
-return([5]); // 10
+F0:
+u256_is_zero([0]) { fallthrough() F0_B0([1]) };
+branch_align() -> ();
+const_as_immediate<Const<u128, 0>>() -> ([2]);
+const_as_immediate<Const<u128, 0>>() -> ([3]);
+struct_construct<core::integer::u256>([2], [3]) -> ([4]);
+store_temp<core::integer::u256>([4]) -> ([4]);
+return([4]);
+F0_B0:
+branch_align() -> ();
+unwrap_non_zero<core::integer::u256>([1]) -> ([5]);
+store_temp<core::integer::u256>([5]) -> ([5]);
+return([5]);
 
-test::foo@0([0]: core::integer::u256) -> (core::integer::u256);
+test::foo@F0([0]: core::integer::u256) -> (core::integer::u256);

--- a/Aegis/Tests/e2e_libfuncs/u256_aegis/u256_safe_divmod.sierra
+++ b/Aegis/Tests/e2e_libfuncs/u256_aegis/u256_safe_divmod.sierra
@@ -11,11 +11,12 @@ libfunc struct_construct<Tuple<core::integer::u256, core::integer::u256>> = stru
 libfunc store_temp<RangeCheck> = store_temp<RangeCheck>;
 libfunc store_temp<Tuple<core::integer::u256, core::integer::u256>> = store_temp<Tuple<core::integer::u256, core::integer::u256>>;
 
-u256_safe_divmod([0], [1], [2]) -> ([3], [4], [5], [6]); // 0
-u128_mul_guarantee_verify([3], [6]) -> ([7]); // 1
-struct_construct<Tuple<core::integer::u256, core::integer::u256>>([4], [5]) -> ([8]); // 2
-store_temp<RangeCheck>([7]) -> ([7]); // 3
-store_temp<Tuple<core::integer::u256, core::integer::u256>>([8]) -> ([8]); // 4
-return([7], [8]); // 5
+F0:
+u256_safe_divmod([0], [1], [2]) -> ([3], [4], [5], [6]);
+u128_mul_guarantee_verify([3], [6]) -> ([7]);
+struct_construct<Tuple<core::integer::u256, core::integer::u256>>([4], [5]) -> ([8]);
+store_temp<RangeCheck>([7]) -> ([7]);
+store_temp<Tuple<core::integer::u256, core::integer::u256>>([8]) -> ([8]);
+return([7], [8]);
 
-test::foo@0([0]: RangeCheck, [1]: core::integer::u256, [2]: NonZero<core::integer::u256>) -> (RangeCheck, Tuple<core::integer::u256, core::integer::u256>);
+test::foo@F0([0]: RangeCheck, [1]: core::integer::u256, [2]: NonZero<core::integer::u256>) -> (RangeCheck, Tuple<core::integer::u256, core::integer::u256>);

--- a/Aegis/Tests/e2e_libfuncs/u256_aegis/u256_sqrt.sierra
+++ b/Aegis/Tests/e2e_libfuncs/u256_aegis/u256_sqrt.sierra
@@ -6,9 +6,10 @@ libfunc u256_sqrt = u256_sqrt;
 libfunc store_temp<RangeCheck> = store_temp<RangeCheck>;
 libfunc store_temp<u128> = store_temp<u128>;
 
-u256_sqrt([0], [1]) -> ([2], [3]); // 0
-store_temp<RangeCheck>([2]) -> ([2]); // 1
-store_temp<u128>([3]) -> ([3]); // 2
-return([2], [3]); // 3
+F0:
+u256_sqrt([0], [1]) -> ([2], [3]);
+store_temp<RangeCheck>([2]) -> ([2]);
+store_temp<u128>([3]) -> ([3]);
+return([2], [3]);
 
-test::foo@0([0]: RangeCheck, [1]: core::integer::u256) -> (RangeCheck, u128);
+test::foo@F0([0]: RangeCheck, [1]: core::integer::u256) -> (RangeCheck, u128);

--- a/Aegis/Tests/e2e_libfuncs/u32_aegis/u32_eq.sierra
+++ b/Aegis/Tests/e2e_libfuncs/u32_aegis/u32_eq.sierra
@@ -1,9 +1,11 @@
 type u32 = u32 [storable: true, drop: true, dup: true, zero_sized: false];
 type Unit = Struct<ut@Tuple> [storable: true, drop: true, dup: true, zero_sized: true];
 type core::bool = Enum<ut@core::bool, Unit, Unit> [storable: true, drop: true, dup: true, zero_sized: false];
+type Const<u32, 12> = Const<u32, 12> [storable: false, drop: false, dup: false, zero_sized: false];
+type Const<u32, 11> = Const<u32, 11> [storable: false, drop: false, dup: false, zero_sized: false];
 
-libfunc u32_const<11> = u32_const<11>;
-libfunc u32_const<12> = u32_const<12>;
+libfunc const_as_immediate<Const<u32, 11>> = const_as_immediate<Const<u32, 11>>;
+libfunc const_as_immediate<Const<u32, 12>> = const_as_immediate<Const<u32, 12>>;
 libfunc store_temp<u32> = store_temp<u32>;
 libfunc u32_eq = u32_eq;
 libfunc branch_align = branch_align;
@@ -12,19 +14,21 @@ libfunc enum_init<core::bool, 0> = enum_init<core::bool, 0>;
 libfunc store_temp<core::bool> = store_temp<core::bool>;
 libfunc enum_init<core::bool, 1> = enum_init<core::bool, 1>;
 
-u32_const<11>() -> ([0]); // 0
-u32_const<12>() -> ([1]); // 1
-store_temp<u32>([0]) -> ([0]); // 2
-u32_eq([0], [1]) { fallthrough() 9() }; // 3
-branch_align() -> (); // 4
-struct_construct<Unit>() -> ([2]); // 5
-enum_init<core::bool, 0>([2]) -> ([3]); // 6
-store_temp<core::bool>([3]) -> ([3]); // 7
-return([3]); // 8
-branch_align() -> (); // 9
-struct_construct<Unit>() -> ([4]); // 10
-enum_init<core::bool, 1>([4]) -> ([5]); // 11
-store_temp<core::bool>([5]) -> ([5]); // 12
-return([5]); // 13
+F0:
+const_as_immediate<Const<u32, 11>>() -> ([0]);
+const_as_immediate<Const<u32, 12>>() -> ([1]);
+store_temp<u32>([0]) -> ([0]);
+u32_eq([0], [1]) { fallthrough() F0_B0() };
+branch_align() -> ();
+struct_construct<Unit>() -> ([2]);
+enum_init<core::bool, 0>([2]) -> ([3]);
+store_temp<core::bool>([3]) -> ([3]);
+return([3]);
+F0_B0:
+branch_align() -> ();
+struct_construct<Unit>() -> ([4]);
+enum_init<core::bool, 1>([4]) -> ([5]);
+store_temp<core::bool>([5]) -> ([5]);
+return([5]);
 
-test::foo@0() -> (core::bool);
+test::foo@F0() -> (core::bool);

--- a/Aegis/Tests/e2e_libfuncs/u32_aegis/u32_is_zero.sierra
+++ b/Aegis/Tests/e2e_libfuncs/u32_aegis/u32_is_zero.sierra
@@ -1,20 +1,23 @@
 type u32 = u32 [storable: true, drop: true, dup: true, zero_sized: false];
+type Const<u32, 1234> = Const<u32, 1234> [storable: false, drop: false, dup: false, zero_sized: false];
 type NonZero<u32> = NonZero<u32> [storable: true, drop: true, dup: true, zero_sized: false];
 
 libfunc u32_is_zero = u32_is_zero;
 libfunc branch_align = branch_align;
-libfunc u32_const<1234> = u32_const<1234>;
+libfunc const_as_immediate<Const<u32, 1234>> = const_as_immediate<Const<u32, 1234>>;
 libfunc store_temp<u32> = store_temp<u32>;
 libfunc unwrap_non_zero<u32> = unwrap_non_zero<u32>;
 
-u32_is_zero([0]) { fallthrough() 5([1]) }; // 0
-branch_align() -> (); // 1
-u32_const<1234>() -> ([2]); // 2
-store_temp<u32>([2]) -> ([2]); // 3
-return([2]); // 4
-branch_align() -> (); // 5
-unwrap_non_zero<u32>([1]) -> ([3]); // 6
-store_temp<u32>([3]) -> ([3]); // 7
-return([3]); // 8
+F0:
+u32_is_zero([0]) { fallthrough() F0_B0([1]) };
+branch_align() -> ();
+const_as_immediate<Const<u32, 1234>>() -> ([2]);
+store_temp<u32>([2]) -> ([2]);
+return([2]);
+F0_B0:
+branch_align() -> ();
+unwrap_non_zero<u32>([1]) -> ([3]);
+store_temp<u32>([3]) -> ([3]);
+return([3]);
 
-test::foo@0([0]: u32) -> (u32);
+test::foo@F0([0]: u32) -> (u32);

--- a/Aegis/Tests/e2e_libfuncs/u32_aegis/u32_overflowing_add.sierra
+++ b/Aegis/Tests/e2e_libfuncs/u32_aegis/u32_overflowing_add.sierra
@@ -9,16 +9,18 @@ libfunc store_temp<RangeCheck> = store_temp<RangeCheck>;
 libfunc store_temp<core::result::Result::<core::integer::u32, core::integer::u32>> = store_temp<core::result::Result::<core::integer::u32, core::integer::u32>>;
 libfunc enum_init<core::result::Result::<core::integer::u32, core::integer::u32>, 1> = enum_init<core::result::Result::<core::integer::u32, core::integer::u32>, 1>;
 
-u32_overflowing_add([0], [1], [2]) { fallthrough([3], [4]) 6([5], [6]) }; // 0
-branch_align() -> (); // 1
-enum_init<core::result::Result::<core::integer::u32, core::integer::u32>, 0>([4]) -> ([7]); // 2
-store_temp<RangeCheck>([3]) -> ([3]); // 3
-store_temp<core::result::Result::<core::integer::u32, core::integer::u32>>([7]) -> ([7]); // 4
-return([3], [7]); // 5
-branch_align() -> (); // 6
-enum_init<core::result::Result::<core::integer::u32, core::integer::u32>, 1>([6]) -> ([8]); // 7
-store_temp<RangeCheck>([5]) -> ([5]); // 8
-store_temp<core::result::Result::<core::integer::u32, core::integer::u32>>([8]) -> ([8]); // 9
-return([5], [8]); // 10
+F0:
+u32_overflowing_add([0], [1], [2]) { fallthrough([3], [4]) F0_B0([5], [6]) };
+branch_align() -> ();
+enum_init<core::result::Result::<core::integer::u32, core::integer::u32>, 0>([4]) -> ([7]);
+store_temp<RangeCheck>([3]) -> ([3]);
+store_temp<core::result::Result::<core::integer::u32, core::integer::u32>>([7]) -> ([7]);
+return([3], [7]);
+F0_B0:
+branch_align() -> ();
+enum_init<core::result::Result::<core::integer::u32, core::integer::u32>, 1>([6]) -> ([8]);
+store_temp<RangeCheck>([5]) -> ([5]);
+store_temp<core::result::Result::<core::integer::u32, core::integer::u32>>([8]) -> ([8]);
+return([5], [8]);
 
-test::foo@0([0]: RangeCheck, [1]: u32, [2]: u32) -> (RangeCheck, core::result::Result::<core::integer::u32, core::integer::u32>);
+test::foo@F0([0]: RangeCheck, [1]: u32, [2]: u32) -> (RangeCheck, core::result::Result::<core::integer::u32, core::integer::u32>);

--- a/Aegis/Tests/e2e_libfuncs/u32_aegis/u32_overflowing_sub.sierra
+++ b/Aegis/Tests/e2e_libfuncs/u32_aegis/u32_overflowing_sub.sierra
@@ -9,16 +9,18 @@ libfunc store_temp<RangeCheck> = store_temp<RangeCheck>;
 libfunc store_temp<core::result::Result::<core::integer::u32, core::integer::u32>> = store_temp<core::result::Result::<core::integer::u32, core::integer::u32>>;
 libfunc enum_init<core::result::Result::<core::integer::u32, core::integer::u32>, 1> = enum_init<core::result::Result::<core::integer::u32, core::integer::u32>, 1>;
 
-u32_overflowing_sub([0], [1], [2]) { fallthrough([3], [4]) 6([5], [6]) }; // 0
-branch_align() -> (); // 1
-enum_init<core::result::Result::<core::integer::u32, core::integer::u32>, 0>([4]) -> ([7]); // 2
-store_temp<RangeCheck>([3]) -> ([3]); // 3
-store_temp<core::result::Result::<core::integer::u32, core::integer::u32>>([7]) -> ([7]); // 4
-return([3], [7]); // 5
-branch_align() -> (); // 6
-enum_init<core::result::Result::<core::integer::u32, core::integer::u32>, 1>([6]) -> ([8]); // 7
-store_temp<RangeCheck>([5]) -> ([5]); // 8
-store_temp<core::result::Result::<core::integer::u32, core::integer::u32>>([8]) -> ([8]); // 9
-return([5], [8]); // 10
+F0:
+u32_overflowing_sub([0], [1], [2]) { fallthrough([3], [4]) F0_B0([5], [6]) };
+branch_align() -> ();
+enum_init<core::result::Result::<core::integer::u32, core::integer::u32>, 0>([4]) -> ([7]);
+store_temp<RangeCheck>([3]) -> ([3]);
+store_temp<core::result::Result::<core::integer::u32, core::integer::u32>>([7]) -> ([7]);
+return([3], [7]);
+F0_B0:
+branch_align() -> ();
+enum_init<core::result::Result::<core::integer::u32, core::integer::u32>, 1>([6]) -> ([8]);
+store_temp<RangeCheck>([5]) -> ([5]);
+store_temp<core::result::Result::<core::integer::u32, core::integer::u32>>([8]) -> ([8]);
+return([5], [8]);
 
-test::foo@0([0]: RangeCheck, [1]: u32, [2]: u32) -> (RangeCheck, core::result::Result::<core::integer::u32, core::integer::u32>);
+test::foo@F0([0]: RangeCheck, [1]: u32, [2]: u32) -> (RangeCheck, core::result::Result::<core::integer::u32, core::integer::u32>);

--- a/Aegis/Tests/e2e_libfuncs/u32_aegis/u32_safe_divmod.sierra
+++ b/Aegis/Tests/e2e_libfuncs/u32_aegis/u32_safe_divmod.sierra
@@ -8,10 +8,11 @@ libfunc struct_construct<Tuple<u32, u32>> = struct_construct<Tuple<u32, u32>>;
 libfunc store_temp<RangeCheck> = store_temp<RangeCheck>;
 libfunc store_temp<Tuple<u32, u32>> = store_temp<Tuple<u32, u32>>;
 
-u32_safe_divmod([0], [1], [2]) -> ([3], [4], [5]); // 0
-struct_construct<Tuple<u32, u32>>([4], [5]) -> ([6]); // 1
-store_temp<RangeCheck>([3]) -> ([3]); // 2
-store_temp<Tuple<u32, u32>>([6]) -> ([6]); // 3
-return([3], [6]); // 4
+F0:
+u32_safe_divmod([0], [1], [2]) -> ([3], [4], [5]);
+struct_construct<Tuple<u32, u32>>([4], [5]) -> ([6]);
+store_temp<RangeCheck>([3]) -> ([3]);
+store_temp<Tuple<u32, u32>>([6]) -> ([6]);
+return([3], [6]);
 
-test::foo@0([0]: RangeCheck, [1]: u32, [2]: NonZero<u32>) -> (RangeCheck, Tuple<u32, u32>);
+test::foo@F0([0]: RangeCheck, [1]: u32, [2]: NonZero<u32>) -> (RangeCheck, Tuple<u32, u32>);

--- a/Aegis/Tests/e2e_libfuncs/u32_aegis/u32_sqrt.sierra
+++ b/Aegis/Tests/e2e_libfuncs/u32_aegis/u32_sqrt.sierra
@@ -6,9 +6,10 @@ libfunc u32_sqrt = u32_sqrt;
 libfunc store_temp<RangeCheck> = store_temp<RangeCheck>;
 libfunc store_temp<u16> = store_temp<u16>;
 
-u32_sqrt([0], [1]) -> ([2], [3]); // 0
-store_temp<RangeCheck>([2]) -> ([2]); // 1
-store_temp<u16>([3]) -> ([3]); // 2
-return([2], [3]); // 3
+F0:
+u32_sqrt([0], [1]) -> ([2], [3]);
+store_temp<RangeCheck>([2]) -> ([2]);
+store_temp<u16>([3]) -> ([3]);
+return([2], [3]);
 
-test::foo@0([0]: RangeCheck, [1]: u32) -> (RangeCheck, u16);
+test::foo@F0([0]: RangeCheck, [1]: u32) -> (RangeCheck, u16);

--- a/Aegis/Tests/e2e_libfuncs/u32_aegis/u32_try_from_felt252.sierra
+++ b/Aegis/Tests/e2e_libfuncs/u32_aegis/u32_try_from_felt252.sierra
@@ -12,17 +12,19 @@ libfunc store_temp<core::option::Option::<core::integer::u32>> = store_temp<core
 libfunc struct_construct<Unit> = struct_construct<Unit>;
 libfunc enum_init<core::option::Option::<core::integer::u32>, 1> = enum_init<core::option::Option::<core::integer::u32>, 1>;
 
-u32_try_from_felt252([0], [1]) { fallthrough([2], [3]) 6([4]) }; // 0
-branch_align() -> (); // 1
-enum_init<core::option::Option::<core::integer::u32>, 0>([3]) -> ([5]); // 2
-store_temp<RangeCheck>([2]) -> ([2]); // 3
-store_temp<core::option::Option::<core::integer::u32>>([5]) -> ([5]); // 4
-return([2], [5]); // 5
-branch_align() -> (); // 6
-struct_construct<Unit>() -> ([6]); // 7
-enum_init<core::option::Option::<core::integer::u32>, 1>([6]) -> ([7]); // 8
-store_temp<RangeCheck>([4]) -> ([4]); // 9
-store_temp<core::option::Option::<core::integer::u32>>([7]) -> ([7]); // 10
-return([4], [7]); // 11
+F0:
+u32_try_from_felt252([0], [1]) { fallthrough([2], [3]) F0_B0([4]) };
+branch_align() -> ();
+enum_init<core::option::Option::<core::integer::u32>, 0>([3]) -> ([5]);
+store_temp<RangeCheck>([2]) -> ([2]);
+store_temp<core::option::Option::<core::integer::u32>>([5]) -> ([5]);
+return([2], [5]);
+F0_B0:
+branch_align() -> ();
+struct_construct<Unit>() -> ([6]);
+enum_init<core::option::Option::<core::integer::u32>, 1>([6]) -> ([7]);
+store_temp<RangeCheck>([4]) -> ([4]);
+store_temp<core::option::Option::<core::integer::u32>>([7]) -> ([7]);
+return([4], [7]);
 
-test::foo@0([0]: RangeCheck, [1]: felt252) -> (RangeCheck, core::option::Option::<core::integer::u32>);
+test::foo@F0([0]: RangeCheck, [1]: felt252) -> (RangeCheck, core::option::Option::<core::integer::u32>);

--- a/Aegis/Tests/e2e_libfuncs/u32_aegis/u32_wide_mul.sierra
+++ b/Aegis/Tests/e2e_libfuncs/u32_aegis/u32_wide_mul.sierra
@@ -4,8 +4,9 @@ type u64 = u64 [storable: true, drop: true, dup: true, zero_sized: false];
 libfunc u32_wide_mul = u32_wide_mul;
 libfunc store_temp<u64> = store_temp<u64>;
 
-u32_wide_mul([0], [1]) -> ([2]); // 0
-store_temp<u64>([2]) -> ([2]); // 1
-return([2]); // 2
+F0:
+u32_wide_mul([0], [1]) -> ([2]);
+store_temp<u64>([2]) -> ([2]);
+return([2]);
 
-test::foo@0([0]: u32, [1]: u32) -> (u64);
+test::foo@F0([0]: u32, [1]: u32) -> (u64);

--- a/Aegis/Tests/e2e_libfuncs/u512_aegis/u512_safe_divmod_by_u256.sierra
+++ b/Aegis/Tests/e2e_libfuncs/u512_aegis/u512_safe_divmod_by_u256.sierra
@@ -12,15 +12,16 @@ libfunc struct_construct<Tuple<core::integer::u512, core::integer::u256>> = stru
 libfunc store_temp<RangeCheck> = store_temp<RangeCheck>;
 libfunc store_temp<Tuple<core::integer::u512, core::integer::u256>> = store_temp<Tuple<core::integer::u512, core::integer::u256>>;
 
-u512_safe_divmod_by_u256([0], [1], [2]) -> ([3], [4], [5], [6], [7], [8], [9], [10]); // 0
-u128_mul_guarantee_verify([3], [10]) -> ([11]); // 1
-u128_mul_guarantee_verify([11], [9]) -> ([12]); // 2
-u128_mul_guarantee_verify([12], [8]) -> ([13]); // 3
-u128_mul_guarantee_verify([13], [7]) -> ([14]); // 4
-u128_mul_guarantee_verify([14], [6]) -> ([15]); // 5
-struct_construct<Tuple<core::integer::u512, core::integer::u256>>([4], [5]) -> ([16]); // 6
-store_temp<RangeCheck>([15]) -> ([15]); // 7
-store_temp<Tuple<core::integer::u512, core::integer::u256>>([16]) -> ([16]); // 8
-return([15], [16]); // 9
+F0:
+u512_safe_divmod_by_u256([0], [1], [2]) -> ([3], [4], [5], [6], [7], [8], [9], [10]);
+u128_mul_guarantee_verify([3], [10]) -> ([11]);
+u128_mul_guarantee_verify([11], [9]) -> ([12]);
+u128_mul_guarantee_verify([12], [8]) -> ([13]);
+u128_mul_guarantee_verify([13], [7]) -> ([14]);
+u128_mul_guarantee_verify([14], [6]) -> ([15]);
+struct_construct<Tuple<core::integer::u512, core::integer::u256>>([4], [5]) -> ([16]);
+store_temp<RangeCheck>([15]) -> ([15]);
+store_temp<Tuple<core::integer::u512, core::integer::u256>>([16]) -> ([16]);
+return([15], [16]);
 
-test::foo@0([0]: RangeCheck, [1]: core::integer::u512, [2]: NonZero<core::integer::u256>) -> (RangeCheck, Tuple<core::integer::u512, core::integer::u256>);
+test::foo@F0([0]: RangeCheck, [1]: core::integer::u512, [2]: NonZero<core::integer::u256>) -> (RangeCheck, Tuple<core::integer::u512, core::integer::u256>);

--- a/Aegis/Tests/e2e_libfuncs/u64_aegis/u64_eq.sierra
+++ b/Aegis/Tests/e2e_libfuncs/u64_aegis/u64_eq.sierra
@@ -1,9 +1,11 @@
 type u64 = u64 [storable: true, drop: true, dup: true, zero_sized: false];
 type Unit = Struct<ut@Tuple> [storable: true, drop: true, dup: true, zero_sized: true];
 type core::bool = Enum<ut@core::bool, Unit, Unit> [storable: true, drop: true, dup: true, zero_sized: false];
+type Const<u64, 12> = Const<u64, 12> [storable: false, drop: false, dup: false, zero_sized: false];
+type Const<u64, 11> = Const<u64, 11> [storable: false, drop: false, dup: false, zero_sized: false];
 
-libfunc u64_const<11> = u64_const<11>;
-libfunc u64_const<12> = u64_const<12>;
+libfunc const_as_immediate<Const<u64, 11>> = const_as_immediate<Const<u64, 11>>;
+libfunc const_as_immediate<Const<u64, 12>> = const_as_immediate<Const<u64, 12>>;
 libfunc store_temp<u64> = store_temp<u64>;
 libfunc u64_eq = u64_eq;
 libfunc branch_align = branch_align;
@@ -12,19 +14,21 @@ libfunc enum_init<core::bool, 0> = enum_init<core::bool, 0>;
 libfunc store_temp<core::bool> = store_temp<core::bool>;
 libfunc enum_init<core::bool, 1> = enum_init<core::bool, 1>;
 
-u64_const<11>() -> ([0]); // 0
-u64_const<12>() -> ([1]); // 1
-store_temp<u64>([0]) -> ([0]); // 2
-u64_eq([0], [1]) { fallthrough() 9() }; // 3
-branch_align() -> (); // 4
-struct_construct<Unit>() -> ([2]); // 5
-enum_init<core::bool, 0>([2]) -> ([3]); // 6
-store_temp<core::bool>([3]) -> ([3]); // 7
-return([3]); // 8
-branch_align() -> (); // 9
-struct_construct<Unit>() -> ([4]); // 10
-enum_init<core::bool, 1>([4]) -> ([5]); // 11
-store_temp<core::bool>([5]) -> ([5]); // 12
-return([5]); // 13
+F0:
+const_as_immediate<Const<u64, 11>>() -> ([0]);
+const_as_immediate<Const<u64, 12>>() -> ([1]);
+store_temp<u64>([0]) -> ([0]);
+u64_eq([0], [1]) { fallthrough() F0_B0() };
+branch_align() -> ();
+struct_construct<Unit>() -> ([2]);
+enum_init<core::bool, 0>([2]) -> ([3]);
+store_temp<core::bool>([3]) -> ([3]);
+return([3]);
+F0_B0:
+branch_align() -> ();
+struct_construct<Unit>() -> ([4]);
+enum_init<core::bool, 1>([4]) -> ([5]);
+store_temp<core::bool>([5]) -> ([5]);
+return([5]);
 
-test::foo@0() -> (core::bool);
+test::foo@F0() -> (core::bool);

--- a/Aegis/Tests/e2e_libfuncs/u64_aegis/u64_is_zero.sierra
+++ b/Aegis/Tests/e2e_libfuncs/u64_aegis/u64_is_zero.sierra
@@ -1,20 +1,23 @@
 type u64 = u64 [storable: true, drop: true, dup: true, zero_sized: false];
+type Const<u64, 1234> = Const<u64, 1234> [storable: false, drop: false, dup: false, zero_sized: false];
 type NonZero<u64> = NonZero<u64> [storable: true, drop: true, dup: true, zero_sized: false];
 
 libfunc u64_is_zero = u64_is_zero;
 libfunc branch_align = branch_align;
-libfunc u64_const<1234> = u64_const<1234>;
+libfunc const_as_immediate<Const<u64, 1234>> = const_as_immediate<Const<u64, 1234>>;
 libfunc store_temp<u64> = store_temp<u64>;
 libfunc unwrap_non_zero<u64> = unwrap_non_zero<u64>;
 
-u64_is_zero([0]) { fallthrough() 5([1]) }; // 0
-branch_align() -> (); // 1
-u64_const<1234>() -> ([2]); // 2
-store_temp<u64>([2]) -> ([2]); // 3
-return([2]); // 4
-branch_align() -> (); // 5
-unwrap_non_zero<u64>([1]) -> ([3]); // 6
-store_temp<u64>([3]) -> ([3]); // 7
-return([3]); // 8
+F0:
+u64_is_zero([0]) { fallthrough() F0_B0([1]) };
+branch_align() -> ();
+const_as_immediate<Const<u64, 1234>>() -> ([2]);
+store_temp<u64>([2]) -> ([2]);
+return([2]);
+F0_B0:
+branch_align() -> ();
+unwrap_non_zero<u64>([1]) -> ([3]);
+store_temp<u64>([3]) -> ([3]);
+return([3]);
 
-test::foo@0([0]: u64) -> (u64);
+test::foo@F0([0]: u64) -> (u64);

--- a/Aegis/Tests/e2e_libfuncs/u64_aegis/u64_overflowing_add.sierra
+++ b/Aegis/Tests/e2e_libfuncs/u64_aegis/u64_overflowing_add.sierra
@@ -9,16 +9,18 @@ libfunc store_temp<RangeCheck> = store_temp<RangeCheck>;
 libfunc store_temp<core::result::Result::<core::integer::u64, core::integer::u64>> = store_temp<core::result::Result::<core::integer::u64, core::integer::u64>>;
 libfunc enum_init<core::result::Result::<core::integer::u64, core::integer::u64>, 1> = enum_init<core::result::Result::<core::integer::u64, core::integer::u64>, 1>;
 
-u64_overflowing_add([0], [1], [2]) { fallthrough([3], [4]) 6([5], [6]) }; // 0
-branch_align() -> (); // 1
-enum_init<core::result::Result::<core::integer::u64, core::integer::u64>, 0>([4]) -> ([7]); // 2
-store_temp<RangeCheck>([3]) -> ([3]); // 3
-store_temp<core::result::Result::<core::integer::u64, core::integer::u64>>([7]) -> ([7]); // 4
-return([3], [7]); // 5
-branch_align() -> (); // 6
-enum_init<core::result::Result::<core::integer::u64, core::integer::u64>, 1>([6]) -> ([8]); // 7
-store_temp<RangeCheck>([5]) -> ([5]); // 8
-store_temp<core::result::Result::<core::integer::u64, core::integer::u64>>([8]) -> ([8]); // 9
-return([5], [8]); // 10
+F0:
+u64_overflowing_add([0], [1], [2]) { fallthrough([3], [4]) F0_B0([5], [6]) };
+branch_align() -> ();
+enum_init<core::result::Result::<core::integer::u64, core::integer::u64>, 0>([4]) -> ([7]);
+store_temp<RangeCheck>([3]) -> ([3]);
+store_temp<core::result::Result::<core::integer::u64, core::integer::u64>>([7]) -> ([7]);
+return([3], [7]);
+F0_B0:
+branch_align() -> ();
+enum_init<core::result::Result::<core::integer::u64, core::integer::u64>, 1>([6]) -> ([8]);
+store_temp<RangeCheck>([5]) -> ([5]);
+store_temp<core::result::Result::<core::integer::u64, core::integer::u64>>([8]) -> ([8]);
+return([5], [8]);
 
-test::foo@0([0]: RangeCheck, [1]: u64, [2]: u64) -> (RangeCheck, core::result::Result::<core::integer::u64, core::integer::u64>);
+test::foo@F0([0]: RangeCheck, [1]: u64, [2]: u64) -> (RangeCheck, core::result::Result::<core::integer::u64, core::integer::u64>);

--- a/Aegis/Tests/e2e_libfuncs/u64_aegis/u64_overflowing_sub.sierra
+++ b/Aegis/Tests/e2e_libfuncs/u64_aegis/u64_overflowing_sub.sierra
@@ -9,16 +9,18 @@ libfunc store_temp<RangeCheck> = store_temp<RangeCheck>;
 libfunc store_temp<core::result::Result::<core::integer::u64, core::integer::u64>> = store_temp<core::result::Result::<core::integer::u64, core::integer::u64>>;
 libfunc enum_init<core::result::Result::<core::integer::u64, core::integer::u64>, 1> = enum_init<core::result::Result::<core::integer::u64, core::integer::u64>, 1>;
 
-u64_overflowing_sub([0], [1], [2]) { fallthrough([3], [4]) 6([5], [6]) }; // 0
-branch_align() -> (); // 1
-enum_init<core::result::Result::<core::integer::u64, core::integer::u64>, 0>([4]) -> ([7]); // 2
-store_temp<RangeCheck>([3]) -> ([3]); // 3
-store_temp<core::result::Result::<core::integer::u64, core::integer::u64>>([7]) -> ([7]); // 4
-return([3], [7]); // 5
-branch_align() -> (); // 6
-enum_init<core::result::Result::<core::integer::u64, core::integer::u64>, 1>([6]) -> ([8]); // 7
-store_temp<RangeCheck>([5]) -> ([5]); // 8
-store_temp<core::result::Result::<core::integer::u64, core::integer::u64>>([8]) -> ([8]); // 9
-return([5], [8]); // 10
+F0:
+u64_overflowing_sub([0], [1], [2]) { fallthrough([3], [4]) F0_B0([5], [6]) };
+branch_align() -> ();
+enum_init<core::result::Result::<core::integer::u64, core::integer::u64>, 0>([4]) -> ([7]);
+store_temp<RangeCheck>([3]) -> ([3]);
+store_temp<core::result::Result::<core::integer::u64, core::integer::u64>>([7]) -> ([7]);
+return([3], [7]);
+F0_B0:
+branch_align() -> ();
+enum_init<core::result::Result::<core::integer::u64, core::integer::u64>, 1>([6]) -> ([8]);
+store_temp<RangeCheck>([5]) -> ([5]);
+store_temp<core::result::Result::<core::integer::u64, core::integer::u64>>([8]) -> ([8]);
+return([5], [8]);
 
-test::foo@0([0]: RangeCheck, [1]: u64, [2]: u64) -> (RangeCheck, core::result::Result::<core::integer::u64, core::integer::u64>);
+test::foo@F0([0]: RangeCheck, [1]: u64, [2]: u64) -> (RangeCheck, core::result::Result::<core::integer::u64, core::integer::u64>);

--- a/Aegis/Tests/e2e_libfuncs/u64_aegis/u64_safe_divmod.sierra
+++ b/Aegis/Tests/e2e_libfuncs/u64_aegis/u64_safe_divmod.sierra
@@ -8,10 +8,11 @@ libfunc struct_construct<Tuple<u64, u64>> = struct_construct<Tuple<u64, u64>>;
 libfunc store_temp<RangeCheck> = store_temp<RangeCheck>;
 libfunc store_temp<Tuple<u64, u64>> = store_temp<Tuple<u64, u64>>;
 
-u64_safe_divmod([0], [1], [2]) -> ([3], [4], [5]); // 0
-struct_construct<Tuple<u64, u64>>([4], [5]) -> ([6]); // 1
-store_temp<RangeCheck>([3]) -> ([3]); // 2
-store_temp<Tuple<u64, u64>>([6]) -> ([6]); // 3
-return([3], [6]); // 4
+F0:
+u64_safe_divmod([0], [1], [2]) -> ([3], [4], [5]);
+struct_construct<Tuple<u64, u64>>([4], [5]) -> ([6]);
+store_temp<RangeCheck>([3]) -> ([3]);
+store_temp<Tuple<u64, u64>>([6]) -> ([6]);
+return([3], [6]);
 
-test::foo@0([0]: RangeCheck, [1]: u64, [2]: NonZero<u64>) -> (RangeCheck, Tuple<u64, u64>);
+test::foo@F0([0]: RangeCheck, [1]: u64, [2]: NonZero<u64>) -> (RangeCheck, Tuple<u64, u64>);

--- a/Aegis/Tests/e2e_libfuncs/u64_aegis/u64_sqrt.sierra
+++ b/Aegis/Tests/e2e_libfuncs/u64_aegis/u64_sqrt.sierra
@@ -6,9 +6,10 @@ libfunc u64_sqrt = u64_sqrt;
 libfunc store_temp<RangeCheck> = store_temp<RangeCheck>;
 libfunc store_temp<u32> = store_temp<u32>;
 
-u64_sqrt([0], [1]) -> ([2], [3]); // 0
-store_temp<RangeCheck>([2]) -> ([2]); // 1
-store_temp<u32>([3]) -> ([3]); // 2
-return([2], [3]); // 3
+F0:
+u64_sqrt([0], [1]) -> ([2], [3]);
+store_temp<RangeCheck>([2]) -> ([2]);
+store_temp<u32>([3]) -> ([3]);
+return([2], [3]);
 
-test::foo@0([0]: RangeCheck, [1]: u64) -> (RangeCheck, u32);
+test::foo@F0([0]: RangeCheck, [1]: u64) -> (RangeCheck, u32);

--- a/Aegis/Tests/e2e_libfuncs/u64_aegis/u64_try_from_felt252.sierra
+++ b/Aegis/Tests/e2e_libfuncs/u64_aegis/u64_try_from_felt252.sierra
@@ -12,17 +12,19 @@ libfunc store_temp<core::option::Option::<core::integer::u64>> = store_temp<core
 libfunc struct_construct<Unit> = struct_construct<Unit>;
 libfunc enum_init<core::option::Option::<core::integer::u64>, 1> = enum_init<core::option::Option::<core::integer::u64>, 1>;
 
-u64_try_from_felt252([0], [1]) { fallthrough([2], [3]) 6([4]) }; // 0
-branch_align() -> (); // 1
-enum_init<core::option::Option::<core::integer::u64>, 0>([3]) -> ([5]); // 2
-store_temp<RangeCheck>([2]) -> ([2]); // 3
-store_temp<core::option::Option::<core::integer::u64>>([5]) -> ([5]); // 4
-return([2], [5]); // 5
-branch_align() -> (); // 6
-struct_construct<Unit>() -> ([6]); // 7
-enum_init<core::option::Option::<core::integer::u64>, 1>([6]) -> ([7]); // 8
-store_temp<RangeCheck>([4]) -> ([4]); // 9
-store_temp<core::option::Option::<core::integer::u64>>([7]) -> ([7]); // 10
-return([4], [7]); // 11
+F0:
+u64_try_from_felt252([0], [1]) { fallthrough([2], [3]) F0_B0([4]) };
+branch_align() -> ();
+enum_init<core::option::Option::<core::integer::u64>, 0>([3]) -> ([5]);
+store_temp<RangeCheck>([2]) -> ([2]);
+store_temp<core::option::Option::<core::integer::u64>>([5]) -> ([5]);
+return([2], [5]);
+F0_B0:
+branch_align() -> ();
+struct_construct<Unit>() -> ([6]);
+enum_init<core::option::Option::<core::integer::u64>, 1>([6]) -> ([7]);
+store_temp<RangeCheck>([4]) -> ([4]);
+store_temp<core::option::Option::<core::integer::u64>>([7]) -> ([7]);
+return([4], [7]);
 
-test::foo@0([0]: RangeCheck, [1]: felt252) -> (RangeCheck, core::option::Option::<core::integer::u64>);
+test::foo@F0([0]: RangeCheck, [1]: felt252) -> (RangeCheck, core::option::Option::<core::integer::u64>);

--- a/Aegis/Tests/e2e_libfuncs/u64_aegis/u64_wide_mul.sierra
+++ b/Aegis/Tests/e2e_libfuncs/u64_aegis/u64_wide_mul.sierra
@@ -4,8 +4,9 @@ type u128 = u128 [storable: true, drop: true, dup: true, zero_sized: false];
 libfunc u64_wide_mul = u64_wide_mul;
 libfunc store_temp<u128> = store_temp<u128>;
 
-u64_wide_mul([0], [1]) -> ([2]); // 0
-store_temp<u128>([2]) -> ([2]); // 1
-return([2]); // 2
+F0:
+u64_wide_mul([0], [1]) -> ([2]);
+store_temp<u128>([2]) -> ([2]);
+return([2]);
 
-test::foo@0([0]: u64, [1]: u64) -> (u128);
+test::foo@F0([0]: u64, [1]: u64) -> (u128);

--- a/Aegis/Tests/e2e_libfuncs/u8_aegis/u8_eq.sierra
+++ b/Aegis/Tests/e2e_libfuncs/u8_aegis/u8_eq.sierra
@@ -1,9 +1,11 @@
 type u8 = u8 [storable: true, drop: true, dup: true, zero_sized: false];
 type Unit = Struct<ut@Tuple> [storable: true, drop: true, dup: true, zero_sized: true];
 type core::bool = Enum<ut@core::bool, Unit, Unit> [storable: true, drop: true, dup: true, zero_sized: false];
+type Const<u8, 12> = Const<u8, 12> [storable: false, drop: false, dup: false, zero_sized: false];
+type Const<u8, 11> = Const<u8, 11> [storable: false, drop: false, dup: false, zero_sized: false];
 
-libfunc u8_const<11> = u8_const<11>;
-libfunc u8_const<12> = u8_const<12>;
+libfunc const_as_immediate<Const<u8, 11>> = const_as_immediate<Const<u8, 11>>;
+libfunc const_as_immediate<Const<u8, 12>> = const_as_immediate<Const<u8, 12>>;
 libfunc store_temp<u8> = store_temp<u8>;
 libfunc u8_eq = u8_eq;
 libfunc branch_align = branch_align;
@@ -12,19 +14,21 @@ libfunc enum_init<core::bool, 0> = enum_init<core::bool, 0>;
 libfunc store_temp<core::bool> = store_temp<core::bool>;
 libfunc enum_init<core::bool, 1> = enum_init<core::bool, 1>;
 
-u8_const<11>() -> ([0]); // 0
-u8_const<12>() -> ([1]); // 1
-store_temp<u8>([0]) -> ([0]); // 2
-u8_eq([0], [1]) { fallthrough() 9() }; // 3
-branch_align() -> (); // 4
-struct_construct<Unit>() -> ([2]); // 5
-enum_init<core::bool, 0>([2]) -> ([3]); // 6
-store_temp<core::bool>([3]) -> ([3]); // 7
-return([3]); // 8
-branch_align() -> (); // 9
-struct_construct<Unit>() -> ([4]); // 10
-enum_init<core::bool, 1>([4]) -> ([5]); // 11
-store_temp<core::bool>([5]) -> ([5]); // 12
-return([5]); // 13
+F0:
+const_as_immediate<Const<u8, 11>>() -> ([0]);
+const_as_immediate<Const<u8, 12>>() -> ([1]);
+store_temp<u8>([0]) -> ([0]);
+u8_eq([0], [1]) { fallthrough() F0_B0() };
+branch_align() -> ();
+struct_construct<Unit>() -> ([2]);
+enum_init<core::bool, 0>([2]) -> ([3]);
+store_temp<core::bool>([3]) -> ([3]);
+return([3]);
+F0_B0:
+branch_align() -> ();
+struct_construct<Unit>() -> ([4]);
+enum_init<core::bool, 1>([4]) -> ([5]);
+store_temp<core::bool>([5]) -> ([5]);
+return([5]);
 
-test::foo@0() -> (core::bool);
+test::foo@F0() -> (core::bool);

--- a/Aegis/Tests/e2e_libfuncs/u8_aegis/u8_is_zero.sierra
+++ b/Aegis/Tests/e2e_libfuncs/u8_aegis/u8_is_zero.sierra
@@ -1,20 +1,23 @@
 type u8 = u8 [storable: true, drop: true, dup: true, zero_sized: false];
+type Const<u8, 123> = Const<u8, 123> [storable: false, drop: false, dup: false, zero_sized: false];
 type NonZero<u8> = NonZero<u8> [storable: true, drop: true, dup: true, zero_sized: false];
 
 libfunc u8_is_zero = u8_is_zero;
 libfunc branch_align = branch_align;
-libfunc u8_const<123> = u8_const<123>;
+libfunc const_as_immediate<Const<u8, 123>> = const_as_immediate<Const<u8, 123>>;
 libfunc store_temp<u8> = store_temp<u8>;
 libfunc unwrap_non_zero<u8> = unwrap_non_zero<u8>;
 
-u8_is_zero([0]) { fallthrough() 5([1]) }; // 0
-branch_align() -> (); // 1
-u8_const<123>() -> ([2]); // 2
-store_temp<u8>([2]) -> ([2]); // 3
-return([2]); // 4
-branch_align() -> (); // 5
-unwrap_non_zero<u8>([1]) -> ([3]); // 6
-store_temp<u8>([3]) -> ([3]); // 7
-return([3]); // 8
+F0:
+u8_is_zero([0]) { fallthrough() F0_B0([1]) };
+branch_align() -> ();
+const_as_immediate<Const<u8, 123>>() -> ([2]);
+store_temp<u8>([2]) -> ([2]);
+return([2]);
+F0_B0:
+branch_align() -> ();
+unwrap_non_zero<u8>([1]) -> ([3]);
+store_temp<u8>([3]) -> ([3]);
+return([3]);
 
-test::foo@0([0]: u8) -> (u8);
+test::foo@F0([0]: u8) -> (u8);

--- a/Aegis/Tests/e2e_libfuncs/u8_aegis/u8_overflowing_add.sierra
+++ b/Aegis/Tests/e2e_libfuncs/u8_aegis/u8_overflowing_add.sierra
@@ -9,16 +9,18 @@ libfunc store_temp<RangeCheck> = store_temp<RangeCheck>;
 libfunc store_temp<core::result::Result::<core::integer::u8, core::integer::u8>> = store_temp<core::result::Result::<core::integer::u8, core::integer::u8>>;
 libfunc enum_init<core::result::Result::<core::integer::u8, core::integer::u8>, 1> = enum_init<core::result::Result::<core::integer::u8, core::integer::u8>, 1>;
 
-u8_overflowing_add([0], [1], [2]) { fallthrough([3], [4]) 6([5], [6]) }; // 0
-branch_align() -> (); // 1
-enum_init<core::result::Result::<core::integer::u8, core::integer::u8>, 0>([4]) -> ([7]); // 2
-store_temp<RangeCheck>([3]) -> ([3]); // 3
-store_temp<core::result::Result::<core::integer::u8, core::integer::u8>>([7]) -> ([7]); // 4
-return([3], [7]); // 5
-branch_align() -> (); // 6
-enum_init<core::result::Result::<core::integer::u8, core::integer::u8>, 1>([6]) -> ([8]); // 7
-store_temp<RangeCheck>([5]) -> ([5]); // 8
-store_temp<core::result::Result::<core::integer::u8, core::integer::u8>>([8]) -> ([8]); // 9
-return([5], [8]); // 10
+F0:
+u8_overflowing_add([0], [1], [2]) { fallthrough([3], [4]) F0_B0([5], [6]) };
+branch_align() -> ();
+enum_init<core::result::Result::<core::integer::u8, core::integer::u8>, 0>([4]) -> ([7]);
+store_temp<RangeCheck>([3]) -> ([3]);
+store_temp<core::result::Result::<core::integer::u8, core::integer::u8>>([7]) -> ([7]);
+return([3], [7]);
+F0_B0:
+branch_align() -> ();
+enum_init<core::result::Result::<core::integer::u8, core::integer::u8>, 1>([6]) -> ([8]);
+store_temp<RangeCheck>([5]) -> ([5]);
+store_temp<core::result::Result::<core::integer::u8, core::integer::u8>>([8]) -> ([8]);
+return([5], [8]);
 
-test::foo@0([0]: RangeCheck, [1]: u8, [2]: u8) -> (RangeCheck, core::result::Result::<core::integer::u8, core::integer::u8>);
+test::foo@F0([0]: RangeCheck, [1]: u8, [2]: u8) -> (RangeCheck, core::result::Result::<core::integer::u8, core::integer::u8>);

--- a/Aegis/Tests/e2e_libfuncs/u8_aegis/u8_overflowing_sub.sierra
+++ b/Aegis/Tests/e2e_libfuncs/u8_aegis/u8_overflowing_sub.sierra
@@ -9,16 +9,18 @@ libfunc store_temp<RangeCheck> = store_temp<RangeCheck>;
 libfunc store_temp<core::result::Result::<core::integer::u8, core::integer::u8>> = store_temp<core::result::Result::<core::integer::u8, core::integer::u8>>;
 libfunc enum_init<core::result::Result::<core::integer::u8, core::integer::u8>, 1> = enum_init<core::result::Result::<core::integer::u8, core::integer::u8>, 1>;
 
-u8_overflowing_sub([0], [1], [2]) { fallthrough([3], [4]) 6([5], [6]) }; // 0
-branch_align() -> (); // 1
-enum_init<core::result::Result::<core::integer::u8, core::integer::u8>, 0>([4]) -> ([7]); // 2
-store_temp<RangeCheck>([3]) -> ([3]); // 3
-store_temp<core::result::Result::<core::integer::u8, core::integer::u8>>([7]) -> ([7]); // 4
-return([3], [7]); // 5
-branch_align() -> (); // 6
-enum_init<core::result::Result::<core::integer::u8, core::integer::u8>, 1>([6]) -> ([8]); // 7
-store_temp<RangeCheck>([5]) -> ([5]); // 8
-store_temp<core::result::Result::<core::integer::u8, core::integer::u8>>([8]) -> ([8]); // 9
-return([5], [8]); // 10
+F0:
+u8_overflowing_sub([0], [1], [2]) { fallthrough([3], [4]) F0_B0([5], [6]) };
+branch_align() -> ();
+enum_init<core::result::Result::<core::integer::u8, core::integer::u8>, 0>([4]) -> ([7]);
+store_temp<RangeCheck>([3]) -> ([3]);
+store_temp<core::result::Result::<core::integer::u8, core::integer::u8>>([7]) -> ([7]);
+return([3], [7]);
+F0_B0:
+branch_align() -> ();
+enum_init<core::result::Result::<core::integer::u8, core::integer::u8>, 1>([6]) -> ([8]);
+store_temp<RangeCheck>([5]) -> ([5]);
+store_temp<core::result::Result::<core::integer::u8, core::integer::u8>>([8]) -> ([8]);
+return([5], [8]);
 
-test::foo@0([0]: RangeCheck, [1]: u8, [2]: u8) -> (RangeCheck, core::result::Result::<core::integer::u8, core::integer::u8>);
+test::foo@F0([0]: RangeCheck, [1]: u8, [2]: u8) -> (RangeCheck, core::result::Result::<core::integer::u8, core::integer::u8>);

--- a/Aegis/Tests/e2e_libfuncs/u8_aegis/u8_safe_divmod.sierra
+++ b/Aegis/Tests/e2e_libfuncs/u8_aegis/u8_safe_divmod.sierra
@@ -8,10 +8,11 @@ libfunc struct_construct<Tuple<u8, u8>> = struct_construct<Tuple<u8, u8>>;
 libfunc store_temp<RangeCheck> = store_temp<RangeCheck>;
 libfunc store_temp<Tuple<u8, u8>> = store_temp<Tuple<u8, u8>>;
 
-u8_safe_divmod([0], [1], [2]) -> ([3], [4], [5]); // 0
-struct_construct<Tuple<u8, u8>>([4], [5]) -> ([6]); // 1
-store_temp<RangeCheck>([3]) -> ([3]); // 2
-store_temp<Tuple<u8, u8>>([6]) -> ([6]); // 3
-return([3], [6]); // 4
+F0:
+u8_safe_divmod([0], [1], [2]) -> ([3], [4], [5]);
+struct_construct<Tuple<u8, u8>>([4], [5]) -> ([6]);
+store_temp<RangeCheck>([3]) -> ([3]);
+store_temp<Tuple<u8, u8>>([6]) -> ([6]);
+return([3], [6]);
 
-test::foo@0([0]: RangeCheck, [1]: u8, [2]: NonZero<u8>) -> (RangeCheck, Tuple<u8, u8>);
+test::foo@F0([0]: RangeCheck, [1]: u8, [2]: NonZero<u8>) -> (RangeCheck, Tuple<u8, u8>);

--- a/Aegis/Tests/e2e_libfuncs/u8_aegis/u8_sqrt.sierra
+++ b/Aegis/Tests/e2e_libfuncs/u8_aegis/u8_sqrt.sierra
@@ -5,9 +5,10 @@ libfunc u8_sqrt = u8_sqrt;
 libfunc store_temp<RangeCheck> = store_temp<RangeCheck>;
 libfunc store_temp<u8> = store_temp<u8>;
 
-u8_sqrt([0], [1]) -> ([2], [3]); // 0
-store_temp<RangeCheck>([2]) -> ([2]); // 1
-store_temp<u8>([3]) -> ([3]); // 2
-return([2], [3]); // 3
+F0:
+u8_sqrt([0], [1]) -> ([2], [3]);
+store_temp<RangeCheck>([2]) -> ([2]);
+store_temp<u8>([3]) -> ([3]);
+return([2], [3]);
 
-test::foo@0([0]: RangeCheck, [1]: u8) -> (RangeCheck, u8);
+test::foo@F0([0]: RangeCheck, [1]: u8) -> (RangeCheck, u8);

--- a/Aegis/Tests/e2e_libfuncs/u8_aegis/u8_try_from_felt252.sierra
+++ b/Aegis/Tests/e2e_libfuncs/u8_aegis/u8_try_from_felt252.sierra
@@ -12,17 +12,19 @@ libfunc store_temp<core::option::Option::<core::integer::u8>> = store_temp<core:
 libfunc struct_construct<Unit> = struct_construct<Unit>;
 libfunc enum_init<core::option::Option::<core::integer::u8>, 1> = enum_init<core::option::Option::<core::integer::u8>, 1>;
 
-u8_try_from_felt252([0], [1]) { fallthrough([2], [3]) 6([4]) }; // 0
-branch_align() -> (); // 1
-enum_init<core::option::Option::<core::integer::u8>, 0>([3]) -> ([5]); // 2
-store_temp<RangeCheck>([2]) -> ([2]); // 3
-store_temp<core::option::Option::<core::integer::u8>>([5]) -> ([5]); // 4
-return([2], [5]); // 5
-branch_align() -> (); // 6
-struct_construct<Unit>() -> ([6]); // 7
-enum_init<core::option::Option::<core::integer::u8>, 1>([6]) -> ([7]); // 8
-store_temp<RangeCheck>([4]) -> ([4]); // 9
-store_temp<core::option::Option::<core::integer::u8>>([7]) -> ([7]); // 10
-return([4], [7]); // 11
+F0:
+u8_try_from_felt252([0], [1]) { fallthrough([2], [3]) F0_B0([4]) };
+branch_align() -> ();
+enum_init<core::option::Option::<core::integer::u8>, 0>([3]) -> ([5]);
+store_temp<RangeCheck>([2]) -> ([2]);
+store_temp<core::option::Option::<core::integer::u8>>([5]) -> ([5]);
+return([2], [5]);
+F0_B0:
+branch_align() -> ();
+struct_construct<Unit>() -> ([6]);
+enum_init<core::option::Option::<core::integer::u8>, 1>([6]) -> ([7]);
+store_temp<RangeCheck>([4]) -> ([4]);
+store_temp<core::option::Option::<core::integer::u8>>([7]) -> ([7]);
+return([4], [7]);
 
-test::foo@0([0]: RangeCheck, [1]: felt252) -> (RangeCheck, core::option::Option::<core::integer::u8>);
+test::foo@F0([0]: RangeCheck, [1]: felt252) -> (RangeCheck, core::option::Option::<core::integer::u8>);

--- a/Aegis/Tests/e2e_libfuncs/u8_aegis/u8_wide_mul.sierra
+++ b/Aegis/Tests/e2e_libfuncs/u8_aegis/u8_wide_mul.sierra
@@ -4,8 +4,9 @@ type u16 = u16 [storable: true, drop: true, dup: true, zero_sized: false];
 libfunc u8_wide_mul = u8_wide_mul;
 libfunc store_temp<u16> = store_temp<u16>;
 
-u8_wide_mul([0], [1]) -> ([2]); // 0
-store_temp<u16>([2]) -> ([2]); // 1
-return([2]); // 2
+F0:
+u8_wide_mul([0], [1]) -> ([2]);
+store_temp<u16>([2]) -> ([2]);
+return([2]);
 
-test::foo@0([0]: u8, [1]: u8) -> (u16);
+test::foo@F0([0]: u8, [1]: u8) -> (u16);

--- a/contrib/extract_aegis_tests.py
+++ b/contrib/extract_aegis_tests.py
@@ -10,10 +10,10 @@ TEST_MARKER = "//! > ===========================================================
 class TestFunData:
     name: str
     test_runner_name: str
-    cairo: str
     casm: str
     function_costs: str
     sierra_code: str
+    cairo_code: str
     test_comments: str | None
 
 @dataclass


### PR DESCRIPTION
There's nonzero amount of failures which means that *not all tests* were updated, I will be looking into that in a second step.